### PR TITLE
Fix: avoid flashing loading state in useAsync

### DIFF
--- a/src/components/create-safe/useEstimateSafeCreationGas.test.ts
+++ b/src/components/create-safe/useEstimateSafeCreationGas.test.ts
@@ -36,7 +36,7 @@ describe('useEstimateSafeCreationGas', () => {
   it('should return no gasLimit by default', () => {
     const { result } = renderHook(() => useEstimateSafeCreationGas(mockProps))
     expect(result.current.gasLimit).toBeUndefined()
-    expect(result.current.gasLimitLoading).toBe(true)
+    expect(result.current.gasLimitLoading).toBe(false)
   })
 
   it('should estimate gas', async () => {
@@ -67,7 +67,7 @@ describe('useEstimateSafeCreationGas', () => {
 
     await waitFor(() => {
       expect(result.current.gasLimit).toBeUndefined()
-      expect(result.current.gasLimitLoading).toBe(true)
+      expect(result.current.gasLimitLoading).toBe(false)
     })
   })
 
@@ -77,7 +77,7 @@ describe('useEstimateSafeCreationGas', () => {
 
     await waitFor(() => {
       expect(result.current.gasLimit).toBeUndefined()
-      expect(result.current.gasLimitLoading).toBe(true)
+      expect(result.current.gasLimitLoading).toBe(false)
     })
   })
 
@@ -87,7 +87,7 @@ describe('useEstimateSafeCreationGas', () => {
 
     await waitFor(() => {
       expect(result.current.gasLimit).toBeUndefined()
-      expect(result.current.gasLimitLoading).toBe(true)
+      expect(result.current.gasLimitLoading).toBe(false)
     })
   })
 })

--- a/src/hooks/__tests__/useAsync.test.ts
+++ b/src/hooks/__tests__/useAsync.test.ts
@@ -9,22 +9,35 @@ describe('useAsync hook', () => {
   })
 
   it('should return the correct state when the promise resolves', async () => {
-    const { result } = renderHook(() => useAsync(() => Promise.resolve('test'), []))
+    const { result } = renderHook(() =>
+      useAsync(() => {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve('foo')
+          }, 100)
+        })
+      }, []),
+    )
+
+    expect(result.current).toEqual([undefined, undefined, false])
+
+    await act(async () => {
+      jest.advanceTimersByTime(10)
+    })
 
     expect(result.current).toEqual([undefined, undefined, true])
 
-    // Wait for the promise to resolve
     await act(async () => {
-      await Promise.resolve()
+      jest.advanceTimersByTime(200)
     })
 
-    expect(result.current).toEqual(['test', undefined, false])
+    expect(result.current).toEqual(['foo', undefined, false])
   })
 
   it('should return the correct state when the promise rejects', async () => {
     const { result } = renderHook(() => useAsync(() => Promise.reject('test'), []))
 
-    expect(result.current).toEqual([undefined, undefined, true])
+    expect(result.current).toEqual([undefined, undefined, false])
 
     // Wait for the promise to resolve
     await act(async () => {

--- a/src/hooks/__tests__/useGasPrice.test.ts
+++ b/src/hooks/__tests__/useGasPrice.test.ts
@@ -79,8 +79,6 @@ describe('useGasPrice', () => {
     // render the hook
     const { result } = renderHook(() => useGasPrice())
 
-    expect(result.current.gasPriceLoading).toBe(true)
-
     // wait for the hook to fetch the gas price
     await act(async () => {
       await Promise.resolve()
@@ -121,8 +119,6 @@ describe('useGasPrice', () => {
     // render the hook
     const { result } = renderHook(() => useGasPrice())
 
-    expect(result.current.gasPriceLoading).toBe(true)
-
     // wait for the hook to fetch the gas price
     await act(async () => {
       await Promise.resolve()
@@ -150,8 +146,6 @@ describe('useGasPrice', () => {
 
     // render the hook
     const { result } = renderHook(() => useGasPrice())
-
-    expect(result.current.gasPriceLoading).toBe(true)
 
     // wait for the hook to fetch the gas price
     await act(async () => {

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -5,7 +5,7 @@ export type AsyncResult<T> = [result: T | undefined, error: Error | undefined, l
 const useAsync = <T>(asyncCall: () => Promise<T>, dependencies: unknown[], clearData = true): AsyncResult<T> => {
   const [data, setData] = useState<T | undefined>()
   const [error, setError] = useState<Error>()
-  const [loading, setLoading] = useState<boolean>(true)
+  const [loading, setLoading] = useState<boolean>(false)
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const callback = useCallback(asyncCall, dependencies)

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -15,7 +15,11 @@ const useAsync = <T>(asyncCall: () => Promise<T>, dependencies: unknown[], clear
 
     clearData && setData(undefined)
     setError(undefined)
-    setLoading(true)
+
+    // Mark as loading with a small timeout to avoid flashing the loading state for quickly resolved promises
+    const loadingTimeout = setTimeout(() => {
+      setLoading(true)
+    }, 10)
 
     callback()
       .then((val: T) => {
@@ -25,11 +29,13 @@ const useAsync = <T>(asyncCall: () => Promise<T>, dependencies: unknown[], clear
         isCurrent && setError(err)
       })
       .finally(() => {
+        clearTimeout(loadingTimeout)
         isCurrent && setLoading(false)
       })
 
     return () => {
       isCurrent = false
+      clearTimeout(loadingTimeout)
     }
   }, [callback, clearData])
 

--- a/src/hooks/useTxHistory.ts
+++ b/src/hooks/useTxHistory.ts
@@ -33,7 +33,7 @@ const useTxHistory = (
     : {
         page: historyState.data,
         error: historyState.error,
-        loading: historyState.loading,
+        loading: historyState.loading || !historyState.data,
       }
 }
 

--- a/src/hooks/useTxQueue.ts
+++ b/src/hooks/useTxQueue.ts
@@ -33,7 +33,7 @@ const useTxQueue = (
     : {
         page: queueState.data,
         error: queueState.error,
-        loading: queueState.loading,
+        loading: queueState.loading || !queueState.data,
       }
 }
 

--- a/src/store/txHistorySlice.ts
+++ b/src/store/txHistorySlice.ts
@@ -6,13 +6,7 @@ import { txDispatch, TxEvent } from '@/services/tx/txEvents'
 import { selectPendingTxs } from './pendingTxsSlice'
 import { makeLoadableSlice } from './common'
 
-const initialState: TransactionListPage = {
-  results: [],
-  next: '',
-  previous: '',
-}
-
-const { slice, selector } = makeLoadableSlice('txHistory', initialState)
+const { slice, selector } = makeLoadableSlice('txHistory', undefined as TransactionListPage | undefined)
 
 export const txHistorySlice = slice
 export const selectTxHistory = selector

--- a/src/store/txQueueSlice.ts
+++ b/src/store/txQueueSlice.ts
@@ -4,19 +4,13 @@ import type { RootState } from '@/store'
 import { makeLoadableSlice } from './common'
 import { isMultisigExecutionInfo, isTransactionListItem } from '@/utils/transaction-guards'
 
-const initialState: TransactionListPage = {
-  results: [],
-  next: '',
-  previous: '',
-}
-
-const { slice, selector } = makeLoadableSlice('txQueue', initialState)
+const { slice, selector } = makeLoadableSlice('txQueue', undefined as TransactionListPage | undefined)
 
 export const txQueueSlice = slice
 export const selectTxQueue = selector
 
 export const selectQueuedTransactions = createSelector(selectTxQueue, (txQueue) => {
-  return txQueue.data.results.filter(isTransactionListItem)
+  return txQueue.data?.results.filter(isTransactionListItem) || []
 })
 
 export const selectQueuedTransactionsByNonce = createSelector(


### PR DESCRIPTION
Debounce the loading state with a 10 ms timeout so that immediately resolving promises don't cause an unnecessary re-rendering.

A typical example from our code:

```
const [data, error, loading] = useAsync(() => {
  if (!provider) return
  return loadData()
}, [provider])
```