### PR TITLE
feat(safe-apps):  Safe App iframe view

### DIFF
--- a/public/images/network-error.svg
+++ b/public/images/network-error.svg
@@ -1,0 +1,28 @@
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="90"
+    height="90"
+    viewBox="0 0 90 90">
+    <g fill="none" fillRule="evenodd">
+      <circle cx="45" cy="45" r="45" fill="#E8E7E6" />
+      <path
+        fill="#B2B5B2"
+        fillRule="nonzero"
+        d="M26.24 62c-.57 0-1.13-.15-1.623-.437a3.254 3.254 0 0 1-1.18-4.44l18.76-32.501a3.234 3.234 0 0 1 5.606 0l18.761 32.501c.286.495.436 1.057.436 1.628A3.244 3.244 0 0 1 63.76 62H26.24z"
+      />
+      <path
+        fill="#E8E7E6"
+        fillRule="nonzero"
+        d="M47 49h-4V36h4zM47 55h-4v-4h4z"
+      />
+      <circle
+        cx="78"
+        cy="78"
+        r="11"
+        fill="#FFC05F"
+        fillRule="nonzero"
+        stroke="#F6F7F8"
+        strokeWidth="4"
+      />
+    </g>
+  </svg>

--- a/public/third-party-cookies-check/index.html
+++ b/public/third-party-cookies-check/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Third Party Cookies Test</title>
+  </head>
+
+  <body>
+    <script>
+      const COOKIE_NAME = 'testcookie'
+      const checkCookiesEnable = () => {
+        let isCookieEnabled = window.navigator.cookieEnabled ? true : false
+
+        if (window.navigator.cookieEnabled === undefined && !isCookieEnabled) {
+          document.cookie = COOKIE_NAME
+          isCookieEnabled = document.cookie.indexOf(COOKIE_NAME) != -1 ? true : false
+        }
+
+        return isCookieEnabled
+      }
+
+      ;(function () {
+        window.addEventListener('message', (event) => {
+          try {
+            let data = event.data
+            if (data.test !== 'cookie') return
+            let result = checkCookiesEnable()
+            parent.postMessage(
+              {
+                isCookieEnabled: result,
+              },
+              event.origin,
+            )
+          } catch (e) {
+            console.error(e)
+          }
+        })
+      })()
+    </script>
+  </body>
+</html>

--- a/src/components/safe-apps/AppCard.tsx
+++ b/src/components/safe-apps/AppCard.tsx
@@ -1,5 +1,6 @@
 import { ReactElement, ReactNode, SyntheticEvent } from 'react'
 import { useRouter } from 'next/router'
+import Link from 'next/link'
 import Avatar from '@mui/material/Avatar'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
@@ -10,7 +11,7 @@ import { SafeAppData } from '@gnosis.pm/safe-react-gateway-sdk'
 import { SAFE_REACT_URL } from '@/config/constants'
 import useChainId from '@/hooks/useChainId'
 import ShareIcon from '@/public/images/share.svg'
-//import DeleteIcon from '@/public/images/delete.svg'
+import { AppRoutes } from '@/config/routes'
 
 type AppCardProps = {
   safeApp: SafeAppData
@@ -24,20 +25,22 @@ type AppCardContainerProps = {
 export const AppCardContainer = ({ url, children }: AppCardContainerProps): ReactElement => {
   if (url) {
     return (
-      <a href={url} target="_blank" rel="noreferrer">
-        <Card
-          sx={({ palette }) => ({
-            height: 190,
-            transition: 'background-color 0.3s ease-in-out, border 0.3s ease-in-out',
-            '&:hover': {
-              backgroundColor: palette.primary.background,
-              border: `2px solid ${palette.primary.light}`,
-            },
-          })}
-        >
-          {children}
-        </Card>
-      </a>
+      <Link href={url}>
+        <a rel="noreferrer">
+          <Card
+            sx={({ palette }) => ({
+              height: 190,
+              transition: 'background-color 0.3s ease-in-out, border 0.3s ease-in-out',
+              '&:hover': {
+                backgroundColor: palette.primary.background,
+                border: `2px solid ${palette.primary.light}`,
+              },
+            })}
+          >
+            {children}
+          </Card>
+        </a>
+      </Link>
     )
   }
 
@@ -62,7 +65,7 @@ const AppCard = ({ safeApp }: AppCardProps): ReactElement => {
   const chainId = useChainId()
 
   const shareUrl = `${SAFE_REACT_URL}/share/safe-app?appUrl=${safeApp.url}&chainId=${chainId}`
-  const url = router.query.safe ? `${SAFE_REACT_URL}/${router.query.safe}/apps?appUrl=${safeApp.url}` : shareUrl
+  const url = router.query.safe ? `${AppRoutes.safe.apps}?safe=${router.query.safe}&appUrl=${safeApp.url}` : shareUrl
 
   const onShareClick = (e: SyntheticEvent) => {
     e.preventDefault()

--- a/src/components/safe-apps/AppFrame/ThirdPartyCookiesWarning.tsx
+++ b/src/components/safe-apps/AppFrame/ThirdPartyCookiesWarning.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Alert, Link, AlertTitle } from '@mui/material'
+
+type ThirdPartyCookiesWarningProps = {
+  onClose: () => void
+}
+
+const HELP_LINK =
+  'https://help.gnosis-safe.io/en/articles/5955031-why-do-i-need-to-enable-third-party-cookies-for-safe-apps'
+
+export const ThirdPartyCookiesWarning = ({ onClose }: ThirdPartyCookiesWarningProps): React.ReactElement => {
+  return (
+    <Alert
+      severity="warning"
+      onClose={onClose}
+      sx={({ palette }) => ({
+        background: palette.warning.light,
+        border: 0,
+        borderBottom: `1px solid ${palette.warning.main}`,
+        borderRadius: '0px !important',
+      })}
+    >
+      <AlertTitle>
+        Third party cookies are disabled. Safe Apps may therefore not work properly. You can find out more information
+        about this{' '}
+        <Link href={HELP_LINK} target="_blank" fontSize="inherit">
+          here
+        </Link>
+      </AlertTitle>
+    </Alert>
+  )
+}

--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -1,0 +1,77 @@
+import { ReactElement, useCallback, useEffect, useMemo } from 'react'
+import { CircularProgress, Typography } from '@mui/material'
+import { SafeAppData } from '@gnosis.pm/safe-react-gateway-sdk'
+import { trackSafeAppOpenCount } from '@/services/safe-apps/track-app-usage-count'
+import { useSafeAppFromManifest } from '@/hooks/safe-apps/useSafeAppFromManifest'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
+import { isSameUrl } from '@/utils/url'
+import { ThirdPartyCookiesWarning } from './ThirdPartyCookiesWarning'
+import useThirdPartyCookies from './useThirdPartyCookies'
+import useAppIsLoading from './useAppIsLoading'
+
+import css from './styles.module.css'
+
+export type TransactionParams = {
+  safeTxGas?: number
+}
+
+type AppFrameProps = {
+  appUrl: string
+}
+
+const AppFrame = ({ appUrl }: AppFrameProps): ReactElement => {
+  const { safe } = useSafeInfo()
+  const [remoteApps] = useRemoteSafeApps()
+  const { safeApp: safeAppFromManifest } = useSafeAppFromManifest(appUrl, safe.chainId)
+  const { thirdPartyCookiesDisabled, setThirdPartyCookiesDisabled } = useThirdPartyCookies()
+  const { iframeRef, appIsLoading, isLoadingSlow, setAppIsLoading } = useAppIsLoading()
+
+  const remoteApp = useMemo(() => remoteApps?.find((app: SafeAppData) => app.url === appUrl), [remoteApps, appUrl])
+
+  useEffect(() => {
+    if (!remoteApp) return
+
+    trackSafeAppOpenCount(remoteApp.id)
+  }, [remoteApp])
+
+  const onIframeLoad = useCallback(() => {
+    const iframe = iframeRef.current
+    if (!iframe || !isSameUrl(iframe.src, appUrl)) {
+      return
+    }
+
+    setAppIsLoading(false)
+  }, [appUrl, iframeRef, setAppIsLoading])
+
+  return (
+    <div className={css.wrapper}>
+      {thirdPartyCookiesDisabled && <ThirdPartyCookiesWarning onClose={() => setThirdPartyCookiesDisabled(false)} />}
+
+      {appIsLoading && (
+        <div className={css.loadingContainer}>
+          {isLoadingSlow && (
+            <Typography variant="h4" gutterBottom>
+              The Safe App is taking too long to load, consider refreshing.
+            </Typography>
+          )}
+          <CircularProgress size={48} color="primary" />
+        </div>
+      )}
+
+      <iframe
+        className={css.iframe}
+        frameBorder="0"
+        id={`iframe-${appUrl}`}
+        ref={iframeRef}
+        src={appUrl}
+        title={safeAppFromManifest?.name}
+        onLoad={onIframeLoad}
+        allow="camera"
+        style={{ display: appIsLoading ? 'none' : 'block' }}
+      />
+    </div>
+  )
+}
+
+export default AppFrame

--- a/src/components/safe-apps/AppFrame/styles.module.css
+++ b/src/components/safe-apps/AppFrame/styles.module.css
@@ -1,0 +1,20 @@
+.wrapper {
+  width: 100%;
+  height: calc(100vh - var(--header-height));
+}
+
+.iframe {
+  height: 100%;
+  width: 100%;
+  overflow: auto;
+  box-sizing: border-box;
+}
+
+.loadingContainer {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+}

--- a/src/components/safe-apps/AppFrame/useAppIsLoading.ts
+++ b/src/components/safe-apps/AppFrame/useAppIsLoading.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { SAFE_APPS_POLLING_INTERVAL } from '@/config/constants'
+
+const APP_LOAD_ERROR_TIMEOUT = 30000
+const APP_LOAD_ERROR = 'There was an error loading the Safe App. There might be a problem with the App provider.'
+
+type UseAppIsLoadingReturnType = {
+  iframeRef: React.RefObject<HTMLIFrameElement>
+  appIsLoading: boolean
+  setAppIsLoading: (appIsLoading: boolean) => void
+  isLoadingSlow: boolean
+}
+
+const useAppIsLoading = (): UseAppIsLoadingReturnType => {
+  const [appIsLoading, setAppIsLoading] = useState<boolean>(true)
+  const [isLoadingSlow, setIsLoadingSlow] = useState<boolean>(false)
+  const [, setAppLoadError] = useState<boolean>(false)
+
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const timer = useRef<number>()
+  const errorTimer = useRef<number>()
+
+  useEffect(() => {
+    const clearTimeouts = () => {
+      clearTimeout(timer.current)
+      clearTimeout(errorTimer.current)
+    }
+
+    if (appIsLoading) {
+      timer.current = window.setTimeout(() => {
+        setIsLoadingSlow(true)
+      }, SAFE_APPS_POLLING_INTERVAL)
+      errorTimer.current = window.setTimeout(() => {
+        setAppLoadError(() => {
+          throw Error(APP_LOAD_ERROR)
+        })
+      }, APP_LOAD_ERROR_TIMEOUT)
+    } else {
+      clearTimeouts()
+      setIsLoadingSlow(false)
+    }
+
+    return () => {
+      clearTimeouts()
+    }
+  }, [appIsLoading])
+
+  return {
+    iframeRef,
+    appIsLoading,
+    setAppIsLoading,
+    isLoadingSlow,
+  }
+}
+
+export default useAppIsLoading

--- a/src/components/safe-apps/AppFrame/useThirdPartyCookies.ts
+++ b/src/components/safe-apps/AppFrame/useThirdPartyCookies.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { SAFE_APPS_THIRD_PARTY_COOKIES_CHECK_URL } from '@/config/constants'
+import { Errors, logError } from '@/services/exceptions'
+
+const SHOW_ALERT_TIMEOUT = 10000
+
+const isSafari = (): boolean => {
+  return navigator.userAgent.indexOf('Safari') > -1 && navigator.userAgent.indexOf('Chrome') <= -1
+}
+
+const createIframe = (uri: string, onload: () => void): HTMLIFrameElement => {
+  const iframeElement: HTMLIFrameElement = document.createElement('iframe')
+
+  iframeElement.src = uri
+  iframeElement.setAttribute('style', 'display:none')
+  iframeElement.onload = onload
+
+  return iframeElement
+}
+
+type ThirdPartyCookiesType = {
+  thirdPartyCookiesDisabled: boolean
+  setThirdPartyCookiesDisabled: (value: boolean) => void
+}
+
+const useThirdPartyCookies = (): ThirdPartyCookiesType => {
+  const iframeRef = useRef<HTMLIFrameElement>()
+  const [thirdPartyCookiesDisabled, setThirdPartyCookiesDisabled] = useState<boolean>(false)
+
+  const messageHandler = useCallback((event: MessageEvent) => {
+    const data = event.data
+
+    try {
+      if (data.hasOwnProperty('isCookieEnabled')) {
+        setThirdPartyCookiesDisabled(!data.isCookieEnabled)
+        window.removeEventListener('message', messageHandler)
+        document.body.removeChild(iframeRef.current as Node)
+      }
+    } catch (error) {
+      logError(Errors._905, (error as Error).message)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (isSafari()) {
+      return
+    }
+
+    window.addEventListener('message', messageHandler)
+
+    const iframeElement: HTMLIFrameElement = createIframe(SAFE_APPS_THIRD_PARTY_COOKIES_CHECK_URL, () =>
+      iframeElement?.contentWindow?.postMessage({ test: 'cookie' }, '*'),
+    )
+
+    iframeRef.current = iframeElement
+    document.body.appendChild(iframeElement)
+  }, [messageHandler])
+
+  useEffect(() => {
+    let id: ReturnType<typeof setTimeout>
+
+    if (thirdPartyCookiesDisabled) {
+      id = setTimeout(() => setThirdPartyCookiesDisabled(false), SHOW_ALERT_TIMEOUT)
+    }
+
+    return () => clearTimeout(id)
+  }, [thirdPartyCookiesDisabled])
+
+  return { thirdPartyCookiesDisabled, setThirdPartyCookiesDisabled }
+}
+
+export default useThirdPartyCookies

--- a/src/components/safe-apps/AppList.tsx
+++ b/src/components/safe-apps/AppList.tsx
@@ -1,0 +1,37 @@
+import { IS_PRODUCTION } from '@/config/constants'
+import { Grid } from '@mui/material'
+import { SafeAppData } from '@gnosis.pm/safe-react-gateway-sdk'
+import { useSafeApps } from '@/hooks/safe-apps/useSafeApps'
+import { AppCard } from './AppCard'
+import { SafeAppsHeader } from './SafeAppsHeader'
+
+const AppList = () => {
+  const { allSafeApps, remoteSafeAppsLoading, customSafeAppsLoading, addCustomApp } = useSafeApps()
+
+  if (remoteSafeAppsLoading || customSafeAppsLoading) {
+    return <p>Loading...</p>
+  }
+
+  return (
+    <>
+      {!IS_PRODUCTION && <SafeAppsHeader onCustomAppSave={addCustomApp} safeAppList={allSafeApps} />}
+
+      <Grid
+        container
+        rowSpacing={2}
+        columnSpacing={2}
+        sx={{
+          p: 3,
+        }}
+      >
+        {allSafeApps.map((a: SafeAppData) => (
+          <Grid key={a.id || a.url} item xs={12} sm={6} md={3} xl={1.5}>
+            <AppCard safeApp={a} />
+          </Grid>
+        ))}
+      </Grid>
+    </>
+  )
+}
+
+export default AppList

--- a/src/components/safe-apps/SafeAppsErrorBoundary/SafeAppsLoadError.tsx
+++ b/src/components/safe-apps/SafeAppsErrorBoundary/SafeAppsLoadError.tsx
@@ -1,0 +1,37 @@
+import Typography from '@mui/material/Typography'
+import Link from '@mui/material/Link'
+import Button from '@mui/material/Button'
+import OpenInNew from '@mui/icons-material/OpenInNew'
+import { SAFE_APPS_SUPPORT_CHAT_URL } from '@/config/constants'
+
+import css from './styles.module.css'
+
+type SafeAppsLoadErrorProps = {
+  onBackToApps: () => void
+}
+
+const SafeAppsLoadError = ({ onBackToApps }: SafeAppsLoadErrorProps): React.ReactElement => {
+  return (
+    <div className={css.wrapper}>
+      <div className={css.content}>
+        <Typography variant="h1">Safe App could not be loaded</Typography>
+
+        <img src="/images/network-error.svg" alt="Safe Apps load error" className={css.image} />
+
+        <div>
+          <Typography component="span">In case the problem persists, please reach out to us via </Typography>
+          <Link target="_blank" href={SAFE_APPS_SUPPORT_CHAT_URL} fontSize="medium">
+            Discord
+            <OpenInNew fontSize="small" color="primary" className={css.icon} />
+          </Link>
+        </div>
+
+        <Button href="#back" color="primary" onClick={onBackToApps}>
+          Go back to the Safe Apps list
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default SafeAppsLoadError

--- a/src/components/safe-apps/SafeAppsErrorBoundary/index.tsx
+++ b/src/components/safe-apps/SafeAppsErrorBoundary/index.tsx
@@ -1,0 +1,40 @@
+import React, { ReactNode, ErrorInfo } from 'react'
+
+type SafeAppsErrorBoundaryProps = {
+  children?: ReactNode
+  render: () => ReactNode
+}
+
+type SafeAppsErrorBoundaryState = {
+  hasError: boolean
+  error?: Error
+}
+
+class SafeAppsErrorBoundary extends React.Component<SafeAppsErrorBoundaryProps, SafeAppsErrorBoundaryState> {
+  public state: SafeAppsErrorBoundaryState = {
+    hasError: false,
+  }
+
+  constructor(props: SafeAppsErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error('Uncaught error:', error, errorInfo)
+  }
+
+  public static getDerivedStateFromError(error: Error): SafeAppsErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  public render(): React.ReactNode {
+    if (this.state.hasError) {
+      return this.props.render()
+    }
+
+    return this.props.children
+  }
+}
+
+export default SafeAppsErrorBoundary

--- a/src/components/safe-apps/SafeAppsErrorBoundary/styles.module.css
+++ b/src/components/safe-apps/SafeAppsErrorBoundary/styles.module.css
@@ -1,0 +1,41 @@
+.wrapper {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.content {
+  width: 400px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.content > * {
+  margin-top: 10px;
+}
+
+.linkWrapper {
+  display: inline-flex;
+  margin-bottom: 10px;
+  align-items: center;
+}
+
+.linkWrapper > :first-of-type {
+  margin-right: 5px;
+}
+
+.icon {
+  position: relative;
+  left: 3px;
+  top: 3px;
+}
+
+.image {
+  margin-top: 15px;
+  margin-bottom: 15px;
+}

--- a/src/components/safe-apps/SafeAppsErrorBoundary/styles.module.css
+++ b/src/components/safe-apps/SafeAppsErrorBoundary/styles.module.css
@@ -5,6 +5,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  height: calc(100vh - var(--header-height));
 }
 
 .content {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -25,3 +25,8 @@ export const SAFE_TOKEN_ADDRESSES: { [chainId: string]: string } = {
   '1': '0x5aFE3855358E112B5647B952709E6165e1c1eEEe',
   '4': '0xCFf1b0FdE85C102552D1D96084AF148f478F964A',
 }
+
+// Safe Apps
+export const SAFE_APPS_POLLING_INTERVAL = process.env.NODE_ENV === 'test' ? 4500 : 15000
+export const SAFE_APPS_THIRD_PARTY_COOKIES_CHECK_URL = 'https://third-party-cookies-check.gnosis-safe.com'
+export const SAFE_APPS_SUPPORT_CHAT_URL = 'https://chat.gnosis-safe.io'

--- a/src/hooks/safe-apps/useSafeAppFromManifest.ts
+++ b/src/hooks/safe-apps/useSafeAppFromManifest.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+import { SafeAppData } from '@gnosis.pm/safe-react-gateway-sdk'
+import { Errors, logError } from '@/services/exceptions'
+import { fetchSafeAppFromManifest } from '@/services/safe-apps/manifest'
+import useAsync from '../useAsync'
+
+type UseSafeAppFromManifestReturnType = {
+  safeApp?: SafeAppData
+  isLoading: boolean
+}
+
+const useSafeAppFromManifest = (appUrl: string, chainId: string): UseSafeAppFromManifestReturnType => {
+  const [data, error, loading] = useAsync<SafeAppData>(() => {
+    if (appUrl && chainId) return fetchSafeAppFromManifest(appUrl, chainId)
+  }, [appUrl, chainId])
+
+  useEffect(() => {
+    if (!error) return
+    logError(Errors._900, `${appUrl}, ${(error as Error).message}`)
+  }, [appUrl, error])
+
+  return { safeApp: data, isLoading: loading }
+}
+
+export { useSafeAppFromManifest }

--- a/src/pages/safe/apps.tsx
+++ b/src/pages/safe/apps.tsx
@@ -1,16 +1,25 @@
 import type { NextPage } from 'next'
+import { useRouter } from 'next/router'
+import AppFrame from '@/components/safe-apps/AppFrame'
+import SafeAppsErrorBoundary from '@/components/safe-apps/SafeAppsErrorBoundary'
+import SafeAppsLoadError from '@/components/safe-apps/SafeAppsErrorBoundary/SafeAppsLoadError'
+import AppList from '@/components/safe-apps/AppList'
 import Head from 'next/head'
-import Grid from '@mui/material/Grid'
-import { useSafeApps } from '@/hooks/safe-apps/useSafeApps'
-import { AppCard } from '@/components/safe-apps/AppCard'
-import { SafeAppsHeader } from '@/components/safe-apps/SafeAppsHeader'
-import { IS_PRODUCTION } from '@/config/constants'
 
 const Apps: NextPage = () => {
-  const { allSafeApps, remoteSafeAppsLoading, customSafeAppsLoading, addCustomApp } = useSafeApps()
+  const router = useRouter()
+  const { appUrl } = router.query
 
-  if (remoteSafeAppsLoading || customSafeAppsLoading) {
-    return <p>Loading...</p>
+  if (!router.isReady) {
+    return null
+  }
+
+  if (appUrl) {
+    return (
+      <SafeAppsErrorBoundary render={() => <SafeAppsLoadError onBackToApps={() => router.back()} />}>
+        <AppFrame appUrl={Array.isArray(appUrl) ? appUrl[0] : appUrl} />
+      </SafeAppsErrorBoundary>
+    )
   }
 
   return (
@@ -19,22 +28,7 @@ const Apps: NextPage = () => {
         <title>Safe Apps</title>
       </Head>
 
-      {!IS_PRODUCTION && <SafeAppsHeader onCustomAppSave={addCustomApp} safeAppList={allSafeApps} />}
-
-      <Grid
-        container
-        rowSpacing={2}
-        columnSpacing={2}
-        sx={{
-          p: 3,
-        }}
-      >
-        {allSafeApps.map((a) => (
-          <Grid key={a.id || a.url} item xs={12} sm={6} md={3} xl={1.5}>
-            <AppCard safeApp={a} />
-          </Grid>
-        ))}
-      </Grid>
+      <AppList />
     </main>
   )
 }

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -61,6 +61,7 @@ enum ErrorCodes {
   _902 = '902: Error loading Safe Apps list',
   _903 = '903: Error loading Safe App manifest',
   _904 = '904: Error loading chains',
+  _905 = '905: Third party cookies are disabled',
 }
 
 export default ErrorCodes

--- a/src/services/safe-apps/track-app-usage-count.ts
+++ b/src/services/safe-apps/track-app-usage-count.ts
@@ -1,0 +1,90 @@
+import local from '@/services/local-storage/local'
+import { SafeAppData } from '@gnosis.pm/safe-react-gateway-sdk'
+
+export const APPS_DASHBOARD = 'APPS_DASHBOARD'
+
+const TX_COUNT_WEIGHT = 2
+const OPEN_COUNT_WEIGHT = 1
+const PINNED_WEIGHT = 10
+
+export type AppTrackData = {
+  [safeAppId: string]: {
+    timestamp: number
+    openCount: number
+    txCount: number
+  }
+}
+
+export const getAppsUsageData = (): AppTrackData => {
+  return local.getItem<AppTrackData>(APPS_DASHBOARD) || {}
+}
+
+export const trackSafeAppOpenCount = (id: SafeAppData['id']): void => {
+  const trackData = getAppsUsageData()
+  const currentOpenCount = trackData[id]?.openCount || 0
+  const currentTxCount = trackData[id]?.txCount || 0
+
+  local.setItem(APPS_DASHBOARD, {
+    ...trackData,
+    [id]: {
+      timestamp: Date.now(),
+      openCount: currentOpenCount + 1,
+      txCount: currentTxCount,
+    },
+  })
+}
+
+export const trackSafeAppTxCount = (id: SafeAppData['id']): void => {
+  const trackData = getAppsUsageData()
+  const currentTxCount = trackData[id]?.txCount || 0
+
+  local.setItem(APPS_DASHBOARD, {
+    ...trackData,
+    // The object contains the openCount when we are creating a transaction
+    [id]: { ...trackData[id], txCount: currentTxCount + 1 },
+  })
+}
+
+// https://stackoverflow.com/a/55212064
+const normalizeBetweenTwoRanges = (
+  val: number,
+  minVal: number,
+  maxVal: number,
+  newMin: number,
+  newMax: number,
+): number => {
+  return newMin + ((val - minVal) * (newMax - newMin)) / (maxVal - minVal)
+}
+
+export const rankSafeApps = (apps: AppTrackData, pinnedSafeApps: SafeAppData[]): string[] => {
+  const appsWithScore = computeTrackedSafeAppsScore(apps)
+
+  for (const app of pinnedSafeApps) {
+    if (appsWithScore[app.id]) {
+      appsWithScore[app.id] += PINNED_WEIGHT
+    } else {
+      appsWithScore[app.id] = PINNED_WEIGHT
+    }
+  }
+
+  return Object.entries(appsWithScore)
+    .sort((a, b) => b[1] - a[1])
+    .map((app) => app[0])
+}
+
+export const computeTrackedSafeAppsScore = (apps: AppTrackData): Record<string, number> => {
+  const scoredApps: Record<string, number> = {}
+
+  const sortedByTimestamp = Object.entries(apps).sort((a, b) => {
+    return a[1].timestamp - b[1].timestamp
+  })
+
+  for (const [idx, app] of Array.from(sortedByTimestamp.entries())) {
+    // UNIX Timestamps add too much weight, so we normalize by uniformly distributing them to range [1..2]
+    const timeMultiplier = normalizeBetweenTwoRanges(idx, 0, sortedByTimestamp.length, 1, 2)
+
+    scoredApps[app[0]] = (TX_COUNT_WEIGHT * app[1].txCount + OPEN_COUNT_WEIGHT * app[1].openCount) * timeMultiplier
+  }
+
+  return scoredApps
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -2,4 +2,8 @@ const trimTrailingSlash = (url: string): string => {
   return url.replace(/\/$/, '')
 }
 
-export { trimTrailingSlash }
+const isSameUrl = (url1: string, url2: string): boolean => {
+  return trimTrailingSlash(url1) === trimTrailingSlash(url2)
+}
+
+export { trimTrailingSlash, isSameUrl }


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/web-core/issues/364

## How this PR fixes it
This PR includes the basic iframe loading components for Safe Apps. The SDK communication is not included in order to  maintain the PR small. Another branch will be created from this one to include SDK communication. It means that apps using the Provider are not going to load as the initial communication should be set. Use something like `CowSwap` to test that properly load

## How to test it
1) Open an app and see it can load properly
2) Open BrokenApp for checking the slow loading messages and error boundaries
3) Check Third party cookies banner working properly
4) Check correct tracking of opened apps in local storage

## Screenshots

<img width="1717" alt="image" src="https://user-images.githubusercontent.com/1576776/185425861-c5383a3a-f5d5-4b18-bca2-c1be51f790f8.png">

