### PR TITLE
fix: tx loading error text

### DIFF
--- a/src/components/common/PaginatedTxns/index.tsx
+++ b/src/components/common/PaginatedTxns/index.tsx
@@ -25,7 +25,7 @@ const PaginatedTxns = ({ useTxns }: { useTxns: typeof useTxHistory | typeof useT
       {allResults.length ? (
         <TxList items={allResults} />
       ) : error ? (
-        <ErrorMessage>Error loading the history</ErrorMessage>
+        <ErrorMessage>Error loading transactions</ErrorMessage>
       ) : loading ? (
         <SkeletonTxList />
       ) : (


### PR DESCRIPTION
## What it solves

Incorrect error text.

## How this PR fixes it

The `<PaginatedTxns>` component is shared between historical and queues transactions. It's now has a generic error message.