### PR TITLE
Fix: Ledger and Trezor now work

### DIFF
--- a/src/components/common/ConnectWallet/styles.module.css
+++ b/src/components/common/ConnectWallet/styles.module.css
@@ -29,6 +29,11 @@
   display: block;
 }
 
+[data-theme='dark'] .imageContainer img[alt*="Trezor"],
+[data-theme='dark'] .imageContainer img[alt*="Ledger"] {
+  filter: invert(100%);
+}
+
 .rowContainer {
   align-self: stretch;
   margin-left: calc(var(--space-2) * -1);

--- a/src/services/onboard.ts
+++ b/src/services/onboard.ts
@@ -23,10 +23,10 @@ export const createOnboard = (chainConfigs: ChainInfo[]): OnboardAPI => {
     id: hexValue(parseInt(cfg.chainId)),
     label: cfg.chainName,
     rpcUrl: getRpcServiceUrl(cfg.rpcUri),
-    publicRpcUrl: cfg.publicRpcUri.value,
     token: cfg.nativeCurrency.symbol,
     color: cfg.theme.backgroundColor,
-    // TODO: add block explorer URL
+    // FIXME: add block explorer URL and uncomment publicRpcUrl once Ledger is fixed
+    // publicRpcUrl: cfg.publicRpcUri.value,
   }))
 
   onboard = Onboard({

--- a/src/styles/onboard.css
+++ b/src/styles/onboard.css
@@ -39,7 +39,7 @@
   --onboard-wallet-app-icon-border-color: var(--color-border-light);
   --onboard-wallet-app-icon-background-transparent: transparent;
 
-  /* FONTS */
+  /* Fonts */
   --onboard-font-family-normal: Averta, sans-serif;
   --onboard-font-family-semibold: Averta, sans-serif;
   --onboard-font-family-light: Averta, sans-serif;
@@ -50,7 +50,10 @@
   --onboard-border-radius-1: 8px;
   --onboard-border-radius-2: 8px;
   --onboard-border-radius-3: 8px;
+
+  /* Z-index */
   --onboard-modal-z-index: 1201;
+  --onboard-account-select-modal-z-index: 1201;
 }
 
 #walletconnect-qrcode-modal {
@@ -62,5 +65,10 @@
 }
 
 [data-theme='dark'] {
-  --onboard-wallet-app-icon-background-transparent: white;
+  --onboard-wallet-app-icon-background-transparent: var(--color-secondary-main);
+}
+
+/* Keystone modal */
+#kv_sdk_container + .ReactModalPortal > div {
+  z-index: var(--onboard-modal-z-index) !important;
 }


### PR DESCRIPTION
Ledger and Trezor can now successfully connect.

The problem was the `publicRpcUrl` property in the chain configs. Somehow it works fine with MetaMask (when you add a chain to MetaMask, it uses this URL in MetaMask), but breaks Ledger/Trezor.

Also fixed the z-index for Ledger and Keystone modals.