### PR TITLE
feat: show link in notifications

### DIFF
--- a/src/components/common/Notifications/index.tsx
+++ b/src/components/common/Notifications/index.tsx
@@ -2,21 +2,43 @@ import { ReactElement, SyntheticEvent, useCallback, useEffect } from 'react'
 import groupBy from 'lodash/groupBy'
 import { useAppDispatch, useAppSelector } from '@/store'
 import { closeNotification, Notification, selectNotifications } from '@/store/notificationsSlice'
-import { Alert, AlertColor, Snackbar, SnackbarCloseReason } from '@mui/material'
+import { Alert, AlertColor, Link, Snackbar, SnackbarCloseReason } from '@mui/material'
 import css from './styles.module.css'
+import NextLink from 'next/link'
+import { useRouter } from 'next/router'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 
 const toastStyle = { position: 'static', margin: 1 }
 
-const Toast = ({ message, severity, onClose }: { message: string; severity: AlertColor; onClose: () => void }) => {
+const Toast = ({
+  message,
+  variant,
+  link,
+  onClose,
+}: {
+  message: string
+  variant: AlertColor
+  link?: Notification['link']
+  onClose: () => void
+}) => {
+  const router = useRouter()
+
   const handleClose = (_: Event | SyntheticEvent, reason?: SnackbarCloseReason) => {
     if (reason === 'clickaway') return
     onClose()
   }
 
   return (
-    <Snackbar open onClose={handleClose} sx={toastStyle} autoHideDuration={severity === 'success' ? 5000 : null}>
-      <Alert severity={severity} onClose={handleClose} elevation={3} sx={{ width: '340px' }}>
+    <Snackbar open onClose={handleClose} sx={toastStyle} autoHideDuration={variant === 'success' ? 5000 : null}>
+      <Alert severity={variant} onClose={handleClose} elevation={3} sx={{ width: '340px' }}>
         {message}
+        {link && (
+          <NextLink href={{ href: link.href, query: router.query }} passHref>
+            <Link className={css.link}>
+              {link.title} <ChevronRightIcon />
+            </Link>
+          </NextLink>
+        )}
       </Alert>
     </Snackbar>
   )
@@ -57,7 +79,7 @@ const Notifications = (): ReactElement | null => {
     <div className={css.container}>
       {visible.map((item) => (
         <div className={css.row} key={item.id}>
-          <Toast message={item.message} severity={item.variant || 'info'} onClose={() => handleClose(item)} />
+          <Toast {...item} onClose={() => handleClose(item)} />
         </div>
       ))}
     </div>

--- a/src/components/common/Notifications/index.tsx
+++ b/src/components/common/Notifications/index.tsx
@@ -5,10 +5,33 @@ import { closeNotification, Notification, selectNotifications } from '@/store/no
 import { Alert, AlertColor, Link, Snackbar, SnackbarCloseReason } from '@mui/material'
 import css from './styles.module.css'
 import NextLink from 'next/link'
-import { useRouter } from 'next/router'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
+import Track from '../Track'
 
 const toastStyle = { position: 'static', margin: 1 }
+
+export const NotificationLink = ({
+  link,
+  onClick,
+}: {
+  link: Notification['link']
+  onClick: (_: Event | SyntheticEvent) => void
+}): ReactElement | null => {
+  if (!link) {
+    return null
+  }
+
+  return (
+    <Track {...OVERVIEW_EVENTS.NOTIFICATION_INTERACTION} label={link.title}>
+      <NextLink onClick={onClick} href={link.pathname} passHref>
+        <Link className={css.link} sx={{ mt: 1 }}>
+          {link.title} <ChevronRightIcon />
+        </Link>
+      </NextLink>
+    </Track>
+  )
+}
 
 const Toast = ({
   message,
@@ -21,8 +44,6 @@ const Toast = ({
   link?: Notification['link']
   onClose: () => void
 }) => {
-  const router = useRouter()
-
   const handleClose = (_: Event | SyntheticEvent, reason?: SnackbarCloseReason) => {
     if (reason === 'clickaway') return
     onClose()
@@ -32,13 +53,7 @@ const Toast = ({
     <Snackbar open onClose={handleClose} sx={toastStyle} autoHideDuration={5000}>
       <Alert severity={variant} onClose={handleClose} elevation={3} sx={{ width: '340px' }}>
         {message}
-        {link && (
-          <NextLink href={{ href: link.href, query: router.query }} passHref>
-            <Link className={css.link}>
-              {link.title} <ChevronRightIcon />
-            </Link>
-          </NextLink>
-        )}
+        <NotificationLink link={link} onClick={handleClose} />
       </Alert>
     </Snackbar>
   )

--- a/src/components/common/Notifications/index.tsx
+++ b/src/components/common/Notifications/index.tsx
@@ -24,8 +24,8 @@ export const NotificationLink = ({
 
   return (
     <Track {...OVERVIEW_EVENTS.NOTIFICATION_INTERACTION} label={link.title}>
-      <NextLink onClick={onClick} href={link.href} passHref>
-        <Link className={css.link}>
+      <NextLink href={link.href} passHref>
+        <Link className={css.link} onClick={onClick}>
           {link.title} <ChevronRightIcon />
         </Link>
       </NextLink>
@@ -49,8 +49,10 @@ const Toast = ({
     onClose()
   }
 
+  const autoHideDuration = variant === 'info' || variant === 'success' ? 5000 : undefined
+
   return (
-    <Snackbar open onClose={handleClose} sx={toastStyle} autoHideDuration={5000}>
+    <Snackbar open onClose={handleClose} sx={toastStyle} autoHideDuration={autoHideDuration}>
       <Alert severity={variant} onClose={handleClose} elevation={3} sx={{ width: '340px' }}>
         {message}
         <NotificationLink link={link} onClick={handleClose} />

--- a/src/components/common/Notifications/index.tsx
+++ b/src/components/common/Notifications/index.tsx
@@ -29,7 +29,7 @@ const Toast = ({
   }
 
   return (
-    <Snackbar open onClose={handleClose} sx={toastStyle} autoHideDuration={variant === 'success' ? 5000 : null}>
+    <Snackbar open onClose={handleClose} sx={toastStyle} autoHideDuration={5000}>
       <Alert severity={variant} onClose={handleClose} elevation={3} sx={{ width: '340px' }}>
         {message}
         {link && (

--- a/src/components/common/Notifications/index.tsx
+++ b/src/components/common/Notifications/index.tsx
@@ -24,8 +24,8 @@ export const NotificationLink = ({
 
   return (
     <Track {...OVERVIEW_EVENTS.NOTIFICATION_INTERACTION} label={link.title}>
-      <NextLink onClick={onClick} href={link.pathname} passHref>
-        <Link className={css.link} sx={{ mt: 1 }}>
+      <NextLink onClick={onClick} href={link.href} passHref>
+        <Link className={css.link}>
           {link.title} <ChevronRightIcon />
         </Link>
       </NextLink>

--- a/src/components/common/Notifications/styles.module.css
+++ b/src/components/common/Notifications/styles.module.css
@@ -17,4 +17,5 @@
   font-weight: 700;
   display: flex;
   align-items: center;
+  margin-top: var(--space-1);
 }

--- a/src/components/common/Notifications/styles.module.css
+++ b/src/components/common/Notifications/styles.module.css
@@ -11,3 +11,10 @@
   justify-content: flex-end;
   word-break: break-word;
 }
+
+.link {
+  text-decoration: none;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+}

--- a/src/components/notification-center/NotificationCenterItem/index.tsx
+++ b/src/components/notification-center/NotificationCenterItem/index.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link'
 import ListItem from '@mui/material/ListItem'
 import ListItemAvatar from '@mui/material/ListItemAvatar'
 import ListItemText from '@mui/material/ListItemText'
@@ -6,7 +5,7 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined'
 import ErrorOutlineOutlinedIcon from '@mui/icons-material/ErrorOutlineOutlined'
 import TaskAltOutlinedIcon from '@mui/icons-material/TaskAltOutlined'
-import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import { NotificationLink } from '@/components/common/Notifications'
 import type { AlertColor } from '@mui/material/Alert'
 import type { ReactElement } from 'react'
 
@@ -16,8 +15,6 @@ import { formatTimeInWords } from '@/utils/date'
 
 import css from './styles.module.css'
 import classnames from 'classnames'
-import Track from '@/components/common/Track'
-import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
 
 const VARIANT_ICONS = {
   error: ErrorOutlineOutlinedIcon,
@@ -44,15 +41,7 @@ const NotificationCenterItem = ({
   const secondaryText = (
     <div className={css.secondaryText}>
       <span>{formatTimeInWords(timestamp)}</span>
-      {link && (
-        <Track {...OVERVIEW_EVENTS.NOTIFICATION_INTERACTION} label={link.title}>
-          <Link onClick={handleClose} href={link.href} passHref>
-            <a className={css.link}>
-              {link.title} <ChevronRightIcon />
-            </a>
-          </Link>
-        </Track>
-      )}
+      <NotificationLink link={link} onClick={handleClose} />
     </div>
   )
 

--- a/src/components/notification-center/NotificationCenterItem/styles.module.css
+++ b/src/components/notification-center/NotificationCenterItem/styles.module.css
@@ -27,10 +27,3 @@
   align-items: center;
   color: var(--color-border-main);
 }
-
-.link {
-  font-weight: 700;
-  color: var(--color-primary-main);
-  display: flex;
-  align-items: center;
-}

--- a/src/components/notification-center/NotificationCenterList/index.tsx
+++ b/src/components/notification-center/NotificationCenterList/index.tsx
@@ -28,7 +28,7 @@ const NotificationCenterList = ({ notifications, handleClose }: NotificationCent
     <Box className={css.scrollContainer}>
       <List sx={{ p: 0 }}>
         {notifications.map((notification) => (
-          <NotificationCenterItem key={notification.timestamp} {...notification} handleClose={handleClose} />
+          <NotificationCenterItem key={notification.id} {...notification} handleClose={handleClose} />
         ))}
       </List>
     </Box>

--- a/src/hooks/useSafeNotifications.ts
+++ b/src/hooks/useSafeNotifications.ts
@@ -4,33 +4,37 @@ import { ImplementationVersionState } from '@gnosis.pm/safe-react-gateway-sdk'
 import useSafeInfo from './useSafeInfo'
 import { useAppDispatch } from '@/store'
 import { AppRoutes } from '@/config/routes'
+import { useCurrentChain } from './useChains'
 
 /**
  * General-purpose notifications relating to the entire Safe
  */
 const useSafeNotifications = (): void => {
   const dispatch = useAppDispatch()
+  const chain = useCurrentChain()
   const { safe, safeAddress } = useSafeInfo()
   const { chainId, version, implementationVersionState } = safe
 
   // Show a notification when the Safe version is out of date
   useEffect(() => {
-    if (implementationVersionState === ImplementationVersionState.OUTDATED) {
-      const id = dispatch(
-        showNotification({
-          variant: 'warning',
-          message: `Your Safe version ${version} is out of date. Please update it.`,
-          groupKey: 'safe-outdated-version',
-          link: {
-            href: AppRoutes.safe.settings.setup,
-            title: 'Update Safe',
-          },
-        }),
-      )
+    if (implementationVersionState !== ImplementationVersionState.OUTDATED) {
+      return
+    }
 
-      return () => {
-        dispatch(closeNotification({ id }))
-      }
+    const id = dispatch(
+      showNotification({
+        variant: 'warning',
+        message: `Your Safe version ${version} is out of date. Please update it.`,
+        groupKey: 'safe-outdated-version',
+        link: {
+          pathname: `${AppRoutes.safe.settings.setup}?safe=${chain?.shortName}:${safeAddress}`,
+          title: 'Update Safe',
+        },
+      }),
+    )
+
+    return () => {
+      dispatch(closeNotification({ id }))
     }
   }, [dispatch, chainId, safeAddress, implementationVersionState, version])
 }

--- a/src/hooks/useSafeNotifications.ts
+++ b/src/hooks/useSafeNotifications.ts
@@ -27,7 +27,7 @@ const useSafeNotifications = (): void => {
         message: `Your Safe version ${version} is out of date. Please update it.`,
         groupKey: 'safe-outdated-version',
         link: {
-          pathname: `${AppRoutes.safe.settings.setup}?safe=${chain?.shortName}:${safeAddress}`,
+          href: `${AppRoutes.safe.settings.setup}?safe=${chain?.shortName}:${safeAddress}`,
           title: 'Update Safe',
         },
       }),
@@ -36,7 +36,7 @@ const useSafeNotifications = (): void => {
     return () => {
       dispatch(closeNotification({ id }))
     }
-  }, [dispatch, chainId, safeAddress, implementationVersionState, version])
+  }, [dispatch, chainId, safeAddress, implementationVersionState, version, chain?.shortName])
 }
 
 export default useSafeNotifications

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -4,6 +4,7 @@ import { useAppDispatch } from '@/store'
 import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
 import { AppRoutes } from '@/config/routes'
 import useSafeInfo from './useSafeInfo'
+import { useCurrentChain } from './useChains'
 
 const TxNotifications: Partial<Record<TxEvent, string>> = {
   [TxEvent.SIGN_FAILED]: 'Signature failed. Please try again.',
@@ -27,6 +28,7 @@ enum Variant {
 
 const useTxNotifications = (): void => {
   const dispatch = useAppDispatch()
+  const chain = useCurrentChain()
   const { safeAddress } = useSafeInfo()
 
   useEffect(() => {
@@ -40,7 +42,6 @@ const useTxNotifications = (): void => {
         const batchId = 'batchId' in detail ? detail.batchId : undefined
 
         const shouldShowLink = event !== TxEvent.EXECUTING && txId
-        const href = AppRoutes.safe.transactions.tx.replace('/safe/', `/${safeAddress}/`).replace(/$/, `?id=${txId}`)
 
         dispatch(
           showNotification({
@@ -49,7 +50,7 @@ const useTxNotifications = (): void => {
             variant: isError ? Variant.ERROR : isSuccess ? Variant.SUCCESS : Variant.INFO,
             ...(shouldShowLink && {
               link: {
-                href,
+                pathname: `${AppRoutes.safe.transactions.tx}?id=${txId}&safe=${chain?.shortName}:${safeAddress}`,
                 title: 'View transaction',
               },
             }),

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -3,7 +3,7 @@ import { showNotification } from '@/store/notificationsSlice'
 import { useAppDispatch } from '@/store'
 import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
 import { AppRoutes } from '@/config/routes'
-import useSafeAddress from './useSafeAddress'
+import useSafeInfo from './useSafeInfo'
 
 const TxNotifications: Partial<Record<TxEvent, string>> = {
   [TxEvent.SIGN_FAILED]: 'Signature failed. Please try again.',
@@ -27,7 +27,7 @@ enum Variant {
 
 const useTxNotifications = (): void => {
   const dispatch = useAppDispatch()
-  const safeAddress = useSafeAddress()
+  const { safeAddress } = useSafeInfo()
 
   useEffect(() => {
     const unsubFns = Object.entries(TxNotifications).map(([event, baseMessage]) =>

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -61,7 +61,7 @@ const useTxNotifications = (): void => {
     return () => {
       unsubFns.forEach((unsub) => unsub())
     }
-  }, [dispatch])
+  }, [dispatch, safeAddress])
 }
 
 export default useTxNotifications

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -50,7 +50,7 @@ const useTxNotifications = (): void => {
             variant: isError ? Variant.ERROR : isSuccess ? Variant.SUCCESS : Variant.INFO,
             ...(shouldShowLink && {
               link: {
-                pathname: `${AppRoutes.safe.transactions.tx}?id=${txId}&safe=${chain?.shortName}:${safeAddress}`,
+                href: `${AppRoutes.safe.transactions.tx}?id=${txId}&safe=${chain?.shortName}:${safeAddress}`,
                 title: 'View transaction',
               },
             }),
@@ -62,7 +62,7 @@ const useTxNotifications = (): void => {
     return () => {
       unsubFns.forEach((unsub) => unsub())
     }
-  }, [dispatch, safeAddress])
+  }, [dispatch, safeAddress, chain?.shortName])
 }
 
 export default useTxNotifications

--- a/src/store/notificationsSlice.ts
+++ b/src/store/notificationsSlice.ts
@@ -10,7 +10,7 @@ export type Notification = {
   timestamp: number
   isDismissed?: boolean
   isRead?: boolean
-  link?: { pathname: string; title: string }
+  link?: { href: string; title: string }
 }
 
 export type NotificationState = Notification[]

--- a/src/store/notificationsSlice.ts
+++ b/src/store/notificationsSlice.ts
@@ -10,7 +10,7 @@ export type Notification = {
   timestamp: number
   isDismissed?: boolean
   isRead?: boolean
-  link?: { href: string; title: string }
+  link?: { pathname: string; title: string }
 }
 
 export type NotificationState = Notification[]


### PR DESCRIPTION
## What it solves

Rendering of notification links.

## How this PR fixes it

The `link` in a notification is now rendered when one is present. A deeplink to transactions was also included.

## How to test it

- Access a Safe that requires an update and observe the link in the notification.
- Create and/or execute a proposed transaction and observe the link in the notification.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/185650229-9c68ebdb-b192-41fa-88f7-c2c15f19da7d.png)
![image](https://user-images.githubusercontent.com/20442784/185650251-f96066d9-a2b2-4781-8ecf-a81a6c4ed7c6.png)
![image](https://user-images.githubusercontent.com/20442784/185650265-4ebb335f-4fe7-4722-b0b4-2a46c4aa96df.png)
