### PR TITLE
Feat: display/edit safeTxGas when not 0

### DIFF
--- a/src/components/common/Notifications/styles.module.css
+++ b/src/components/common/Notifications/styles.module.css
@@ -17,5 +17,5 @@
   font-weight: 700;
   display: flex;
   align-items: center;
-  margin-top: var(--space-1);
+  margin-top: 0.3em;
 }

--- a/src/components/tx/ErrorMessage/index.tsx
+++ b/src/components/tx/ErrorMessage/index.tsx
@@ -23,7 +23,15 @@ const ErrorMessage = ({
         <WarningAmberIcon fontSize="small" />
 
         <div>
-          <Typography variant="body2">{children}</Typography>
+          <Typography variant="body2" component="span">
+            {children}
+          </Typography>
+
+          {error && (
+            <Link component="button" onClick={onDetailsToggle}>
+              Details
+            </Link>
+          )}
 
           {error && showDetails && (
             <Typography variant="body2" className={css.details}>
@@ -31,12 +39,6 @@ const ErrorMessage = ({
             </Typography>
           )}
         </div>
-
-        {error && (
-          <Link component="button" onClick={onDetailsToggle}>
-            Details
-          </Link>
-        )}
       </div>
     </div>
   )

--- a/src/components/tx/ErrorMessage/styles.module.css
+++ b/src/components/tx/ErrorMessage/styles.module.css
@@ -3,6 +3,7 @@
   color: var(--color-error-dark);
   padding: var(--space-2);
   margin: var(--space-2) 0;
+  border-radius: 4px;
 }
 
 .message {
@@ -11,8 +12,12 @@
   gap: var(--space-1);
 }
 
-.message * {
-  line-height: 1.4;
+.message button {
+  margin-left: var(--space-1);
+}
+
+.message svg {
+  margin-top: 4px;
 }
 
 .details {

--- a/src/components/tx/ExecuteCheckbox/index.tsx
+++ b/src/components/tx/ExecuteCheckbox/index.tsx
@@ -1,0 +1,27 @@
+import type { ChangeEvent, ReactElement } from 'react'
+import { Checkbox, FormControlLabel } from '@mui/material'
+import { trackEvent } from '@/services/analytics/analytics'
+import { MODALS_EVENTS } from '@/services/analytics/events/modals'
+
+const ExecuteToggle = ({
+  checked,
+  onChange,
+}: {
+  checked: boolean
+  onChange: (checked: boolean) => void
+}): ReactElement => {
+  const handleChange = (_: ChangeEvent<HTMLInputElement>, checked: boolean) => {
+    trackEvent({ ...MODALS_EVENTS.EXECUTE_TX, label: checked })
+    onChange(checked)
+  }
+
+  return (
+    <FormControlLabel
+      control={<Checkbox checked={checked} onChange={handleChange} />}
+      label="Execute transaction"
+      sx={{ mb: 1 }}
+    />
+  )
+}
+
+export default ExecuteToggle

--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -29,6 +29,7 @@ const GasParams = ({
   gasLimit,
   maxFeePerGas,
   maxPriorityFeePerGas,
+  safeTxGas,
   isLoading,
   isExecution,
   onEdit,
@@ -83,6 +84,8 @@ const GasParams = ({
 
       <AccordionDetails>
         <GasDetail isLoading={nonce === undefined} name="Nonce" value={(nonce ?? '').toString()} />
+
+        {!!safeTxGas && <GasDetail isLoading={false} name="safeTxGas" value={safeTxGas.toString()} />}
 
         {isExecution && (
           <>

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -1,7 +1,8 @@
-import { ChangeEvent, ReactElement, ReactNode, SyntheticEvent, useEffect, useState } from 'react'
+import { type ReactElement, type ReactNode, type SyntheticEvent, useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import type { SafeTransaction, TransactionOptions } from '@gnosis.pm/safe-core-sdk-types'
-import { Button, Checkbox, DialogContent, FormControlLabel } from '@mui/material'
+import { Button, DialogContent } from '@mui/material'
+import { FEATURES } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import { dispatchTxExecution, dispatchTxProposal, dispatchTxSigning, createTx } from '@/services/tx/txSender'
 import useWallet from '@/hooks/wallets/useWallet'
@@ -13,14 +14,12 @@ import ErrorMessage from '@/components/tx/ErrorMessage'
 import AdvancedParamsForm, { AdvancedParameters } from '@/components/tx/AdvancedParamsForm'
 import { isHardwareWallet } from '@/hooks/wallets/wallets'
 import DecodedTx from '../DecodedTx'
+import ExecuteCheckbox from '../ExecuteCheckbox'
 import { logError, Errors } from '@/services/exceptions'
 import { AppRoutes } from '@/config/routes'
 import { type ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { useCurrentChain } from '@/hooks/useChains'
 import { hasFeature } from '@/utils/chains'
-import { FEATURES } from '@gnosis.pm/safe-react-gateway-sdk'
-import { trackEvent } from '@/services/analytics/analytics'
-import { MODALS_EVENTS } from '@/services/analytics/events/modals'
 
 type SignOrExecuteProps = {
   safeTx?: SafeTransaction
@@ -78,6 +77,7 @@ const SignOrExecuteForm = ({
     gasLimit: manualParams?.gasLimit || gasLimit,
     maxFeePerGas: manualParams?.maxFeePerGas || maxFeePerGas,
     maxPriorityFeePerGas: manualParams?.maxPriorityFeePerGas || maxPriorityFeePerGas,
+    safeTxGas: manualParams?.safeTxGas || tx?.data.safeTxGas,
   }
 
   // Estimating gas limit and price
@@ -165,9 +165,9 @@ const SignOrExecuteForm = ({
 
   const onAdvancedSubmit = async (data: AdvancedParameters) => {
     // If nonce was edited, create a new with that nonce
-    if (tx && data.nonce !== tx.data.nonce) {
+    if (tx && (data.nonce !== tx.data.nonce || data.safeTxGas !== tx.data.safeTxGas)) {
       try {
-        setTx(await createTx(tx.data, data.nonce))
+        setTx(await createTx({ ...tx.data, safeTxGas: data.safeTxGas }, data.nonce))
       } catch (err) {
         logError(Errors._103, (err as Error).message)
         return
@@ -179,12 +179,6 @@ const SignOrExecuteForm = ({
     setManualParams(data)
   }
 
-  const onExecuteTxCheckbox = (_: ChangeEvent<HTMLInputElement>, checked: boolean) => {
-    trackEvent({ ...MODALS_EVENTS.EXECUTE_TX, label: checked })
-
-    setShouldExecute(checked)
-  }
-
   const submitDisabled = !isSubmittable || isEstimating || !tx
 
   return isEditingGas ? (
@@ -193,6 +187,7 @@ const SignOrExecuteForm = ({
       gasLimit={advancedParams.gasLimit}
       maxFeePerGas={advancedParams.maxFeePerGas}
       maxPriorityFeePerGas={advancedParams.maxPriorityFeePerGas}
+      safeTxGas={advancedParams.safeTxGas}
       isExecution={willExecute}
       recommendedNonce={safeTx?.data.nonce}
       estimatedGasLimit={gasLimit?.toString()}
@@ -206,13 +201,7 @@ const SignOrExecuteForm = ({
 
         {tx && <DecodedTx tx={tx} txId={txId} />}
 
-        {canExecute && !onlyExecute && (
-          <FormControlLabel
-            control={<Checkbox checked={shouldExecute} onChange={onExecuteTxCheckbox} />}
-            label="Execute transaction"
-            sx={{ mb: 1 }}
-          />
-        )}
+        {canExecute && !onlyExecute && <ExecuteCheckbox checked={shouldExecute} onChange={setShouldExecute} />}
 
         <GasParams
           isExecution={willExecute}
@@ -221,6 +210,7 @@ const SignOrExecuteForm = ({
           gasLimit={advancedParams.gasLimit}
           maxFeePerGas={advancedParams.maxFeePerGas}
           maxPriorityFeePerGas={advancedParams.maxPriorityFeePerGas}
+          safeTxGas={tx?.data.safeTxGas}
           onEdit={() => setEditingGas(true)}
         />
 


### PR DESCRIPTION
## What it solves
If safeTxGas isn't zero, it will display it in the advanced params + in the form.

Safe Core SDK takes care of setting it to 0 for 1.3.0 safes.

<img width="578" alt="Screenshot 2022-08-22 at 12 55 56" src="https://user-images.githubusercontent.com/381895/185905222-f97935a1-211b-460c-9703-4d79a1ef76e3.png">

<img width="581" alt="Screenshot 2022-08-22 at 12 56 03" src="https://user-images.githubusercontent.com/381895/185905239-56c033b9-9b39-4d6b-b4eb-a1d425a3854a.png">
