### PR TITLE
fix: Fix 0 nonce tx execution button

### DIFF
--- a/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/src/components/transactions/ExecuteTxButton/index.tsx
@@ -21,7 +21,7 @@ const ExecuteTxButton = ({
   const txNonce = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo.nonce : undefined
   const isPending = useIsPending(txSummary.id)
 
-  const isNext = !!txNonce && !!safe.nonce && txNonce === safe.nonce
+  const isNext = typeof txNonce !== undefined && typeof safe.nonce !== undefined && txNonce === safe.nonce
   const isDisabled = !isNext || isPending
 
   const onClick = (e: SyntheticEvent) => {

--- a/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/src/components/transactions/ExecuteTxButton/index.tsx
@@ -21,7 +21,7 @@ const ExecuteTxButton = ({
   const txNonce = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo.nonce : undefined
   const isPending = useIsPending(txSummary.id)
 
-  const isNext = typeof txNonce !== undefined && typeof safe.nonce !== undefined && txNonce === safe.nonce
+  const isNext = txNonce !== undefined && txNonce === safe.nonce
   const isDisabled = !isNext || isPending
 
   const onClick = (e: SyntheticEvent) => {


### PR DESCRIPTION
## What it solves

Small fix for the `ExecuteTxButton`. It was staying disabled for txs with nonce 0 i.e. the first transaction in a newly created safe.
