### PR TITLE
Refactor: undefined in useAsync

### DIFF
--- a/src/components/create-safe/useEstimateSafeCreationGas.ts
+++ b/src/components/create-safe/useEstimateSafeCreationGas.ts
@@ -31,7 +31,7 @@ export const useEstimateSafeCreationGas = ({
   const proxyContract = getProxyFactoryContractInstance(chainId)
   const encodedSafeCreationTx = getSafeCreationTx({ owners, threshold, saltNonce, chain: currentChain })
 
-  const [gasLimit, gasLimitError, gasLimitLoading] = useAsync<BigNumber | undefined>(async () => {
+  const [gasLimit, gasLimitError, gasLimitLoading] = useAsync<BigNumber>(() => {
     if (!wallet?.address || !encodedSafeCreationTx || !web3ReadOnly) return
 
     return web3ReadOnly.estimateGas({

--- a/src/components/load-safe/steps/SafeOwnersStep.tsx
+++ b/src/components/load-safe/steps/SafeOwnersStep.tsx
@@ -27,9 +27,10 @@ const SafeOwnersStep = ({ params, onSubmit, onBack }: Props): ReactElement => {
     name: 'owners',
   })
 
-  const [safeInfo] = useAsync<SafeInfo | undefined>(async () => {
-    if (!params.address) return
-    return getSafeInfo(chainId, params.address)
+  const [safeInfo] = useAsync<SafeInfo>(() => {
+    if (params.address) {
+      return getSafeInfo(chainId, params.address)
+    }
   }, [chainId, params.address])
 
   useEffect(() => {

--- a/src/components/safe-apps/AddCustomAppModal.tsx
+++ b/src/components/safe-apps/AddCustomAppModal.tsx
@@ -60,16 +60,14 @@ const AddCustomAppModal = ({ open, onClose, onSave, safeAppsList }: Props) => {
 
   const appUrl = watch('appUrl')
   const debouncedUrl = useDebounce(trimTrailingSlash(appUrl || ''), 300)
-  const [safeApp] = useAsync<SafeAppData | undefined>(async () => {
-    if (!isValidURL(debouncedUrl)) {
-      return
-    }
 
-    try {
-      return await fetchSafeAppFromManifest(debouncedUrl, chainId)
-    } catch (e) {
+  const [safeApp] = useAsync<SafeAppData | undefined>(() => {
+    if (!isValidURL(debouncedUrl)) return
+
+    return fetchSafeAppFromManifest(debouncedUrl, chainId).catch(() => {
       setError('appUrl', { type: 'custom', message: "The App doesn't support Safe App functionality" })
-    }
+      return undefined
+    })
   }, [chainId, debouncedUrl])
 
   const appLogoUrl = safeApp?.iconUrl || APP_LOGO_FALLBACK_IMAGE

--- a/src/components/settings/ContractVersion/UpdateSafeDialog.tsx
+++ b/src/components/settings/ContractVersion/UpdateSafeDialog.tsx
@@ -44,8 +44,9 @@ const ReviewUpdateSafeStep = ({ onSubmit }: { onSubmit: (data: null) => void }) 
   const { safe, safeLoaded } = useSafeInfo()
   const chain = useCurrentChain()
 
-  const [safeTx, safeTxError] = useAsync<SafeTransaction | undefined>(async () => {
-    if (!safeLoaded || !chain) return
+  const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
+    if (!chain || !safeLoaded) return
+
     const txs = createUpdateSafeTxs(safe, chain)
     return createMultiSendTx(txs)
   }, [chain, safe, safeLoaded])

--- a/src/components/settings/SafeModules/RemoveModule/steps/ReviewRemoveModule.tsx
+++ b/src/components/settings/SafeModules/RemoveModule/steps/ReviewRemoveModule.tsx
@@ -14,10 +14,8 @@ export const ReviewRemoveModule = ({ data, onSubmit }: { data: RemoveModuleData;
   const { safe } = useSafeInfo()
   const sdk = useSafeSDK()
 
-  const [safeTx, safeTxError] = useAsync<SafeTransaction | undefined>(async () => {
-    if (!sdk) return
-    const tx = await sdk.getDisableModuleTx(data.address)
-    return createTx(tx.data)
+  const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
+    return sdk?.getDisableModuleTx(data.address).then((tx) => createTx(tx.data))
   }, [sdk, data.address])
 
   useEffect(() => {

--- a/src/components/settings/SpendingLimits/NewSpendingLimit/steps/ReviewSpendingLimit.tsx
+++ b/src/components/settings/SpendingLimits/NewSpendingLimit/steps/ReviewSpendingLimit.tsx
@@ -102,7 +102,7 @@ export const ReviewSpendingLimit = ({ data, onSubmit }: Props) => {
       ? 'One-time spending limit'
       : RESET_TIME_OPTIONS.find((time) => time.value === data.resetTime)?.label
 
-  const [safeTx, safeTxError] = useAsync<SafeTransaction | undefined>(async () => {
+  const [safeTx, safeTxError] = useAsync<SafeTransaction | undefined>(() => {
     return createNewSpendingLimitTx(data, spendingLimits, chainId, decimals, existingSpendingLimit)
   }, [data, spendingLimits, chainId, decimals, existingSpendingLimit])
 

--- a/src/components/settings/SpendingLimits/RemoveSpendingLimit/index.tsx
+++ b/src/components/settings/SpendingLimits/RemoveSpendingLimit/index.tsx
@@ -22,7 +22,7 @@ export const RemoveSpendingLimit = ({
   const chainId = useChainId()
   const provider = useWeb3()
 
-  const [safeTx, safeTxError] = useAsync<SafeTransaction | undefined>(async () => {
+  const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
     const spendingLimitAddress = getSpendingLimitModuleAddress(chainId)
     if (!provider || !spendingLimitAddress) return
 

--- a/src/components/settings/owner/ChangeThresholdDialog/index.tsx
+++ b/src/components/settings/owner/ChangeThresholdDialog/index.tsx
@@ -51,7 +51,7 @@ const ChangeThresholdStep = ({ data, onSubmit }: { data: ChangeThresholdData; on
     setSelectedThreshold(parseInt(event.target.value.toString()))
   }
 
-  const [safeTx, safeTxError] = useAsync<SafeTransaction | undefined>(async () => {
+  const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
     if (selectedThreshold === data.threshold) return
 
     return createUpdateThresholdTx(selectedThreshold)

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -17,7 +17,7 @@ const DecodedTx = ({ tx }: DecodedTxProps): ReactElement | null => {
   const encodedData = tx?.data.data
   const isNativeTransfer = encodedData && isNaN(parseInt(encodedData, 16))
 
-  const [decodedData, error] = useAsync<DecodedDataResponse | undefined>(async () => {
+  const [decodedData, error] = useAsync<DecodedDataResponse>(() => {
     if (!encodedData || isNativeTransfer) return
     return getDecodedData(chainId, encodedData)
   }, [chainId, encodedData, isNativeTransfer])

--- a/src/components/tx/modals/NftTransferModal/ReviewNftTx.tsx
+++ b/src/components/tx/modals/NftTransferModal/ReviewNftTx.tsx
@@ -18,7 +18,7 @@ type ReviewNftTxProps = {
 const ReviewNftTx = ({ params, onSubmit }: ReviewNftTxProps): ReactElement => {
   const { safeAddress, safe } = useSafeInfo()
 
-  const [safeTx, safeTxError] = useAsync<SafeTransaction | undefined>(async () => {
+  const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
     if (!safeAddress) return
     const transferParams = createNftTransferParams(safeAddress, params.recipient, params.token.id, params.token.address)
     return createTx(transferParams)

--- a/src/components/tx/modals/RejectTxModal/RejectTx.tsx
+++ b/src/components/tx/modals/RejectTxModal/RejectTx.tsx
@@ -18,8 +18,8 @@ const RejectTx = ({ txSummary, onSubmit }: RejectTxProps): ReactElement => {
   const { safe } = useSafeInfo()
   const txNonce = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo.nonce : undefined
 
-  const [rejectTx, rejectError] = useAsync<SafeTransaction | undefined>(async () => {
-    return txNonce ? createRejectTx(txNonce) : undefined
+  const [rejectTx, rejectError] = useAsync<SafeTransaction>(() => {
+    if (txNonce) return createRejectTx(txNonce)
   }, [txNonce])
 
   return (

--- a/src/components/tx/modals/TokenTransferModal/ReviewTokenTx.tsx
+++ b/src/components/tx/modals/TokenTransferModal/ReviewTokenTx.tsx
@@ -42,7 +42,7 @@ const ReviewTokenTx = ({ params, onSubmit }: ReviewTokenTxProps): ReactElement =
   const { decimals, address } = token?.tokenInfo || {}
 
   // Create a safeTx
-  const [safeTx, safeTxError] = useAsync<SafeTransaction | undefined>(async () => {
+  const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
     if (!address || !decimals) return
     const txParams = createTokenTransferParams(params.recipient, params.amount, decimals, address)
     return createTx(txParams)

--- a/src/hooks/__tests__/useAsync.test.ts
+++ b/src/hooks/__tests__/useAsync.test.ts
@@ -8,28 +8,22 @@ describe('useAsync hook', () => {
     jest.useFakeTimers()
   })
 
-  it('should return the correct state when the promise resolves', async () => {
-    const { result } = renderHook(() =>
-      useAsync(() => {
-        return new Promise((resolve) => {
-          setTimeout(() => {
-            resolve('foo')
-          }, 100)
-        })
-      }, []),
-    )
+  it('should not set loading state to true when callback returns undefined', async () => {
+    const { result } = renderHook(() => useAsync(() => undefined, []))
 
     expect(result.current).toEqual([undefined, undefined, false])
 
-    await act(async () => {
-      jest.advanceTimersByTime(10)
-    })
+    await act(() => Promise.resolve())
+
+    expect(result.current).toEqual([undefined, undefined, false])
+  })
+
+  it('should return the correct state when the promise resolves', async () => {
+    const { result } = renderHook(() => useAsync(() => Promise.resolve('foo'), []))
 
     expect(result.current).toEqual([undefined, undefined, true])
 
-    await act(async () => {
-      jest.advanceTimersByTime(200)
-    })
+    await act(() => Promise.resolve())
 
     expect(result.current).toEqual(['foo', undefined, false])
   })
@@ -37,7 +31,7 @@ describe('useAsync hook', () => {
   it('should return the correct state when the promise rejects', async () => {
     const { result } = renderHook(() => useAsync(() => Promise.reject('test'), []))
 
-    expect(result.current).toEqual([undefined, undefined, false])
+    expect(result.current).toEqual([undefined, undefined, true])
 
     // Wait for the promise to resolve
     await act(async () => {

--- a/src/hooks/loadables/useLoadBalances.ts
+++ b/src/hooks/loadables/useLoadBalances.ts
@@ -2,21 +2,22 @@ import { useEffect } from 'react'
 import { getBalances, type SafeBalanceResponse } from '@gnosis.pm/safe-react-gateway-sdk'
 import { useAppSelector } from '@/store'
 import useAsync, { type AsyncResult } from '../useAsync'
-import useSafeInfo from '../useSafeInfo'
 import { Errors, logError } from '@/services/exceptions'
 import { selectCurrency } from '@/store/settingsSlice'
+import { selectSafeInfo } from '@/store/safeInfoSlice'
 
 export const useLoadBalances = (): AsyncResult<SafeBalanceResponse> => {
-  const { safe, safeLoaded } = useSafeInfo()
+  // use the selector directly because useSafeInfo is memoized
+  const { data: safe } = useAppSelector(selectSafeInfo)
   const currency = useAppSelector(selectCurrency)
 
   // Re-fetch assets when the entire SafeInfo updates
-  const [data, error, loading] = useAsync<SafeBalanceResponse | undefined>(
-    async () => {
-      if (!safeLoaded) return
+  const [data, error, loading] = useAsync<SafeBalanceResponse>(
+    () => {
+      if (!safe) return
       return getBalances(safe.chainId, safe.address.value, currency)
     },
-    [safe, safeLoaded, currency], // Reload either when the Safe is updated or the currency changes
+    [safe, currency], // Reload either when the Safe is updated or the currency changes
     false, // Don't clear data between SafeInfo polls
   )
 

--- a/src/hooks/loadables/useLoadSafeInfo.ts
+++ b/src/hooks/loadables/useLoadSafeInfo.ts
@@ -15,7 +15,7 @@ export const useLoadSafeInfo = (): AsyncResult<SafeInfo> => {
   const { safe } = useSafeInfo()
   const isStoredSafeValid = safe.chainId === chainId && safe.address.value === address
 
-  const [data, error, loading] = useAsync<SafeInfo | undefined>(async () => {
+  const [data, error, loading] = useAsync<SafeInfo>(() => {
     if (!chainId || !address) return
     return getSafeInfo(chainId, address)
   }, [chainId, address, pollCount])

--- a/src/hooks/loadables/useLoadSpendingLimits.ts
+++ b/src/hooks/loadables/useLoadSpendingLimits.ts
@@ -72,7 +72,7 @@ export const getSpendingLimits = async (
 
 export const useLoadSpendingLimits = (): AsyncResult<SpendingLimitState[]> => {
   const [updateSpendingLimitsTag, setUpdateSpendingLimitsTag] = useState<number>()
-  const { safeAddress, safe } = useSafeInfo()
+  const { safeAddress, safe, safeLoaded } = useSafeInfo()
   const chainId = useChainId()
   const provider = useWeb3ReadOnly()
 
@@ -83,12 +83,12 @@ export const useLoadSpendingLimits = (): AsyncResult<SpendingLimitState[]> => {
   }, [])
 
   const [data, error, loading] = useAsync<SpendingLimitState[] | undefined>(
-    async () => {
-      if (!provider || !safe.modules) return
+    () => {
+      if (!provider || !safeLoaded || !safe.modules) return
 
       return getSpendingLimits(provider, safe.modules, safeAddress, chainId)
     },
-    [provider, safe.modules?.length, safeAddress, chainId, updateSpendingLimitsTag],
+    [provider, safeLoaded, safe.modules?.length, safeAddress, chainId, updateSpendingLimitsTag],
     false,
   )
 

--- a/src/hooks/loadables/useLoadTxHistory.ts
+++ b/src/hooks/loadables/useLoadTxHistory.ts
@@ -9,8 +9,8 @@ export const useLoadTxHistory = (): AsyncResult<TransactionListPage> => {
   const { chainId, txHistoryTag } = safe
 
   // Re-fetch when chainId/address, or txHistoryTag change
-  const [data, error, loading] = useAsync<TransactionListPage | undefined>(
-    async () => {
+  const [data, error, loading] = useAsync<TransactionListPage>(
+    () => {
       if (!safeLoaded) return
       return getTransactionHistory(chainId, safeAddress)
     },

--- a/src/hooks/loadables/useLoadTxQueue.ts
+++ b/src/hooks/loadables/useLoadTxQueue.ts
@@ -16,8 +16,8 @@ export const useLoadTxQueue = (): AsyncResult<TransactionListPage> => {
   }, [])
 
   // Re-fetch when chainId/address, or txQueueTag change
-  const [data, error, loading] = useAsync<TransactionListPage | undefined>(
-    async () => {
+  const [data, error, loading] = useAsync<TransactionListPage>(
+    () => {
       if (!safeLoaded) return
       return getTransactionQueue(chainId, safeAddress)
     },

--- a/src/hooks/useAddressResolver.ts
+++ b/src/hooks/useAddressResolver.ts
@@ -20,7 +20,7 @@ export const useAddressResolver = (address: string, fallback?: string) => {
   const isDomainLookupEnabled = !!currentChain && hasFeature(currentChain, FEATURES.DOMAIN_LOOKUP)
   const shouldResolve = !addressBookName && isDomainLookupEnabled && !!ethersProvider && !!debouncedValue
 
-  const [ensName, _, isResolving] = useAsync<string | undefined>(async () => {
+  const [ensName, _, isResolving] = useAsync<string | undefined>(() => {
     if (!shouldResolve) return
     return lookupAddress(ethersProvider, debouncedValue)
   }, [ethersProvider, debouncedValue, shouldResolve])

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -20,7 +20,11 @@ const useAsync = <T>(
 
     const promise = callback()
 
-    if (!promise) return
+    // Not a promise, exit early
+    if (!promise) {
+      setLoading(false)
+      return
+    }
 
     let isCurrent = true
     setLoading(true)

--- a/src/hooks/useCollectibles.ts
+++ b/src/hooks/useCollectibles.ts
@@ -9,7 +9,7 @@ export const useCollectibles = (pageUrl?: string): AsyncResult<SafeCollectiblesP
   const chainId = useChainId()
   const safeAddress = useSafeAddress()
 
-  const [data, error, loading] = useAsync<SafeCollectiblesPage | undefined>(async () => {
+  const [data, error, loading] = useAsync<SafeCollectiblesPage>(() => {
     return getCollectiblesPage(chainId, safeAddress, undefined, pageUrl)
   }, [safeAddress, chainId, pageUrl])
 

--- a/src/hooks/useGasLimit.ts
+++ b/src/hooks/useGasLimit.ts
@@ -84,8 +84,8 @@ const useGasLimit = (
     [safeTx?.data.operation],
   )
 
-  const [gasLimit, gasLimitError, gasLimitLoading] = useAsync<BigNumber | undefined>(async () => {
-    if (!safeAddress || !walletAddress || !encodedSafeTx || !web3ReadOnly) return undefined
+  const [gasLimit, gasLimitError, gasLimitLoading] = useAsync<BigNumber>(() => {
+    if (!safeAddress || !walletAddress || !encodedSafeTx || !web3ReadOnly) return
 
     return web3ReadOnly.estimateGas({
       to: safeAddress,

--- a/src/hooks/useGasPrice.ts
+++ b/src/hooks/useGasPrice.ts
@@ -58,14 +58,14 @@ const useGasPrice = (): {
   const [counter] = useIntervalCounter(REFRESH_DELAY)
   const provider = useWeb3ReadOnly()
 
-  const [gasPrice, gasPriceError, gasPriceLoading] = useAsync<BigNumber | undefined>(async () => {
-    if (!gasPriceConfigs) return
-    return getGasPrice(gasPriceConfigs)
+  const [gasPrice, gasPriceError, gasPriceLoading] = useAsync<BigNumber | undefined>(() => {
+    if (gasPriceConfigs) {
+      return getGasPrice(gasPriceConfigs)
+    }
   }, [gasPriceConfigs, counter])
 
-  const [feeData, feeDataError, feeDataLoading] = useAsync<FeeData | undefined>(async () => {
-    if (!provider) return
-    return provider.getFeeData()
+  const [feeData, feeDataError, feeDataLoading] = useAsync<FeeData>(() => {
+    return provider?.getFeeData()
   }, [provider, counter])
 
   // Save the previous gas price so that we don't return undefined each time it's polled

--- a/src/hooks/useOwnedSafes.ts
+++ b/src/hooks/useOwnedSafes.ts
@@ -19,10 +19,9 @@ const useOwnedSafes = (): OwnedSafesCache['walletAddress'] => {
   const { address: walletAddress } = useWallet() || {}
   const [ownedSafesCache, setOwnedSafesCache] = useLocalStorage<OwnedSafesCache>(CACHE_KEY, {})
 
-  const [ownedSafes] = useAsync<OwnedSafes['safes'] | undefined>(async () => {
+  const [ownedSafes] = useAsync<OwnedSafes>(() => {
     if (!chainId || !walletAddress) return
-
-    return (await getOwnedSafes(chainId, walletAddress)).safes
+    return getOwnedSafes(chainId, walletAddress)
   }, [chainId, walletAddress])
 
   useEffect(() => {
@@ -32,7 +31,7 @@ const useOwnedSafes = (): OwnedSafesCache['walletAddress'] => {
       ...prev,
       [walletAddress]: {
         ...(prev[walletAddress] || {}),
-        [chainId]: ownedSafes,
+        [chainId]: ownedSafes.safes,
       },
     }))
   }, [ownedSafes, setOwnedSafesCache, walletAddress, chainId])

--- a/src/hooks/useTxHistory.ts
+++ b/src/hooks/useTxHistory.ts
@@ -15,7 +15,7 @@ const useTxHistory = (
   const { chainId } = safe
 
   // If pageUrl is passed, load a new history page from the API
-  const [page, error, loading] = useAsync<TransactionListPage | undefined>(async () => {
+  const [page, error, loading] = useAsync<TransactionListPage>(() => {
     if (!pageUrl || !safeLoaded) return
     return getTransactionHistory(chainId, safeAddress, pageUrl)
   }, [chainId, safeAddress, safeLoaded, pageUrl])

--- a/src/hooks/useTxQueue.ts
+++ b/src/hooks/useTxQueue.ts
@@ -15,7 +15,7 @@ const useTxQueue = (
   const { chainId } = safe
 
   // If pageUrl is passed, load a new queue page from the API
-  const [page, error, loading] = useAsync<TransactionListPage | undefined>(async () => {
+  const [page, error, loading] = useAsync<TransactionListPage>(() => {
     if (!pageUrl || !safeLoaded) return
     return getTransactionQueue(chainId, safeAddress, pageUrl)
   }, [chainId, safeAddress, safeLoaded, pageUrl])

--- a/src/services/__tests__/domains.test.ts
+++ b/src/services/__tests__/domains.test.ts
@@ -1,5 +1,5 @@
 import { type JsonRpcProvider } from '@ethersproject/providers'
-import { resolveName, lookupAddress } from '../domains'
+import { resolveName, lookupAddress, isDomain } from '../domains'
 import { logError } from '../exceptions'
 
 // mock rpcProvider
@@ -19,24 +19,37 @@ jest.mock('../exceptions', () => ({
 }))
 
 describe('domains', () => {
-  it('should resolve names', async () => {
-    expect(await resolveName(rpcProvider, '0x123')).toBe(undefined)
-    expect(await resolveName(rpcProvider, 'test.')).toBe(undefined)
-    expect(await resolveName(rpcProvider, 'test.com')).toBe('0x0000000000000000000000000000000000000000')
-    expect(await resolveName(rpcProvider, 'test.eth')).toBe('0x0000000000000000000000000000000000000000')
+  describe('isDomain', () => {
+    it('should check the domain format', async () => {
+      expect(isDomain('safe.eth')).toBe(true)
+      expect(isDomain('safe.com')).toBe(true)
+      expect(isDomain('test.safe.xyz')).toBe(true)
+      expect(isDomain('safe.')).toBe(false)
+      expect(isDomain('0x123')).toBe(false)
+    })
   })
 
-  it('look up addresses', async () => {
-    expect(await lookupAddress(rpcProvider, '0x0000000000000000000000000000000000000000')).toBe('safe.eth')
+  describe('resolveName', () => {
+    it('should resolve names', async () => {
+      expect(await resolveName(rpcProvider, 'test.eth')).toBe('0x0000000000000000000000000000000000000000')
+    })
+
+    it('should return undefined and log on error', async () => {
+      const address = await resolveName(badRpcProvider, 'safe.eth')
+      expect(address).toBe(undefined)
+      expect(logError).toHaveBeenCalledWith('101: Failed to resolve the address', 'bad resolveName')
+    })
   })
 
-  it('should log an error if lookup fails', async () => {
-    const name = await lookupAddress(badRpcProvider, '0x0000000000000000000000000000000000000000')
-    expect(name).toBe(undefined)
-    expect(logError).toHaveBeenCalledWith('101: Failed to resolve the address', 'bad lookupAddress')
+  describe('lookupAddress', () => {
+    it('look up addresses', async () => {
+      expect(await lookupAddress(rpcProvider, '0x0000000000000000000000000000000000000000')).toBe('safe.eth')
+    })
 
-    const address = await resolveName(badRpcProvider, 'safe.eth')
-    expect(address).toBe(undefined)
-    expect(logError).toHaveBeenCalledWith('101: Failed to resolve the address', 'bad resolveName')
+    it('should log an error if lookup fails', async () => {
+      const name = await lookupAddress(badRpcProvider, '0x0000000000000000000000000000000000000000')
+      expect(name).toBe(undefined)
+      expect(logError).toHaveBeenCalledWith('101: Failed to resolve the address', 'bad lookupAddress')
+    })
   })
 })

--- a/src/services/domains.ts
+++ b/src/services/domains.ts
@@ -9,10 +9,11 @@ type EthersError = Error & {
 // ENS domains can have any TLD, so just check that it ends with a dot-separated tld
 const DOMAIN_RE = /[^.]+[.][^.]+$/iu
 
-export const resolveName = async (rpcProvider: JsonRpcProvider, name: string): Promise<string | undefined> => {
-  // Check if the value looks like a domain name
-  if (!DOMAIN_RE.test(name)) return
+export function isDomain(domain: string): boolean {
+  return DOMAIN_RE.test(domain)
+}
 
+export const resolveName = async (rpcProvider: JsonRpcProvider, name: string): Promise<string | undefined> => {
   try {
     return (await rpcProvider.resolveName(name)) || undefined
   } catch (e) {


### PR DESCRIPTION
## What it solves

`useAsync` often has to check for missing dependencies from other hooks, and we've been doing it from inside an async function. This can cause an unnecessary re-rendering of the `loading` state.

## How this PR fixes it

This PR allows returning `undefined` from the `useAsync` callback (not `Promise<undefined>`!), in which case it bypasses the whole loading routine, and `setLoading` will never be set to true in that case.

## Side changes
I also fixed `useLoadBalances` which weren't polling because of the safe hook memoization.

## How to test it

Unit tests + check places that have a loader:
* name/address-resolving inputs
* tx queue/history