### PR TITLE
feat: Add Spending limit tx type selection when sending funds

### DIFF
--- a/src/components/tx/SpendingLimitRow/index.tsx
+++ b/src/components/tx/SpendingLimitRow/index.tsx
@@ -3,7 +3,7 @@ import { Controller, useFormContext } from 'react-hook-form'
 import { formatUnits } from '@ethersproject/units'
 import { TokenInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { SpendingLimitState } from '@/store/spendingLimitsSlice'
-import { SendTxType } from '@/components/tx/modals/TokenTransferModal/SendAssetsForm'
+import { SendAssetsField, SendTxType } from '@/components/tx/modals/TokenTransferModal/SendAssetsForm'
 
 const SpendingLimitRow = ({
   spendingLimit,
@@ -23,9 +23,9 @@ const SpendingLimitRow = ({
         <Controller
           rules={{ required: true }}
           control={control}
-          name="type"
+          name={SendAssetsField.type}
           render={({ field }) => (
-            <RadioGroup {...field} defaultValue={SendTxType.multiSig} name="type-button-group">
+            <RadioGroup {...field} defaultValue={SendTxType.multiSig}>
               <FormControlLabel
                 value={SendTxType.multiSig}
                 label="Multisig Transaction"

--- a/src/components/tx/SpendingLimitRow/index.tsx
+++ b/src/components/tx/SpendingLimitRow/index.tsx
@@ -3,6 +3,7 @@ import { Controller, useFormContext } from 'react-hook-form'
 import { formatUnits } from '@ethersproject/units'
 import { TokenInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { SpendingLimitState } from '@/store/spendingLimitsSlice'
+import { SendTxType } from '@/components/tx/modals/TokenTransferModal/SendAssetsForm'
 
 const SpendingLimitRow = ({
   spendingLimit,
@@ -24,15 +25,15 @@ const SpendingLimitRow = ({
           control={control}
           name="type"
           render={({ field }) => (
-            <RadioGroup {...field} defaultValue="multiSig" name="type-button-group">
+            <RadioGroup {...field} defaultValue={SendTxType.multiSig} name="type-button-group">
               <FormControlLabel
-                value="multiSig"
+                value={SendTxType.multiSig}
                 label="Multisig Transaction"
                 control={<Radio />}
                 componentsProps={{ typography: { variant: 'body2' } }}
               />
               <FormControlLabel
-                value="spendingLimit"
+                value={SendTxType.spendingLimit}
                 label={`Spending Limit Transaction (${formattedAmount} ${selectedToken?.symbol})`}
                 control={<Radio />}
                 componentsProps={{ typography: { variant: 'body2' } }}

--- a/src/components/tx/SpendingLimitRow/index.tsx
+++ b/src/components/tx/SpendingLimitRow/index.tsx
@@ -1,14 +1,17 @@
 import { FormControl, FormControlLabel, Radio, RadioGroup, Typography } from '@mui/material'
 import { Controller, useFormContext } from 'react-hook-form'
 import { formatUnits } from '@ethersproject/units'
-import useSpendingLimit from '@/hooks/useSpendingLimit'
 import { TokenInfo } from '@gnosis.pm/safe-react-gateway-sdk'
+import { SpendingLimitState } from '@/store/spendingLimitsSlice'
 
-const SpendingLimitRow = ({ selectedToken }: { selectedToken: TokenInfo | undefined }) => {
-  const spendingLimit = useSpendingLimit(selectedToken)
+const SpendingLimitRow = ({
+  spendingLimit,
+  selectedToken,
+}: {
+  spendingLimit: SpendingLimitState
+  selectedToken: TokenInfo | undefined
+}) => {
   const { control } = useFormContext()
-
-  if (!spendingLimit) return null
 
   const formattedAmount = formatUnits(spendingLimit.amount, selectedToken?.decimals)
 

--- a/src/components/tx/SpendingLimitRow/index.tsx
+++ b/src/components/tx/SpendingLimitRow/index.tsx
@@ -1,0 +1,45 @@
+import { FormControl, FormControlLabel, Radio, RadioGroup, Typography } from '@mui/material'
+import { Controller, useFormContext } from 'react-hook-form'
+import { formatUnits } from '@ethersproject/units'
+import useSpendingLimit from '@/hooks/useSpendingLimit'
+import { TokenInfo } from '@gnosis.pm/safe-react-gateway-sdk'
+
+const SpendingLimitRow = ({ selectedToken }: { selectedToken: TokenInfo | undefined }) => {
+  const spendingLimit = useSpendingLimit(selectedToken)
+  const { control } = useFormContext()
+
+  if (!spendingLimit) return null
+
+  const formattedAmount = formatUnits(spendingLimit.amount, selectedToken?.decimals)
+
+  return (
+    <>
+      <Typography>Send as</Typography>
+      <FormControl sx={{ mb: 2 }}>
+        <Controller
+          rules={{ required: true }}
+          control={control}
+          name="type"
+          render={({ field }) => (
+            <RadioGroup {...field} defaultValue="multiSig" name="type-button-group">
+              <FormControlLabel
+                value="multiSig"
+                label="Multisig Transaction"
+                control={<Radio />}
+                componentsProps={{ typography: { variant: 'body2' } }}
+              />
+              <FormControlLabel
+                value="spendingLimit"
+                label={`Spending Limit Transaction (${formattedAmount} ${selectedToken?.symbol})`}
+                control={<Radio />}
+                componentsProps={{ typography: { variant: 'body2' } }}
+              />
+            </RadioGroup>
+          )}
+        />
+      </FormControl>
+    </>
+  )
+}
+
+export default SpendingLimitRow

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -42,7 +42,7 @@ export enum SendTxType {
   spendingLimit = 'spendingLimit',
 }
 
-enum Field {
+export enum SendAssetsField {
   recipient = 'recipient',
   tokenAddress = 'tokenAddress',
   amount = 'amount',
@@ -50,10 +50,10 @@ enum Field {
 }
 
 export type SendAssetsFormData = {
-  [Field.recipient]: string
-  [Field.tokenAddress]: string
-  [Field.amount]: string
-  [Field.type]: SendTxType
+  [SendAssetsField.recipient]: string
+  [SendAssetsField.tokenAddress]: string
+  [SendAssetsField.amount]: string
+  [SendAssetsField.type]: SendTxType
 }
 
 type SendAssetsFormProps = {
@@ -65,7 +65,7 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
   const { balances } = useBalances()
 
   const formMethods = useForm<SendAssetsFormData>({
-    defaultValues: { ...formData, [Field.type]: SendTxType.multiSig },
+    defaultValues: { ...formData, [SendAssetsField.type]: SendTxType.multiSig },
   })
   const {
     register,
@@ -76,12 +76,12 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
   } = formMethods
 
   // Selected token
-  const tokenAddress = watch(Field.tokenAddress)
+  const tokenAddress = watch(SendAssetsField.tokenAddress)
   const selectedToken = tokenAddress
     ? balances.items.find((item) => item.tokenInfo.address === tokenAddress)
     : undefined
 
-  const type = watch(Field.type)
+  const type = watch(SendAssetsField.type)
   const spendingLimit = useSpendingLimit(selectedToken?.tokenInfo)
   const isSpendingLimitType = type === SendTxType.spendingLimit
 
@@ -89,7 +89,7 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
     if (!selectedToken) return
 
     const amount = spendingLimit && isSpendingLimitType ? spendingLimit.amount : selectedToken.balance
-    setValue(Field.amount, formatDecimals(amount, selectedToken.tokenInfo.decimals))
+    setValue(SendAssetsField.amount, formatDecimals(amount, selectedToken.tokenInfo.decimals))
   }
 
   return (
@@ -99,7 +99,7 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
           <SendFromBlock />
 
           <FormControl fullWidth sx={{ mb: 2 }}>
-            <AddressBookInput name={Field.recipient} label="Recipient" />
+            <AddressBookInput name={SendAssetsField.recipient} label="Recipient" />
           </FormControl>
 
           <FormControl fullWidth sx={{ mb: 2 }}>
@@ -109,9 +109,9 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
               label={errors.tokenAddress?.message || 'Select an asset'}
               defaultValue={formData?.tokenAddress || ''}
               error={!!errors.tokenAddress}
-              {...register(Field.tokenAddress, {
+              {...register(SendAssetsField.tokenAddress, {
                 required: true,
-                onChange: () => setValue(Field.amount, ''),
+                onChange: () => setValue(SendAssetsField.amount, ''),
               })}
             >
               {balances.items.map((item) => (
@@ -140,9 +140,9 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
               }}
               // @see https://github.com/react-hook-form/react-hook-form/issues/220
               InputLabelProps={{
-                shrink: !!watch(Field.amount),
+                shrink: !!watch(SendAssetsField.amount),
               }}
-              {...register(Field.amount, {
+              {...register(SendAssetsField.amount, {
                 required: true,
                 validate: (val) =>
                   isSpendingLimitType

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -37,7 +37,10 @@ export const AutocompleteItem = (item: { tokenInfo: TokenInfo; balance: string }
   </Grid>
 )
 
-type SendTxType = 'multiSig' | 'spendingLimit'
+export enum SendTxType {
+  multiSig = 'multiSig',
+  spendingLimit = 'spendingLimit',
+}
 
 enum Field {
   recipient = 'recipient',
@@ -62,7 +65,7 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
   const { balances } = useBalances()
 
   const formMethods = useForm<SendAssetsFormData>({
-    defaultValues: { ...formData, [Field.type]: 'multiSig' },
+    defaultValues: { ...formData, [Field.type]: SendTxType.multiSig },
   })
   const {
     register,
@@ -80,7 +83,7 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
 
   const type = watch(Field.type)
   const spendingLimit = useSpendingLimit(selectedToken?.tokenInfo)
-  const isSpendingLimitType = type === 'spendingLimit'
+  const isSpendingLimitType = type === SendTxType.spendingLimit
 
   const onMaxAmountClick = () => {
     if (!selectedToken) return

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -20,6 +20,7 @@ import useBalances from '@/hooks/useBalances'
 import AddressBookInput from '@/components/common/AddressBookInput'
 import InputValueHelper from '@/components/common/InputValueHelper'
 import SendFromBlock from '../../SendFromBlock'
+import SpendingLimitRow from '@/components/tx/SpendingLimitRow'
 
 export const AutocompleteItem = (item: { tokenInfo: TokenInfo; balance: string }): ReactElement => (
   <Grid container alignItems="center" gap={1}>
@@ -35,16 +36,20 @@ export const AutocompleteItem = (item: { tokenInfo: TokenInfo; balance: string }
   </Grid>
 )
 
+type SendTxType = 'multiSig' | 'spendingLimit'
+
 enum Field {
   recipient = 'recipient',
   tokenAddress = 'tokenAddress',
   amount = 'amount',
+  type = 'type',
 }
 
 export type SendAssetsFormData = {
   [Field.recipient]: string
   [Field.tokenAddress]: string
   [Field.amount]: string
+  [Field.type]: SendTxType
 }
 
 type SendAssetsFormProps = {
@@ -56,7 +61,7 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
   const { balances } = useBalances()
 
   const formMethods = useForm<SendAssetsFormData>({
-    defaultValues: formData,
+    defaultValues: { ...formData, [Field.type]: 'multiSig' },
   })
   const {
     register,
@@ -106,6 +111,8 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
               ))}
             </Select>
           </FormControl>
+
+          <SpendingLimitRow selectedToken={selectedToken?.tokenInfo} />
 
           <FormControl fullWidth>
             <TextField

--- a/src/hooks/useSpendingLimit.ts
+++ b/src/hooks/useSpendingLimit.ts
@@ -1,0 +1,17 @@
+import { useSelector } from 'react-redux'
+import { TokenInfo } from '@gnosis.pm/safe-react-gateway-sdk'
+import useWallet from '@/hooks/wallets/useWallet'
+import { selectSpendingLimits, SpendingLimitState } from '@/store/spendingLimitsSlice'
+import { sameAddress } from '@/utils/addresses'
+
+const useSpendingLimit = (selectedToken?: TokenInfo): SpendingLimitState | undefined => {
+  const wallet = useWallet()
+  const spendingLimits = useSelector(selectSpendingLimits)
+  const userSpendingLimits = spendingLimits?.filter((spendingLimit) =>
+    sameAddress(spendingLimit.beneficiary, wallet?.address),
+  )
+
+  return userSpendingLimits.find((spendingLimit) => sameAddress(spendingLimit.token, selectedToken?.address))
+}
+
+export default useSpendingLimit

--- a/src/hooks/useSpendingLimit.ts
+++ b/src/hooks/useSpendingLimit.ts
@@ -7,11 +7,12 @@ import { sameAddress } from '@/utils/addresses'
 const useSpendingLimit = (selectedToken?: TokenInfo): SpendingLimitState | undefined => {
   const wallet = useWallet()
   const spendingLimits = useSelector(selectSpendingLimits)
-  const userSpendingLimits = spendingLimits?.filter((spendingLimit) =>
-    sameAddress(spendingLimit.beneficiary, wallet?.address),
-  )
 
-  return userSpendingLimits.find((spendingLimit) => sameAddress(spendingLimit.token, selectedToken?.address))
+  return spendingLimits.find(
+    (spendingLimit) =>
+      sameAddress(spendingLimit.token, selectedToken?.address) &&
+      sameAddress(spendingLimit.beneficiary, wallet?.address),
+  )
 }
 
 export default useSpendingLimit

--- a/src/utils/__tests__/validation.test.ts
+++ b/src/utils/__tests__/validation.test.ts
@@ -1,4 +1,4 @@
-import { validateAddress, validateChainId, validatePrefixedAddress } from '@/utils/validation'
+import { validateAddress, validateAmount, validateChainId, validatePrefixedAddress } from '@/utils/validation'
 
 describe('validation', () => {
   describe('Ethereum address validation', () => {
@@ -40,6 +40,27 @@ describe('validation', () => {
 
     it('should pass validation is the address has the correct prefix', () => {
       expect(validate('rin:0x1234567890123456789012345678901234567890')).toBe(undefined)
+    })
+  })
+
+  describe('Token amount validation', () => {
+    it('returns an error if its not a number', () => {
+      const result = validateAmount('abc', 18, '100')
+
+      expect(result).toBe('The amount must be a number')
+    })
+
+    it('returns an error if its a number smaller than or equal 0', () => {
+      const result1 = validateAmount('0', 18, '100')
+      expect(result1).toBe('The amount must be greater than 0')
+
+      const result2 = validateAmount('-1', 18, '100')
+      expect(result2).toBe('The amount must be greater than 0')
+    })
+
+    it('returns an error if its larger than the max', () => {
+      const result = validateAmount('101', 18, '100000000000000000000')
+      expect(result).toBe('Maximum value is 100')
     })
   })
 })

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -73,6 +73,22 @@ export const validateTokenAmount = (amount: string, token?: { balance: string; t
   }
 }
 
+export const validateAmount = (amount: string, decimals?: number, max?: string) => {
+  if (!decimals || !max) return
+
+  if (isNaN(Number(amount))) {
+    return 'The amount must be a number'
+  }
+
+  if (parseFloat(amount) <= 0) {
+    return 'The amount must be greater than 0'
+  }
+
+  if (toWei(amount, decimals).gt(max)) {
+    return `Maximum value is ${formatDecimals(max, decimals)}`
+  }
+}
+
 export const isValidURL = (url: string, protocolsAllowed = ['https:']): boolean => {
   try {
     const urlInfo = new URL(url)


### PR DESCRIPTION
## What it solves

- When sending funds and selecting a token for which a spending limit exists we show a radio group selection
- Selecting the Max amount changes depending on what is selected

## How to test

1. Create a new transaction and select a token for which a spending limit exists for the connected wallet address
2. Observe 2 options showing up (Multisend, Spending Limit)

## Screenshot
<img width="641" alt="Screenshot 2022-08-22 at 14 42 51" src="https://user-images.githubusercontent.com/5880855/185923770-e05de29e-9acb-4779-9e12-30856fcd8ac3.png">

