### PR TITLE
WIP: chore: cleanup workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
 
       - name: Setup Node.js w/ yarn cache
         uses: actions/setup-node@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,41 +1,41 @@
-name: e2e
+name: E2E
 
 on:
   pull_request:
 
 jobs:
   e2e:
-    runs-on: ubuntu-20.04
-    name: E2E on Chrome
+    runs-on: ubuntu-latest
+    name: Cypress on Chrome
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
+      - name: Checkout
       - uses: actions/checkout@v3
 
-      - name: Setup Node.js
+      - name: Setup Node.js w/ yarn cache
         uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'
 
-      - name: Yarn install
-        run: yarn install
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
       - name: Build
         run: yarn build && yarn export
 
       - name: Serve
-        run: yarn serve &
+        run: yarn serve
 
-      - uses: cypress-io/github-action@v4
+      - uses: Run Cypress tests
         with:
           spec: cypress/e2e/smoke/*.cy.js
           browser: chrome
           record: false
           config: baseUrl=http://localhost:8080
         env:
-          CYPRESS_ENV: ${{ env.REACT_APP_ENV}}
-          CYPRESS_MNEMONIC: ${{secrets.CYPRESS_MNEMONIC}}
+          CYPRESS_MNEMONIC: ${{ secrets.CYPRESS_MNEMONIC }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Serve
         run: yarn serve
 
-      - uses: Run Cypress tests
+      - name: Run Cypress tests
+        uses: cypress-io/github-action@v4
         with:
           spec: cypress/e2e/smoke/*.cy.js
           browser: chrome

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --verbose

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,13 +16,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Node.js w/ yarn cache
+      - name: Setup Node.js w/ dependencies
         uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'
-
-      - name: Install dependencies
         run: yarn install --verbose
 
       - name: Build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --verbose
 
       - name: Build
         run: yarn build && yarn export

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           node-version: 16
           cache: 'yarn'
+
+      - name: Install dependencies
         run: yarn install --verbose
 
       - name: Build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
 
       - name: Setup Node.js w/ yarn cache
         uses: actions/setup-node@v3
@@ -26,7 +26,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Run ESLint
-      - uses: bradennapier/eslint-plus-action@v3.4.2
+        uses: bradennapier/eslint-plus-action@v3.4.2
         with:
           npmInstall: false
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --verbose
 
       - name: Run ESLint
         uses: bradennapier/eslint-plus-action@v3.4.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           node-version: 16
           cache: 'yarn'
+
+      - name: Install dependencies
         run: yarn install --verbose
 
       - name: Run ESLint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,13 +16,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Node.js w/ yarn cache
+      - name: Setup Node.js w/ dependencies
         uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'
-
-      - name: Install dependencies
         run: yarn install --verbose
 
       - name: Run ESLint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,31 +1,32 @@
-name: 'Lint'
-on: [pull_request]
+name: Lint
+
+on:
+  pull_request:
 
 jobs:
   eslint:
     runs-on: ubuntu-latest
+    name: ESLint
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - name: Checkout
+      - uses: actions/checkout@v3
 
-      - name: Yarn cache
-        uses: actions/cache@v2
+      - name: Setup Node.js w/ yarn cache
+        uses: actions/setup-node@v3
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          node-version: 16
+          cache: 'yarn'
 
-      - name: Yarn install
-        run: |
-          mkdir .yarncache
-          yarn install --cache-folder ./.yarncache --immutable
-          rm -rf .yarncache
-          yarn cache clean
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
-      - uses: Maggi64/eslint-plus-action@master
+      - name: Run ESLint
+      - uses: bradennapier/eslint-plus-action@v3.4.2
         with:
           npmInstall: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
 
       - name: Setup Node.js w/ yarn cache
         uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,41 +1,34 @@
 name: Unit tests
+
 on:
   pull_request:
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    name: Jest
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
+      - name: Setup Node.js w/ yarn cache
+        uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: 'yarn'
 
-      - name: Yarn cache
-        uses: actions/cache@v2
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
-      - name: Yarn install
-        run: |
-          mkdir .yarncache
-          yarn install --cache-folder ./.yarncache  --immutable
-          rm -rf .yarncache
-          yarn cache clean
-
-      - name: Run tests
+      - name: Run Jest tests
         run: 'yarn test:ci'
 
-      - name: Comment in failing tests
+      - name: Add failing tests comment
         uses: mattallty/jest-github-action@v1.0.3
         if: failure()
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           node-version: 16
           cache: 'yarn'
+
+      - name: Install dependencies
         run: yarn install --verbose
 
       - name: Run Jest tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --verbose
 
       - name: Run Jest tests
         run: 'yarn test:ci'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,13 +16,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Node.js w/ yarn cache
+      - name: Setup Node.js w/ dependencies
         uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'
-
-      - name: Install dependencies
         run: yarn install --verbose
 
       - name: Run Jest tests


### PR DESCRIPTION
## What it solves

Simpler workflows including `yarn` caching from `actions/setup-node`.

## How this PR fixes it

All workflows (`e2e.yml`, `lint.yml` and `test.yml`) have been updated to use the same initialisation process which caches `yarn` via the `actions/setup-node` action. The linter action was also updated as the previous one was deprecated.

## How to test it

Observe the passing workflows on this branch.