### PR TITLE
fix: row-specific validation

### DIFF
--- a/src/components/address-book/ImportDialog/__tests__/validation.test.ts
+++ b/src/components/address-book/ImportDialog/__tests__/validation.test.ts
@@ -103,7 +103,7 @@ describe('Address book import validation', () => {
       const entries = [
         ['0xAb5e3288640396C3988af5a820510682f3C58adF', 'name', '1'],
         ['0x1F2504De05f5167650bE5B28c472601Be434b60A', 'name1', '4'],
-        ['0x1F2504De05f5167650bE5B28c472601Be434b60A', 'name1', '   1 0   0'],
+        ['0x1F2504De05f5167650bE5B28c472601Be434b60A', 'name1', '   100'],
       ]
 
       expect(hasValidAbEntryChainIds(entries)).toBe(true)
@@ -115,7 +115,7 @@ describe('Address book import validation', () => {
         ['0x1F2504De05f5167650bE5B28c472601Be434b60A', 'name1', ''],
       ]
       const entries2 = [
-        ['0xAb5e3288640396C3988af5a820510682f3C58adF', 'name', 'abc'],
+        ['0xAb5e3288640396C3988af5a820510682f3C58adF', 'name', ' 1 0 0 '],
         ['0x1F2504De05f5167650bE5B28c472601Be434b60A', 'name1', '4', 'extra'],
       ]
       const entries3 = [['0xAb5e3288640396C3988af5a820510682f3C58adF'], []]

--- a/src/components/address-book/ImportDialog/__tests__/validation.test.ts
+++ b/src/components/address-book/ImportDialog/__tests__/validation.test.ts
@@ -5,6 +5,7 @@ import {
   hasValidAbEntryAddresses,
   hasValidAbEntryChainIds,
   hasValidAbHeader,
+  hasValidAbNames,
 } from '../validation'
 
 describe('Address book import validation', () => {
@@ -76,11 +77,33 @@ describe('Address book import validation', () => {
       expect(hasValidAbEntryAddresses(entries3)).toBe(false)
     })
   })
+
+  describe('hasValidAbNames', () => {
+    it('should return true if all entries have valid names', () => {
+      const entries = [
+        ['0xAb5e3288640396C3988af5a820510682f3C58adF', 'name', 'chainId'],
+        ['0x1F2504De05f5167650bE5B28c472601Be434b60A', 'name1', 'chainId1'],
+      ]
+
+      expect(hasValidAbNames(entries)).toBe(true)
+    })
+
+    it('should return false if any entry has invalid names', () => {
+      const entries = [
+        ['0xAb5e3288640396C3988af5a820510682f3C58adF', '', 'chainId'],
+        ['0x1F2504De05f5167650bEA', 'name2', 'chainId2'],
+      ]
+
+      expect(hasValidAbNames(entries)).toBe(false)
+    })
+  })
+
   describe('hasValidAbEntryChainIds', () => {
     it('should return true if all entries have valid chainIds', () => {
       const entries = [
         ['0xAb5e3288640396C3988af5a820510682f3C58adF', 'name', '1'],
         ['0x1F2504De05f5167650bE5B28c472601Be434b60A', 'name1', '4'],
+        ['0x1F2504De05f5167650bE5B28c472601Be434b60A', 'name1', '   1 0   0'],
       ]
 
       expect(hasValidAbEntryChainIds(entries)).toBe(true)
@@ -146,7 +169,7 @@ describe('Address book import validation', () => {
         meta: {} as ParseMeta,
       } as ParseResult<string[]>
 
-      expect(abOnUploadValidator(result)).toBe('Invalid or corrupt address book')
+      expect(abOnUploadValidator(result)).toBe('Invalid or corrupt address book header')
     })
 
     it('should return an error if no entries are present', () => {
@@ -159,7 +182,7 @@ describe('Address book import validation', () => {
       expect(abOnUploadValidator(result)).toBe('No entries found in address book')
     })
 
-    it('should return an error if some entries have empty values', () => {
+    it('should return an error if some entries have invalid addresses', () => {
       const result = {
         data: [
           ['address', 'name', 'chainId'],
@@ -169,20 +192,33 @@ describe('Address book import validation', () => {
         meta: {} as ParseMeta,
       } as ParseResult<string[]>
 
-      expect(abOnUploadValidator(result)).toBe('Address book contains invalid addresses')
+      expect(abOnUploadValidator(result)).toBe('Address book contains an invalid address on row 2')
+    })
+
+    it('should return an error if some entries have empty names', () => {
+      const result = {
+        data: [
+          ['address', 'name', 'chainId'],
+          ['0xAb5e3288640396C3988af5a820510682f3C58adF', '', '1'],
+        ],
+        errors: [],
+        meta: {} as ParseMeta,
+      } as ParseResult<string[]>
+
+      expect(abOnUploadValidator(result)).toBe('Address book contains an invalid name on row 2')
     })
 
     it('should return an error if some entries have invalid chain IDs', () => {
       const result = {
         data: [
           ['address', 'name', 'chainId'],
-          ['0x0', 'name', '2394857230948572034598723049587230495872304958704'],
+          ['0xAb5e3288640396C3988af5a820510682f3C58adF', 'name', '2394857230948572034598723049587230495872304958704'],
         ],
         errors: [],
         meta: {} as ParseMeta,
       } as ParseResult<string[]>
 
-      expect(abOnUploadValidator(result)).toBe('Address book contains invalid addresses')
+      expect(abOnUploadValidator(result)).toBe('Address book contains an invalid chain ID on row 2')
     })
   })
 })

--- a/src/components/address-book/ImportDialog/index.tsx
+++ b/src/components/address-book/ImportDialog/index.tsx
@@ -33,7 +33,7 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
     if (!csvData) return [0, 0]
     const entries = csvData.data.slice(1).filter(hasEntry)
     const entryLen = entries.length
-    const chainLen = new Set(entries.map((entry) => entry[2].replace(/\s/g, ''))).size
+    const chainLen = new Set(entries.map((entry) => entry[2].trim())).size
     return [entryLen, chainLen]
   }, [csvData])
 
@@ -50,7 +50,7 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
     for (const entry of entries) {
       if (hasEntry(entry)) {
         const [address, name, chainId] = entry
-        dispatch(upsertAddressBookEntry({ address, name, chainId: chainId.replace(/\s/g, '') }))
+        dispatch(upsertAddressBookEntry({ address, name, chainId: chainId.trim() }))
       }
     }
 

--- a/src/components/address-book/ImportDialog/index.tsx
+++ b/src/components/address-book/ImportDialog/index.tsx
@@ -130,15 +130,15 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
                     </Grid>
 
                     <ProgressBar />
-
-                    <Typography mt={1} sx={({ palette }) => ({ color: error ? palette.error.main : undefined })}>
-                      {error
-                        ? error
-                        : `Found ${entryCount} entries on ${chainCount} ${chainCount > 1 ? 'chains' : 'chain'}`}
-                    </Typography>
                   </div>
                 ) : (
                   'Drop your CSV file here or click to upload.'
+                )}
+
+                {(error || acceptedFile) && (
+                  <Typography mt={1} sx={({ palette }) => ({ color: error ? palette.error.main : undefined })}>
+                    {error || `Found ${entryCount} entries on ${chainCount} ${chainCount > 1 ? 'chains' : 'chain'}`}
+                  </Typography>
                 )}
               </Box>
             )

--- a/src/components/address-book/ImportDialog/index.tsx
+++ b/src/components/address-book/ImportDialog/index.tsx
@@ -33,7 +33,7 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
     if (!csvData) return [0, 0]
     const entries = csvData.data.slice(1).filter(hasEntry)
     const entryLen = entries.length
-    const chainLen = new Set(entries.map((entry) => entry[2])).size
+    const chainLen = new Set(entries.map((entry) => entry[2].replace(/\s/g, ''))).size
     return [entryLen, chainLen]
   }, [csvData])
 
@@ -132,7 +132,9 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
                     <ProgressBar />
 
                     <Typography mt={1} sx={({ palette }) => ({ color: error ? palette.error.main : undefined })}>
-                      {error ? error : `Found ${entryCount} entries on ${chainCount} chains`}
+                      {error
+                        ? error
+                        : `Found ${entryCount} entries on ${chainCount} ${chainCount > 1 ? 'chains' : 'chain'}`}
                     </Typography>
                   </div>
                 ) : (

--- a/src/components/address-book/ImportDialog/validation.ts
+++ b/src/components/address-book/ImportDialog/validation.ts
@@ -29,7 +29,7 @@ export const hasValidAbEntryChainIds = (entries: string[][]) => {
     if (entry.length < 3) {
       return false
     }
-    const chainId = entry[2].replace(/\s/g, '')
+    const chainId = entry[2].trim()
     return !validateChainId(chainId)
   })
 }

--- a/src/components/address-book/ImportDialog/validation.ts
+++ b/src/components/address-book/ImportDialog/validation.ts
@@ -20,6 +20,10 @@ export const hasValidAbEntryAddresses = (entries: string[][]) => {
   return entries.every((entry) => entry.length >= 1 && !validateAddress(entry[0]))
 }
 
+export const hasValidAbNames = (entries: string[][]) => {
+  return entries.every((entry) => entry.length >= 2 && !!entry[1])
+}
+
 export const hasValidAbEntryChainIds = (entries: string[][]) => {
   return entries.every((entry) => {
     if (entry.length < 3) {
@@ -45,7 +49,7 @@ export const abOnUploadValidator = ({ data, errors }: ParseResult<string[]>): st
 
   // Wrong header
   if (!hasValidAbHeader(header)) {
-    return 'Invalid or corrupt address book'
+    return 'Invalid or corrupt address book header'
   }
 
   // No entries
@@ -53,13 +57,23 @@ export const abOnUploadValidator = ({ data, errors }: ParseResult<string[]>): st
     return 'No entries found in address book'
   }
 
+  // We + 2 to each row to make up for header and index
+
   // An entry has invalid address
   if (!hasValidAbEntryAddresses(entries)) {
-    return 'Address book contains invalid addresses'
+    const i = entries.findIndex((entry) => (entry.length >= 1 ? validateAddress(entry[0]) : true))
+    return `Address book contains an invalid address on row ${i + 2}`
+  }
+
+  // An entry has invalid name
+  if (!hasValidAbNames(entries)) {
+    const i = entries.findIndex((entry) => (entry.length >= 2 ? !entry[1] : true))
+    return `Address book contains an invalid name on row ${i + 2}`
   }
 
   // An entry has invalid chainId
   if (!hasValidAbEntryChainIds(entries)) {
-    return 'Address book contains invalid chain IDs'
+    const i = entries.findIndex((entry) => (entry.length >= 3 ? validateChainId(entry[2]) : true))
+    return `Address book contains an invalid chain ID on row ${i + 2}`
   }
 }


### PR DESCRIPTION
## What it solves

Clearer error messages and entry count.

## How this PR fixes it

1. Rejected uploads (wrong filetype or >1MB csv files) now display their error message.
2. Chain IDs padded with whitespace that match other chain IDs in an address book are counted as the same when displaying the chain count, i.e. `"100"` is the same as `"  100    "`
3. Validation messages are row-specific.

## How to test it

1. Drag a non-csv file or attempt to upload a >1MB csv file. Observe the related error message.
2. Upload an address book that contains two entries on the same chain, but modifying one `chainId` to have whitespace at the beginning or end. Observe the row-specific error message.
3. Upload an address book with an invalid address, then name. Observe each time a row-specific error message. Invalid chain IDs match testing method 2.

## Analytics changes
## Screenshots
![image](https://user-images.githubusercontent.com/20442784/185632241-e6585816-a3d2-4622-b74b-a3be24233f05.png)