### PR TITLE
fix: hide gas params if no tx + threshold when 1/1

### DIFF
--- a/src/components/settings/RequiredConfirmations/index.tsx
+++ b/src/components/settings/RequiredConfirmations/index.tsx
@@ -24,7 +24,7 @@ export const RequiredConfirmation = ({
           <Typography paddingTop={3}>
             <b>{threshold}</b> out of <b>{owners}</b> owners.
           </Typography>
-          {isGranted && <ChangeThresholdDialog />}
+          {isGranted && owners > 1 && <ChangeThresholdDialog />}
         </Grid>
       </Grid>
     </Box>

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -214,15 +214,17 @@ const SignOrExecuteForm = ({
           />
         )}
 
-        <GasParams
-          isExecution={willExecute}
-          isLoading={isEstimating}
-          nonce={advancedParams.nonce}
-          gasLimit={advancedParams.gasLimit}
-          maxFeePerGas={advancedParams.maxFeePerGas}
-          maxPriorityFeePerGas={advancedParams.maxPriorityFeePerGas}
-          onEdit={() => setEditingGas(true)}
-        />
+        {tx && (
+          <GasParams
+            isExecution={willExecute}
+            isLoading={isEstimating}
+            nonce={advancedParams.nonce}
+            gasLimit={advancedParams.gasLimit}
+            maxFeePerGas={advancedParams.maxFeePerGas}
+            maxPriorityFeePerGas={advancedParams.maxPriorityFeePerGas}
+            onEdit={() => setEditingGas(true)}
+          />
+        )}
 
         {(error || (willExecute && gasLimitError)) && (
           <ErrorMessage error={error || gasLimitError}>


### PR DESCRIPTION
## What it solves

Nonce not displaying when changing nonce.

## How this PR fixes it

1. When no `tx` exists in `<SignOrExecuteForm>`, `<GasParams>` is hidden. `<ChangeThresholdDialog>` does not create a transaction unless a new threshold is selected:

![image](https://user-images.githubusercontent.com/20442784/185898932-ebc8cbce-6463-430e-9084-c6ad60092ee5.png)

2. On top of this, the "Change" button to alter a Safe threshold is hidden on 1/1 Safes.

## How to test it

1. Open a 1/2 Safe and attempt to change the threshold. Observe no gas parameters in the dialog, as well as the submit button being disabled until choosing a new threshold.
2. Open a 1/1 Safe and observe no threshold "Change" button in the settings.

## Screenshots
1. 
![threshold dialog](https://user-images.githubusercontent.com/20442784/185899393-ea9eb765-6547-4b11-bd2d-30a99c9e1e38.gif)

2.
![image](https://user-images.githubusercontent.com/20442784/185899328-a13bc99d-6df6-45c4-a3fd-cfdde1fe5913.png)

