### PR TITLE
fix: batch execution tooltip error

### DIFF
--- a/src/components/transactions/BatchExecuteButton/index.tsx
+++ b/src/components/transactions/BatchExecuteButton/index.tsx
@@ -35,16 +35,18 @@ const BatchExecuteButton = ({ items }: { items: (TransactionListItem | Transacti
           : 'All transactions highlighted in light green will be included in the batch execution.'
       }
     >
-      <Button
-        onMouseEnter={handleOnMouseEnter}
-        onMouseLeave={handleOnMouseLeave}
-        className={css.button}
-        variant="contained"
-        size="small"
-        disabled={isDisabled}
-      >
-        Execute Batch {isBatchable && ` (${batchableTransactions.length})`}
-      </Button>
+      <span>
+        <Button
+          onMouseEnter={handleOnMouseEnter}
+          onMouseLeave={handleOnMouseLeave}
+          className={css.button}
+          variant="contained"
+          size="small"
+          disabled={isDisabled}
+        >
+          Execute Batch {isBatchable && ` (${batchableTransactions.length})`}
+        </Button>
+      </span>
     </CustomTooltip>
   )
 }


### PR DESCRIPTION
## What it solves

Batch execution tooltip console error.

## How this PR fixes it

The `children` of the `CustomTooltip` is now wrapped in a `<span>`.

## How to test it

Open the queue list and observe no console error about tooltips.