### PR TITLE
Chore: fix e2e job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,24 +15,14 @@ jobs:
         with:
           node-version: 16
 
-      - name: Yarn cache
-        uses: actions/cache@v2
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-
       - name: Yarn install
-        run: |
-          mkdir .yarncache
-          yarn install --cache-folder ./.yarncache --immutable
-          rm -rf .yarncache
-          yarn cache clean
+        run: yarn install --immutable
 
-      - name: Build & serve
-        run: |
-          yarn build
-          yarn export
-          yarn serve &
+      - name: Build
+        run: yarn build && yarn export
+
+      - name: Serve
+        run: yarn serve &
 
       - uses: cypress-io/github-action@v4
         with:


### PR DESCRIPTION
## What it solves
The job seems to be failing occasionally due to the yarn cache.

## How this PR fixes it
Hopefully disabling cache should help.