### PR TITLE
fix: Add span wrapper for disabled tooltip buttons

### DIFF
--- a/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/src/components/transactions/ExecuteTxButton/index.tsx
@@ -33,9 +33,11 @@ const ExecuteTxButton = ({
     <>
       {compact ? (
         <Tooltip title="Execute" arrow placement="top">
-          <IconButton onClick={onClick} color="primary" disabled={isDisabled} size="small">
-            <RocketLaunchIcon fontSize="small" />
-          </IconButton>
+          <span>
+            <IconButton onClick={onClick} color="primary" disabled={isDisabled} size="small">
+              <RocketLaunchIcon fontSize="small" />
+            </IconButton>
+          </span>
         </Tooltip>
       ) : (
         <Button onClick={onClick} variant="contained" disabled={isDisabled} size="stretched">

--- a/src/components/transactions/RejectTxButton/index.tsx
+++ b/src/components/transactions/RejectTxButton/index.tsx
@@ -39,9 +39,11 @@ const RejectTxButton = ({
     <>
       {compact ? (
         <Tooltip title="Reject" arrow placement="top">
-          <IconButton onClick={onClick} color="error" size="small" disabled={isDisabled}>
-            <HighlightOffIcon fontSize="small" />
-          </IconButton>
+          <span>
+            <IconButton onClick={onClick} color="error" size="small" disabled={isDisabled}>
+              <HighlightOffIcon fontSize="small" />
+            </IconButton>
+          </span>
         </Tooltip>
       ) : (
         <Button onClick={onClick} color="error" variant="contained" disabled={isDisabled} size="stretched">

--- a/src/components/transactions/SignTxButton/index.tsx
+++ b/src/components/transactions/SignTxButton/index.tsx
@@ -34,9 +34,11 @@ const SignTxButton = ({
     <>
       {compact ? (
         <Tooltip title="Sign" arrow placement="top">
-          <IconButton onClick={onClick} color="primary" disabled={isDisabled} size="small">
-            <CheckIcon fontSize="small" />
-          </IconButton>
+          <span>
+            <IconButton onClick={onClick} color="primary" disabled={isDisabled} size="small">
+              <CheckIcon fontSize="small" />
+            </IconButton>
+          </span>
         </Tooltip>
       ) : (
         <Button onClick={onClick} variant="contained" disabled={isDisabled} size="stretched">


### PR DESCRIPTION
Small fix for the Mui warning in console that `Tooltip` shouldn't be used with a disabled child element