### PR TITLE
fix: threshold change/delegate call warning styles

### DIFF
--- a/src/components/transactions/Warning/index.tsx
+++ b/src/components/transactions/Warning/index.tsx
@@ -9,7 +9,7 @@ const UNEXPECTED_DELEGATE_ARTICLE =
   'https://help.gnosis-safe.io/en/articles/6302452-why-do-i-see-an-unexpected-delegate-call-warning-in-my-transaction'
 
 export const DelegateCallWarning = ({ showWarning }: { showWarning: boolean }): ReactElement => {
-  const severity = !showWarning ? 'warning' : 'success'
+  const severity = showWarning ? 'warning' : 'success'
   return (
     <CustomTooltip
       sx={{
@@ -39,7 +39,7 @@ export const DelegateCallWarning = ({ showWarning }: { showWarning: boolean }): 
         severity={severity}
         icon={<InfoOutlinedIcon />}
       >
-        <b>{!showWarning ? 'Unexpected Delegate Call' : 'Delegate Call'}</b>
+        <b>{showWarning ? 'Unexpected Delegate Call' : 'Delegate Call'}</b>
       </Alert>
     </CustomTooltip>
   )

--- a/src/components/transactions/Warning/index.tsx
+++ b/src/components/transactions/Warning/index.tsx
@@ -1,54 +1,49 @@
 import { ReactElement } from 'react'
 import { Alert, Link } from '@mui/material'
 import { tooltipClasses } from '@mui/material/Tooltip'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import css from './styles.module.css'
 import CustomTooltip from '@/components/common/CustomTooltip'
 
 const UNEXPECTED_DELEGATE_ARTICLE =
   'https://help.gnosis-safe.io/en/articles/6302452-why-do-i-see-an-unexpected-delegate-call-warning-in-my-transaction'
 
-export const DelegateCallWarning = ({ showWarning }: { showWarning: boolean }): ReactElement => (
-  <CustomTooltip
-    sx={{
-      [`& .${tooltipClasses.arrow}`]: {
-        left: '-46px !important', // place the arrow over the Alert icon
-      },
-    }}
-    title={
-      <>
-        This transaction calls a smart contract that will be able to modify your Safe.
-        {showWarning && (
-          <>
-            <br />
-            <Link href={UNEXPECTED_DELEGATE_ARTICLE} rel="noopener noreferrer" target="_blank">
-              Learn more
-            </Link>
-          </>
-        )}
-      </>
-    }
-    placement="top-start"
-    arrow
-  >
-    <Alert
-      className={css.alert}
-      sx={({ palette }) => ({
-        color: showWarning ? palette.warning.dark : palette.success.main,
-        backgroundColor: `${showWarning ? palette.warning.light : palette.success.background}`,
-        border: 0,
-        borderLeft: `3px solid ${showWarning ? palette.warning.dark : palette.success.main}`,
-
-        '&.MuiAlert-standardInfo .MuiAlert-icon': {
-          marginRight: '8px',
-          color: `${showWarning ? palette.warning.dark : palette.success.main}`,
+export const DelegateCallWarning = ({ showWarning }: { showWarning: boolean }): ReactElement => {
+  const severity = !showWarning ? 'warning' : 'success'
+  return (
+    <CustomTooltip
+      sx={{
+        [`& .${tooltipClasses.arrow}`]: {
+          left: '-46px !important', // place the arrow over the Alert icon
         },
-      })}
-      severity="info"
+      }}
+      title={
+        <>
+          This transaction calls a smart contract that will be able to modify your Safe.
+          {showWarning && (
+            <>
+              <br />
+              <Link href={UNEXPECTED_DELEGATE_ARTICLE} rel="noopener noreferrer" target="_blank">
+                Learn more
+              </Link>
+            </>
+          )}
+        </>
+      }
+      placement="top-start"
+      arrow
     >
-      <b>{showWarning ? 'Unexpected Delegate Call' : 'Delegate Call'}</b>
-    </Alert>
-  </CustomTooltip>
-)
+      <Alert
+        className={css.alert}
+        sx={{ borderLeft: ({ palette }) => `3px solid ${palette[severity].main}` }}
+        severity={severity}
+        icon={<InfoOutlinedIcon />}
+      >
+        <b>{!showWarning ? 'Unexpected Delegate Call' : 'Delegate Call'}</b>
+      </Alert>
+    </CustomTooltip>
+  )
+}
 
 export const ThresholdWarning = (): ReactElement => (
   <CustomTooltip
@@ -63,17 +58,9 @@ export const ThresholdWarning = (): ReactElement => (
   >
     <Alert
       className={css.alert}
-      sx={({ palette }) => ({
-        color: palette.secondary.main,
-        background: palette.warning.light,
-        borderLeft: `3px solid ${palette.warning.dark}`,
-
-        '&.MuiAlert-standardInfo .MuiAlert-icon': {
-          marginRight: '8px',
-          color: palette.warning.dark,
-        },
-      })}
-      severity="info"
+      sx={{ borderLeft: ({ palette }) => `3px solid ${palette.warning.main}` }}
+      severity="warning"
+      icon={<InfoOutlinedIcon />}
     >
       <b>Confirmation policy change</b>
     </Alert>

--- a/src/components/transactions/Warning/index.tsx
+++ b/src/components/transactions/Warning/index.tsx
@@ -39,7 +39,7 @@ export const DelegateCallWarning = ({ showWarning }: { showWarning: boolean }): 
         severity={severity}
         icon={<InfoOutlinedIcon />}
       >
-        <b>{showWarning ? 'Unexpected Delegate Call' : 'Delegate Call'}</b>
+        <b>{showWarning ? 'Unexpected delegate call' : 'Delegate call'}</b>
       </Alert>
     </CustomTooltip>
   )


### PR DESCRIPTION
## What it solves

Styling of threshold changes/(unexpected) delegate call warnings.

## How this PR fixes it

`<Alert>`s are now styled in a similar fashion to notifications:

![image](https://user-images.githubusercontent.com/20442784/185912831-7431b827-94b5-43fd-aed5-a624faee11bd.png)

## How to test it

- Observe the correctly styled threshold warning here
`rin:0x501E66bF7a8F742FA40509588eE751e93fA354Df/transactions/tx?id=multisig_0x501E66bF7a8F742FA40509588eE751e93fA354Df_0xb8badb9506ca147386d9980fb4ba78a04fa61298ee3a13c368ec5f685b3c87e8` in light/dark mode.
- Observe the correctly styled unexpected threshold warning here
`rin:0x73a7AA145338587f7aB7f63c06d187C85dF4727e/transactions/tx?id=multisig_0x73a7AA145338587f7aB7f63c06d187C85dF4727e_0xba28109747222d6cfb7f0fb75f03d49957e343674bc116162b038e244dbcc6d6`.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/185912792-e1a1e157-fa91-47a6-9b8b-3e5cec9387af.png)
![image](https://user-images.githubusercontent.com/20442784/185912812-952c08f4-7ee0-4805-9918-5aabd2901bbd.png)

![image](https://user-images.githubusercontent.com/20442784/185912821-81060787-8dab-4854-94de-5d7f42a867a4.png)
![image](https://user-images.githubusercontent.com/20442784/185912886-d0a28720-c990-4e0a-982e-fb685938d781.png)

![image](https://user-images.githubusercontent.com/20442784/185912908-c1720bc7-acea-449b-a6dd-345c67afb64a.png)
![image](https://user-images.githubusercontent.com/20442784/185912919-833f378f-5555-4d1a-9bd7-7526efa62603.png)