### PR TITLE
style: Align batch execute button on smaller screens

### DIFF
--- a/src/components/transactions/BatchExecuteButton/styles.module.css
+++ b/src/components/transactions/BatchExecuteButton/styles.module.css
@@ -3,3 +3,9 @@
   right: 0;
   top: -50px;
 }
+
+@media (max-width: 600px) {
+  .button {
+    top: var(--space-2);
+  }
+}

--- a/src/components/transactions/GroupedTxListItems/styles.module.css
+++ b/src/components/transactions/GroupedTxListItems/styles.module.css
@@ -30,3 +30,11 @@
 .willBeReplaced * {
   text-decoration: line-through;
 }
+
+@media (max-width: 600px) {
+  .disclaimerContainer {
+    gap: var(--space-1);
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## What it solves

- Moves the Batch Execute button down to not overlap with the tabs on smaller screens
- Scaffolds grouped tx description on smaller screens

## Screenshots

<img width="413" alt="Screenshot 2022-08-19 at 15 20 40" src="https://user-images.githubusercontent.com/5880855/185628522-d3c0e8db-49af-4331-9297-90da7c8b1174.png">
<img width="392" alt="Screenshot 2022-08-19 at 15 25 11" src="https://user-images.githubusercontent.com/5880855/185628556-e8eb8a4c-7e4d-4612-853c-15b8effcd308.png">

