### PR TITLE
fix: wrap header logo in anchor

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -35,7 +35,7 @@ const Header = ({ onMenuToggle }: HeaderProps): ReactElement => {
 
       <div className={classnames(css.element, css.hideMobile, css.logo)}>
         <Track {...OVERVIEW_EVENTS.HOME}>
-          <Link href={{ href: AppRoutes.index, query: router.query }} passHref>
+          <Link href={AppRoutes.index} passHref>
             <a>
               <SafeLogo alt="Safe Logo" height={29} />
             </a>

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -36,7 +36,9 @@ const Header = ({ onMenuToggle }: HeaderProps): ReactElement => {
       <div className={classnames(css.element, css.hideMobile, css.logo)}>
         <Track {...OVERVIEW_EVENTS.HOME}>
           <Link href={{ href: AppRoutes.index, query: router.query }} passHref>
-            <SafeLogo alt="Safe Logo" height={29} />
+            <a>
+              <SafeLogo alt="Safe Logo" height={29} />
+            </a>
           </Link>
         </Track>
       </div>

--- a/src/components/common/Track/index.tsx
+++ b/src/components/common/Track/index.tsx
@@ -22,9 +22,7 @@ const Track = ({ children, as: Wrapper = 'div', ...trackData }: Props): typeof c
     const trackEl = el.current
 
     const handleClick = () => {
-      trackEvent({
-        ...trackData,
-      })
+      trackEvent(trackData)
     }
 
     // We cannot use onClick as events in children do not always bubble up


### PR DESCRIPTION
## What it solves

Logo link in header.

## How this PR fixes it

`passHref` was not functioning correctly as it wasn't wrapped in an anchor.

## How to test it

Hover over the logo in the header and observe the cursor change. Clicking it should navigate you to `/`.