### PR TITLE
fix: Use operation from core-sdk for multisend tx call

### DIFF
--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -71,7 +71,7 @@ export const createTx = async (txParams: SafeTransactionDataPartial, nonce?: num
 export const createMultiSendTx = async (txParams: MetaTransactionData[]): Promise<SafeTransaction> => {
   const safeSDK = getAndValidateSafeSDK()
   const tx = await safeSDK.createTransaction(txParams)
-  return createTx({ ...tx.data })
+  return createTx(tx.data)
 }
 
 const withRecommendedNonce = async (

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -71,7 +71,7 @@ export const createTx = async (txParams: SafeTransactionDataPartial, nonce?: num
 export const createMultiSendTx = async (txParams: MetaTransactionData[]): Promise<SafeTransaction> => {
   const safeSDK = getAndValidateSafeSDK()
   const tx = await safeSDK.createTransaction(txParams)
-  return createTx({ ...tx.data, operation: 1 })
+  return createTx({ ...tx.data })
 }
 
 const withRecommendedNonce = async (

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -69,9 +69,7 @@ export const createTx = async (txParams: SafeTransactionDataPartial, nonce?: num
  * If only one tx is passed it will be created without multiSend.
  */
 export const createMultiSendTx = async (txParams: MetaTransactionData[]): Promise<SafeTransaction> => {
-  const safeSDK = getAndValidateSafeSDK()
-  const tx = await safeSDK.createTransaction(txParams)
-  return createTx(tx.data)
+  return withRecommendedNonce((safeSDK) => safeSDK.createTransaction(txParams))
 }
 
 const withRecommendedNonce = async (


### PR DESCRIPTION
## What it solves

Small fix for Spending Limits (and potentially other places) when the multisend call only has 1 tx, the core-sdk already sets `operation: 0` so we should reuse that

## How to test

1. Create a new spending limit, it has more than 1 tx and is encoded as a multisend call
2. Change the same spending limit, owner and token need to be the same
3. Observe that there is no error message
4. Observe that the tx can be executed