### PR TITLE
fix: don't add fallback names to address book

### DIFF
--- a/src/components/load-safe/steps/SafeReviewStep.tsx
+++ b/src/components/load-safe/steps/SafeReviewStep.tsx
@@ -47,6 +47,7 @@ const SafeReviewStep = ({ params, onBack }: Props) => {
         },
       }),
     )
+
     dispatch(
       upsertAddressBookEntry({
         chainId,
@@ -55,7 +56,11 @@ const SafeReviewStep = ({ params, onBack }: Props) => {
       }),
     )
 
-    for (const { address, name } of params.owners) {
+    for (const { address, name, fallbackName } of params.owners) {
+      if (name === fallbackName) {
+        continue
+      }
+
       dispatch(
         upsertAddressBookEntry({
           chainId,


### PR DESCRIPTION
## What it solves

Fallback names being added to address book.

## How this PR fixes it

Before adding owners of a Safe to the address book, they are first checked against the `fallbackName`.

## How to test it

Create/load a Safe but do not enter names for the owner(s). After successful creation/load, observe that the owners will not be present in the address book.