### PR TITLE
Fix: dark mode toggle + asset icons in dark mode

### DIFF
--- a/src/components/common/TokenAmount/index.tsx
+++ b/src/components/common/TokenAmount/index.tsx
@@ -17,13 +17,15 @@ export const TokenIcon = ({
   const FALLBACK_ICON = '/images/token-placeholder.svg'
 
   return !logoUri ? null : (
-    <ImageFallback
-      src={logoUri}
-      alt={tokenSymbol}
-      className={css.tokenIcon}
-      fallbackSrc={FALLBACK_ICON}
-      height={size}
-    />
+    <span className={css.iconWrapper}>
+      <ImageFallback
+        src={logoUri}
+        alt={tokenSymbol}
+        className={css.tokenIcon}
+        fallbackSrc={FALLBACK_ICON}
+        height={size}
+      />
+    </span>
   )
 }
 

--- a/src/components/common/TokenAmount/styles.module.css
+++ b/src/components/common/TokenAmount/styles.module.css
@@ -28,10 +28,10 @@
 
 [data-theme="dark"] .iconWrapper:after {
   content: '';
-  left: 1px;
-  top: 1px;
-  right: 1px;
-  bottom: 1px;
+  left: -1px;
+  top: -1px;
+  right: -1px;
+  bottom: -1px;
   position: absolute;
   z-index: 1;
   background: var(--color-text-primary);

--- a/src/components/common/TokenAmount/styles.module.css
+++ b/src/components/common/TokenAmount/styles.module.css
@@ -7,11 +7,33 @@
   color: var(--color-text-primary);
 }
 
-.tokenIcon {
-  width: auto;
-}
-
 .symbol {
   white-space: normal;
   word-break: break-all;
+}
+
+.tokenIcon {
+  width: auto;
+  display: block;
+}
+
+.iconWrapper {
+  position: relative;
+}
+
+[data-theme="dark"] .iconWrapper img {
+  position: relative;
+  z-index: 2;
+}
+
+[data-theme="dark"] .iconWrapper:after {
+  content: '';
+  left: 1px;
+  top: 1px;
+  right: 1px;
+  bottom: 1px;
+  position: absolute;
+  z-index: 1;
+  background: var(--color-text-primary);
+  border-radius: 100%;
 }

--- a/src/components/tx/modals/TokenTransferModal/ReviewTokenTx.tsx
+++ b/src/components/tx/modals/TokenTransferModal/ReviewTokenTx.tsx
@@ -18,7 +18,9 @@ import SendFromBlock from '../../SendFromBlock'
 const TokenTransferReview = ({ params, tokenInfo }: { params: SendAssetsFormData; tokenInfo: TokenInfo }) => {
   return (
     <Box className={css.tokenPreview}>
-      <TokenIcon logoUri={tokenInfo.logoUri} tokenSymbol={tokenInfo.symbol} />
+      <Box className={css.tokenIcon}>
+        <TokenIcon logoUri={tokenInfo.logoUri} tokenSymbol={tokenInfo.symbol} />
+      </Box>
 
       <Box mt={1} fontSize={20}>
         {params.amount} {tokenInfo.symbol}

--- a/src/components/tx/modals/TokenTransferModal/styles.module.css
+++ b/src/components/tx/modals/TokenTransferModal/styles.module.css
@@ -10,6 +10,7 @@
   text-align: center;
 }
 
-.tokenPreview img {
-  margin: 0;
+.tokenIcon {
+  display: flex;
+  justify-content: center;
 }

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -3,18 +3,28 @@ import { selectSettings } from '@/store/settingsSlice'
 import { useEffect, useMemo, useState } from 'react'
 import initTheme from '@/styles/theme'
 
-const mediaQuery = '(prefers-color-scheme: dark)'
+const isSystemDarkMode = (): boolean => {
+  const mediaQuery = '(prefers-color-scheme: dark)'
+  return typeof window !== 'undefined' && window.matchMedia(mediaQuery).matches
+}
 
-export const useDarkMode = () => {
+export const useDarkMode = (): boolean => {
   const settings = useAppSelector(selectSettings)
   const [isDarkMode, setIsDarkMode] = useState<boolean>(false)
 
   useEffect(() => {
-    const systemPreference = window.matchMedia(mediaQuery)
-    setIsDarkMode(settings.theme.darkMode ?? systemPreference.matches)
+    setIsDarkMode(settings.theme.darkMode ?? isSystemDarkMode())
+  }, [settings.theme.darkMode])
 
+  return isDarkMode
+}
+
+export const useDarkModeTheme = () => {
+  const isDarkMode = useDarkMode()
+
+  useEffect(() => {
     document.documentElement.setAttribute('data-theme', isDarkMode ? 'dark' : 'light')
-  }, [isDarkMode, settings.theme.darkMode])
+  }, [isDarkMode])
 
   return useMemo(() => initTheme(isDarkMode), [isDarkMode])
 }

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -19,7 +19,7 @@ export const useDarkMode = (): boolean => {
   return isDarkMode
 }
 
-export const useDarkModeTheme = () => {
+export const useLightDarkTheme = () => {
   const isDarkMode = useDarkMode()
 
   useEffect(() => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -23,7 +23,7 @@ import { useInitSession } from '@/hooks/useInitSession'
 import useStorageMigration from '@/services/ls-migration'
 import Notifications from '@/components/common/Notifications'
 import CookieBanner from '@/components/common/CookieBanner'
-import { useDarkModeTheme } from '@/hooks/useDarkMode'
+import { useLightDarkTheme } from '@/hooks/useDarkMode'
 import { cgwDebugStorage } from '@/components/sidebar/DebugToggle'
 import { useTxTracking } from '@/hooks/useTxTracking'
 
@@ -54,7 +54,7 @@ const InitApp = (): null => {
 }
 
 const AppProviders = ({ children }: { children: ReactNode[] }) => {
-  const theme = useDarkModeTheme()
+  const theme = useLightDarkTheme()
 
   return (
     <Sentry.ErrorBoundary showDialog fallback={({ error }) => <div>{error.message}</div>}>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -23,7 +23,7 @@ import { useInitSession } from '@/hooks/useInitSession'
 import useStorageMigration from '@/services/ls-migration'
 import Notifications from '@/components/common/Notifications'
 import CookieBanner from '@/components/common/CookieBanner'
-import { useDarkMode } from '@/hooks/useDarkMode'
+import { useDarkModeTheme } from '@/hooks/useDarkMode'
 import { cgwDebugStorage } from '@/components/sidebar/DebugToggle'
 import { useTxTracking } from '@/hooks/useTxTracking'
 
@@ -54,7 +54,7 @@ const InitApp = (): null => {
 }
 
 const AppProviders = ({ children }: { children: ReactNode[] }) => {
-  const theme = useDarkMode()
+  const theme = useDarkModeTheme()
 
   return (
     <Sentry.ErrorBoundary showDialog fallback={({ error }) => <div>{error.message}</div>}>

--- a/src/pages/safe/settings/appearance.tsx
+++ b/src/pages/safe/settings/appearance.tsx
@@ -9,10 +9,12 @@ import { Breadcrumbs } from '@/components/common/Breadcrumbs'
 import SettingsIcon from '@/public/images/sidebar/settings.svg'
 import { trackEvent } from '@/services/analytics/analytics'
 import { SETTINGS_EVENTS } from '@/services/analytics/events/settings'
+import { useDarkMode } from '@/hooks/useDarkMode'
 
 const Appearance: NextPage = () => {
   const dispatch = useAppDispatch()
   const settings = useAppSelector(selectSettings)
+  const isDarkMode = useDarkMode()
 
   const handleToggle = (
     action: typeof setCopyShortName | typeof setDarkMode | typeof setShowShortName,
@@ -89,8 +91,8 @@ const Appearance: NextPage = () => {
             <FormControlLabel
               control={
                 <Checkbox
-                  checked={settings.theme.darkMode}
-                  onChange={handleToggle(setShowShortName, SETTINGS_EVENTS.APPEARANCE.DARK_MODE)}
+                  checked={isDarkMode}
+                  onChange={handleToggle(setDarkMode, SETTINGS_EVENTS.APPEARANCE.DARK_MODE)}
                 />
               }
               label="Dark mode"

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -23,9 +23,7 @@ const initialState: SettingsState = {
     copy: true,
     qr: true,
   },
-  theme: {
-    darkMode: true,
-  },
+  theme: {},
 }
 
 export const settingsSlice = createSlice({


### PR DESCRIPTION
Fixes the dark mode switch and default value in store + adds a light background for token icons in dark mode.

<img width="578" alt="Screenshot 2022-08-19 at 10 16 25" src="https://user-images.githubusercontent.com/381895/185575636-1ea0b21e-f1bf-40ec-b286-0359617a5d46.png">

