### PR TITLE
Fix: token icon in spending limits; decapitalize labels

### DIFF
--- a/src/components/create-safe/index.tsx
+++ b/src/components/create-safe/index.tsx
@@ -28,7 +28,7 @@ export const CreateSafeSteps: TxStepperProps['steps'] = [
     ),
   },
   {
-    label: 'Owners and Confirmations',
+    label: 'Owners and confirmations',
     render: (data, onSubmit, onBack, setStep) => (
       <OwnerPolicyStep params={data as SafeFormData} onSubmit={onSubmit} onBack={onBack} setStep={setStep} />
     ),

--- a/src/components/settings/SafeModules/RemoveModule/index.tsx
+++ b/src/components/settings/SafeModules/RemoveModule/index.tsx
@@ -11,7 +11,7 @@ export type RemoveModuleData = {
 
 const RemoveModuleSteps: TxStepperProps['steps'] = [
   {
-    label: 'Remove Module',
+    label: 'Remove module',
     render: (data, onSubmit) => <ReviewRemoveModule data={data as RemoveModuleData} onSubmit={onSubmit} />,
   },
 ]

--- a/src/components/settings/SpendingLimits/NoSpendingLimits.tsx
+++ b/src/components/settings/SpendingLimits/NoSpendingLimits.tsx
@@ -20,6 +20,7 @@ export const NoSpendingLimits = () => {
           </Typography>
         </Box>
       </Grid>
+
       <Grid item sm={12} md={3}>
         <Box>
           <img
@@ -34,6 +35,7 @@ export const NoSpendingLimits = () => {
           <Typography>You can set allowances for any asset stored in your Safe</Typography>
         </Box>
       </Grid>
+
       <Grid item sm={12} md={3}>
         <Box>
           <img alt="Select time" title="Time" height={75} src="/images/settings/spending-limit/time.svg" />

--- a/src/components/settings/SpendingLimits/SpendingLimitsTable.tsx
+++ b/src/components/settings/SpendingLimits/SpendingLimitsTable.tsx
@@ -14,11 +14,12 @@ import { RemoveSpendingLimit } from '@/components/settings/SpendingLimits/Remove
 import useIsGranted from '@/hooks/useIsGranted'
 import Track from '@/components/common/Track'
 import { SETTINGS_EVENTS } from '@/services/analytics/events/settings'
+import { TokenIcon } from '@/components/common/TokenAmount'
 
 const headCells = [
   { id: 'beneficiary', label: 'Beneficiary' },
   { id: 'spent', label: 'Spent' },
-  { id: 'resetTime', label: 'Reset Time' },
+  { id: 'resetTime', label: 'Reset time' },
   { id: 'actions', label: 'Actions' },
 ]
 
@@ -58,7 +59,7 @@ export const SpendingLimitsTable = ({ spendingLimits }: { spendingLimits: Spendi
             rawValue: spendingLimit.spent,
             content: (
               <Box display="flex" alignItems="center" gap={1}>
-                <img src={token?.tokenInfo.logoUri} alt={token?.tokenInfo.name} width={24} height={24} />
+                <TokenIcon logoUri={token?.tokenInfo.logoUri} tokenSymbol={token?.tokenInfo.symbol} />
                 {`${spendingLimit.spent} of ${formattedAmount} ${token?.tokenInfo.symbol}`}
               </Box>
             ),

--- a/src/components/settings/SpendingLimits/index.tsx
+++ b/src/components/settings/SpendingLimits/index.tsx
@@ -20,7 +20,7 @@ const SpendingLimits = () => {
       <Grid container direction="row" justifyContent="space-between" spacing={3} mb={2}>
         <Grid item lg={4} xs={12}>
           <Typography variant="h4" fontWeight={700}>
-            Spending limit
+            Spending limits
           </Typography>
         </Grid>
 

--- a/src/components/settings/owner/RemoveOwnerDialog/index.tsx
+++ b/src/components/settings/owner/RemoveOwnerDialog/index.tsx
@@ -22,11 +22,11 @@ const RemoveOwnerSteps: TxStepperProps['steps'] = [
     render: (data, onSubmit) => <ReviewSelectedOwnerStep data={data as RemoveOwnerData} onSubmit={onSubmit} />,
   },
   {
-    label: 'Set Threshold',
+    label: 'Set threshold',
     render: (data, onSubmit) => <SetThresholdStep data={data as RemoveOwnerData} onSubmit={onSubmit} />,
   },
   {
-    label: 'Review Transaction',
+    label: 'Review transaction',
     render: (data, onSubmit) => <ReviewRemoveOwnerTxStep data={data as RemoveOwnerData} onSubmit={onSubmit} />,
   },
 ]

--- a/src/components/sidebar/SidebarNavigation/config.tsx
+++ b/src/components/sidebar/SidebarNavigation/config.tsx
@@ -58,7 +58,7 @@ export const navItems: NavItem[] = [
         href: AppRoutes.safe.settings.modules,
       },
       {
-        label: 'Spending Limits',
+        label: 'Spending limits',
         href: AppRoutes.safe.settings.spendingLimits,
       },
     ],


### PR DESCRIPTION
## What it solves
Spending limit token icons didn't have a fallback, fixed by using `<TokenIcon>`.

Also removed capital initial letters in titles.