### PR TITLE
fix: enable export with any address book entry

### DIFF
--- a/src/components/address-book/AddressBookTable/index.tsx
+++ b/src/components/address-book/AddressBookTable/index.tsx
@@ -17,6 +17,8 @@ import Box from '@mui/material/Box'
 import useAddressBook from '@/hooks/useAddressBook'
 import Track from '@/components/common/Track'
 import { ADDRESS_BOOK_EVENTS } from '@/services/analytics/events/addressBook'
+import { useAppSelector } from '@/store'
+import { selectAllAddressBooks } from '@/store/addressBookSlice'
 
 const headCells = [
   { id: 'name', label: 'Name' },
@@ -57,6 +59,9 @@ const AddressBookTable = () => {
     setOpen(defaultOpen)
     setDefaultValues(undefined)
   }
+
+  const allAddressBooks = useAppSelector(selectAllAddressBooks)
+  const canExport = Object.keys(allAddressBooks).length > 0
 
   const addressBook = useAddressBook()
   const addressBookEntries = Object.entries(addressBook)
@@ -108,7 +113,7 @@ const AddressBookTable = () => {
         <Track {...ADDRESS_BOOK_EVENTS.DOWNLOAD_BUTTON}>
           <Button
             onClick={handleOpenModal(ModalType.EXPORT)}
-            disabled={addressBookEntries.length === 0}
+            disabled={!canExport}
             variant="contained"
             size="small"
             disableElevation

--- a/src/components/address-book/AddressBookTable/index.tsx
+++ b/src/components/address-book/AddressBookTable/index.tsx
@@ -61,7 +61,7 @@ const AddressBookTable = () => {
   }
 
   const allAddressBooks = useAppSelector(selectAllAddressBooks)
-  const canExport = Object.keys(allAddressBooks).length > 0
+  const canExport = Object.values(allAddressBooks).length > 0
 
   const addressBook = useAddressBook()
   const addressBookEntries = Object.entries(addressBook)


### PR DESCRIPTION
## What it solves

Enabling export button providing there is at least one address book entry stored locally.

## How this PR fixes it

Instead of referencing the `length` of the address book of the current chain, 'all' address books are checked instead.

Note: we do not remove the `chainId` key from the address book if all entries are removed from said chain, hence `values` are checked.

## How to test it

Ensure an entry exists on one chain then switch to another chain that has no address book entries. Observe the export button is now enabled.