### PR TITLE
Chore: add build to the lint job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,13 @@ jobs:
     runs-on: ubuntu-20.04
     name: E2E on Chrome
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+
       - uses: actions/checkout@v2
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,6 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2
-        if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
@@ -34,11 +33,11 @@ jobs:
           rm -rf .yarncache
           yarn cache clean
 
-      - name: Build & serve
-        run: |
-          yarn build
-          yarn export
-          yarn serve &
+      - name: Build
+        run: yarn build && yarn export
+
+      - name: Serve
+        run: yarn serve &
 
       - uses: cypress-io/github-action@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,17 +6,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: Yarn cache
         uses: actions/cache@v2
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
       - name: Yarn install
         run: |
           mkdir .yarncache
           yarn install --cache-folder ./.yarncache --immutable
           rm -rf .yarncache
           yarn cache clean
+
       - uses: Maggi64/eslint-plus-action@master
         with:
           npmInstall: false
+
+      - name: Build
+        run: yarn build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,11 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+
       - uses: actions/checkout@v2
 
       - name: Yarn cache
@@ -24,5 +29,5 @@ jobs:
         with:
           npmInstall: false
 
-      - name: Build
+      - name: Ensure build works
         run: yarn build


### PR DESCRIPTION
## What it solves
Adds a build command to quickly fail the more lengthy CI jobs (CloudFlare and e2e tests) if the build isn't working.