### PR TITLE
Fix: duplicate results in paginated txns

### DIFF
--- a/src/components/common/LoadMoreButton/index.tsx
+++ b/src/components/common/LoadMoreButton/index.tsx
@@ -1,14 +1,9 @@
 import { type ReactElement } from 'react'
 import { Button } from '@mui/material'
 
-type LoadMoreButtonProps = {
-  loading: boolean
-  onLoadMore: () => void
-}
-
-const LoadMoreButton = ({ loading, onLoadMore }: LoadMoreButtonProps): ReactElement => {
+const LoadMoreButton = ({ onLoadMore }: { onLoadMore: () => void }): ReactElement => {
   return (
-    <Button onClick={onLoadMore} disabled={loading} variant="outlined">
+    <Button onClick={onLoadMore} variant="outlined">
       Load more
     </Button>
   )

--- a/src/components/common/PaginatedTxns/index.tsx
+++ b/src/components/common/PaginatedTxns/index.tsx
@@ -19,7 +19,7 @@ const TxPage = ({
   useTxns,
   onNextPage,
 }: {
-  pageUrl?: string
+  pageUrl: string
   useTxns: typeof useTxHistory | typeof useTxQueue
   onNextPage?: (pageUrl?: string) => void
 }): ReactElement => {

--- a/src/components/common/PaginatedTxns/index.tsx
+++ b/src/components/common/PaginatedTxns/index.tsx
@@ -1,5 +1,4 @@
-import { type ReactElement, useState, useEffect } from 'react'
-import { type TransactionListItem } from '@gnosis.pm/safe-react-gateway-sdk'
+import { type ReactElement, useState } from 'react'
 import { Box } from '@mui/material'
 import TxList from '@/components/transactions/TxList'
 import ErrorMessage from '@/components/tx/ErrorMessage'
@@ -8,52 +7,64 @@ import useTxQueue from '@/hooks/useTxQueue'
 import PagePlaceholder from '../PagePlaceholder'
 import LoadMoreButton from '../LoadMoreButton'
 import SkeletonTxList from './SkeletonTxList'
-import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
-import { trackEvent } from '@/services/analytics/analytics'
+
+const NoQueuedTxns = () => (
+  <Box mt="5vh">
+    <PagePlaceholder imageUrl="/images/no-transactions.svg" text="Queued transactions will appear here" />
+  </Box>
+)
+
+const TxPage = ({
+  pageUrl,
+  useTxns,
+  onNextPage,
+}: {
+  pageUrl?: string
+  useTxns: typeof useTxHistory | typeof useTxQueue
+  onNextPage?: (pageUrl?: string) => void
+}): ReactElement => {
+  const { page, error } = useTxns(pageUrl)
+
+  if (page) {
+    const isQueue = useTxns === useTxQueue
+
+    return (
+      <>
+        {page.results.length ? <TxList items={page.results} /> : isQueue && <NoQueuedTxns />}
+
+        {onNextPage && page.next && (
+          <Box my={4} textAlign="center">
+            <LoadMoreButton onLoadMore={() => onNextPage(page.next)} />
+          </Box>
+        )}
+      </>
+    )
+  }
+
+  if (error) {
+    return <ErrorMessage>Error loading transactions</ErrorMessage>
+  }
+
+  return <SkeletonTxList />
+}
 
 const PaginatedTxns = ({ useTxns }: { useTxns: typeof useTxHistory | typeof useTxQueue }): ReactElement => {
-  const [pageUrl, setPageUrl] = useState<string | undefined>()
-  const [allResults, setAllResults] = useState<TransactionListItem[]>([])
-  const { page, error, loading } = useTxns(pageUrl)
+  const [pages, setPages] = useState<string[]>([''])
 
-  const isQueue = useTxns === useTxQueue
-
-  useEffect(() => {
-    if (page?.results.length) {
-      setAllResults((prev) => prev.concat(page.results))
-    }
-  }, [page])
-
-  useEffect(() => {
-    if (isQueue) {
-      trackEvent({
-        ...TX_LIST_EVENTS.QUEUED_TXS,
-        label: allResults.length,
-      })
-    }
-  }, [allResults.length, isQueue])
+  const onNextPage = (pageUrl = '') => {
+    setPages((prev) => [...prev, pageUrl])
+  }
 
   return (
     <Box mb={4} position="relative">
-      {allResults.length ? (
-        <TxList items={allResults} />
-      ) : error ? (
-        <ErrorMessage>Error loading transactions</ErrorMessage>
-      ) : loading ? (
-        <SkeletonTxList />
-      ) : (
-        isQueue && (
-          <Box mt="5vh">
-            <PagePlaceholder imageUrl="/images/no-transactions.svg" text="Queued transactions will appear here" />
-          </Box>
-        )
-      )}
-
-      {(page?.next || loading) && (
-        <Box my={4} textAlign="center">
-          <LoadMoreButton onLoadMore={() => setPageUrl(page?.next)} loading={loading} />
-        </Box>
-      )}
+      {pages.map((pageUrl, index) => (
+        <TxPage
+          key={pageUrl}
+          pageUrl={pageUrl}
+          useTxns={useTxns}
+          onNextPage={index === pages.length - 1 ? onNextPage : undefined}
+        />
+      ))}
     </Box>
   )
 }

--- a/src/hooks/useTxHistory.ts
+++ b/src/hooks/useTxHistory.ts
@@ -32,12 +32,12 @@ const useTxHistory = (
     ? {
         page,
         error: error?.message,
-        loading: loading || !page,
+        loading: loading,
       }
     : {
         page: historyState.data,
         error: historyState.error,
-        loading: historyState.loading || !historyState.data,
+        loading: historyState.loading,
       }
 }
 

--- a/src/hooks/useTxQueue.ts
+++ b/src/hooks/useTxQueue.ts
@@ -28,12 +28,12 @@ const useTxQueue = (
     ? {
         page,
         error: error?.message,
-        loading: loading || !page,
+        loading: loading,
       }
     : {
         page: queueState.data,
         error: queueState.error,
-        loading: queueState.loading || !queueState.data,
+        loading: queueState.loading,
       }
 }
 

--- a/src/pages/safe/balances/nfts.tsx
+++ b/src/pages/safe/balances/nfts.tsx
@@ -15,7 +15,7 @@ const NftPage = ({
   pageUrl,
   onNextPage,
 }: {
-  pageUrl?: string
+  pageUrl: string
   onNextPage?: (pageUrl?: string) => void
 }): ReactElement => {
   const [collectibles, error] = useCollectibles(pageUrl)
@@ -75,11 +75,7 @@ const NFTs: NextPage = () => {
         </Alert>
 
         {pages.map((pageUrl, index) => (
-          <NftPage
-            key={index}
-            pageUrl={pageUrl}
-            onNextPage={index === pages.length - 1 ? (pageUrl) => onNextPage(pageUrl) : undefined}
-          />
+          <NftPage key={index} pageUrl={pageUrl} onNextPage={index === pages.length - 1 ? onNextPage : undefined} />
         ))}
       </Box>
     </main>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,7 +11,7 @@ import { safeInfoSlice } from './safeInfoSlice'
 import { balancesSlice } from './balancesSlice'
 import { sessionSlice } from './sessionSlice'
 import { txHistorySlice, txHistoryMiddleware } from './txHistorySlice'
-import { txQueueSlice } from './txQueueSlice'
+import { txQueueSlice, txQueueMiddleware } from './txQueueSlice'
 import { addressBookSlice } from './addressBookSlice'
 import { notificationsSlice } from './notificationsSlice'
 import { getPreloadedState, persistState } from './persistStore'
@@ -50,7 +50,13 @@ const persistedSlices: (keyof PreloadedState<RootState>)[] = [
   cookiesSlice.name,
 ]
 
-const middleware = [persistState(persistedSlices), txHistoryMiddleware, addedSafesMiddleware, cookiesMiddleware]
+const middleware = [
+  persistState(persistedSlices),
+  txHistoryMiddleware,
+  txQueueMiddleware,
+  addedSafesMiddleware,
+  cookiesMiddleware,
+]
 
 export const getPersistedState = () => {
   return getPreloadedState(persistedSlices)

--- a/src/store/txQueueSlice.ts
+++ b/src/store/txQueueSlice.ts
@@ -1,8 +1,10 @@
-import { createSelector } from '@reduxjs/toolkit'
+import { createSelector, Middleware } from '@reduxjs/toolkit'
 import { TransactionListPage } from '@gnosis.pm/safe-react-gateway-sdk'
 import type { RootState } from '@/store'
 import { makeLoadableSlice } from './common'
 import { isMultisigExecutionInfo, isTransactionListItem } from '@/utils/transaction-guards'
+import { trackEvent } from '@/services/analytics/analytics'
+import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 
 const { slice, selector } = makeLoadableSlice('txQueue', undefined as TransactionListPage | undefined)
 
@@ -22,3 +24,22 @@ export const selectQueuedTransactionsByNonce = createSelector(
     })
   },
 )
+
+export const txQueueMiddleware: Middleware<{}, RootState> = () => (next) => (action) => {
+  const result = next(action)
+
+  switch (action.type) {
+    case txQueueSlice.actions.set.type: {
+      const { payload } = action as ReturnType<typeof txQueueSlice.actions.set>
+
+      if (!payload.data) return
+
+      trackEvent({
+        ...TX_LIST_EVENTS.QUEUED_TXS,
+        label: payload.data.results.length.toString(),
+      })
+    }
+  }
+
+  return result
+}


### PR DESCRIPTION
## What it solves
There were duplicate tx items in the history when a new tx was successfully indexed. This was due to the allResults continuously  accumulating loaded results.

## How it solves it
Now, we display each page separately with its own loader hook. So that if a page is updated, it will re-render itself seamlessly.