### PR TITLE
Fix page scroll

### DIFF
--- a/src/components/common/Footer/index.tsx
+++ b/src/components/common/Footer/index.tsx
@@ -7,19 +7,13 @@ import { openCookieBanner } from '@/store/popupSlice'
 import { AppRoutes } from '@/config/routes'
 import packageJson from '../../../../package.json'
 
-const footerPages = [
-  AppRoutes.welcome,
-  AppRoutes.safe.settings.index,
-  AppRoutes.safe.settings.setup,
-  AppRoutes.safe.settings.modules,
-  AppRoutes.safe.settings.appearance,
-]
+const footerPages = [AppRoutes.welcome, AppRoutes.safe.settings.index]
 
 const Footer = (): ReactElement | null => {
   const router = useRouter()
   const dispatch = useAppDispatch()
 
-  if (!footerPages.includes(router.pathname)) {
+  if (!footerPages.some((path) => router.pathname.startsWith(path))) {
     return null
   }
 

--- a/src/components/common/Header/styles.module.css
+++ b/src/components/common/Header/styles.module.css
@@ -40,6 +40,16 @@
   border-right: none;
 }
 
+@media (max-width: 900px) {
+  .logo {
+    display: none;
+  }
+
+  .menuButton {
+    display: block;
+  }
+}
+
 @media (max-width: 600px) {
   .element {
     padding: 0 var(--space-1);
@@ -53,12 +63,7 @@
     padding-right: 0;
   }
 
-  .logo,
   .hideMobile {
     display: none;
-  }
-
-  .menuButton {
-    display: block;
   }
 }

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -23,8 +23,8 @@ const PageLayout = ({ children }: { children: ReactElement }): ReactElement => {
   }, [router.pathname, router.query.safe])
 
   return (
-    <div className={css.container}>
-      <header>
+    <>
+      <header className={css.header}>
         <Header onMenuToggle={onMenuToggle} />
       </header>
 
@@ -43,7 +43,7 @@ const PageLayout = ({ children }: { children: ReactElement }): ReactElement => {
 
         <Footer />
       </div>
-    </div>
+    </>
   )
 }
 

--- a/src/components/common/PageLayout/styles.module.css
+++ b/src/components/common/PageLayout/styles.module.css
@@ -1,38 +1,22 @@
-.container {
-  height: 100vh;
-  width: 100vw;
-  overflow: hidden;
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-  grid-template-columns: auto 1fr;
-  grid-template-areas:
-    'header header'
-    'sidebar main';
-}
-
-.container header {
-  grid-area: header;
-  position: relative;
+.header {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
   z-index: 1201;
 }
 
 .main {
-  grid-area: main;
-  overflow-y: auto;
-  overflow-x: hidden;
-  min-height: calc(100vh - var(--header-height)); /* needed for scroll */
-  position: relative;
   background-color: var(--color-background-main);
+  padding-left: 230px;
+  padding-top: var(--header-height);
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
 }
 
 .content {
   flex: 1;
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  align-items: stretch;
 }
 
 .content main {
@@ -40,32 +24,23 @@
 }
 
 .sidebar {
-  grid-area: sidebar;
+  position: fixed;
+  height: 100vh;
+  left: 0;
+  top: 0;
+  padding-top: var(--header-height);
 }
 
 @media (max-width: 600px) {
-  .container {
-    display: block;
-    padding-top: var(--header-height);
-    height: auto;
-  }
-
-  .container header {
-    position: fixed;
-    width: 100%;
-    top: 0;
-    left: 0;
+  .main {
+    padding-left: 0;
   }
 
   .sidebar {
     display: none;
   }
 
-  .main {
-    overflow: hidden;
-  }
-
-  .content main {
+  .main main {
     padding: var(--space-2);
   }
 }

--- a/src/components/common/PageLayout/styles.module.css
+++ b/src/components/common/PageLayout/styles.module.css
@@ -31,7 +31,7 @@
   padding-top: var(--header-height);
 }
 
-@media (max-width: 600px) {
+@media (max-width: 900px) {
   .main {
     padding-left: 0;
   }
@@ -39,7 +39,9 @@
   .sidebar {
     display: none;
   }
+}
 
+@media (max-width: 600px) {
   .main main {
     padding: var(--space-2);
   }

--- a/src/components/common/PageLayout/styles.module.css
+++ b/src/components/common/PageLayout/styles.module.css
@@ -17,6 +17,7 @@
 
 .content {
   flex: 1;
+  position: relative;
 }
 
 .content main {

--- a/src/components/sidebar/Sidebar/index.tsx
+++ b/src/components/sidebar/Sidebar/index.tsx
@@ -12,7 +12,6 @@ import SidebarFooter from '@/components/sidebar/SidebarFooter'
 
 import css from './styles.module.css'
 import { AppRoutes } from '@/config/routes'
-import OwnedSafes from '../OwnedSafes'
 import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
 import { trackEvent } from '@/services/analytics/analytics'
 
@@ -46,9 +45,7 @@ const Sidebar = (): ReactElement => {
             <SidebarNavigation />
           </>
         ) : (
-          <div className={css.noSafeHeader}>
-            <OwnedSafes />
-          </div>
+          <div className={css.noSafeHeader} />
         )}
 
         <div style={{ flexGrow: 1 }} />

--- a/src/components/sidebar/Sidebar/styles.module.css
+++ b/src/components/sidebar/Sidebar/styles.module.css
@@ -8,7 +8,7 @@
 }
 
 .container {
-  width: 220px;
+  width: 230px;
   border-right: 1px solid var(--color-border-light);
 }
 
@@ -19,8 +19,7 @@
   max-height: calc(100vh - var(--header-height)); /* needed for scroll */
 }
 
-.drawer,
-.noSafe {
+.drawer {
   width: 400px;
   max-width: 90vw;
 }


### PR DESCRIPTION
## What it solves
When navigating between long pages with scroll, the scroll position wasn't resetting. This was because we have a custom scrollable container (.main) instead of the body.

This PR changes the page layout so that the whole page scrolls, and the header and sidebar are sticky.

## Side changes
I had to remove the owned safes on the welcome page for now. They break all the beautiful CSS logic. Hopefully we'll restore it in a new design.