### PR TITLE
WIP: fix: number of confirmations in stepper

### DIFF
--- a/src/components/transactions/TxSigners/index.tsx
+++ b/src/components/transactions/TxSigners/index.tsx
@@ -124,11 +124,7 @@ export const TxSigners = ({
     }
 
     return detailedExecutionInfo.confirmations
-  }, [
-    isPending,
-    wallet?.address,
-    isMultisigExecutionDetails(detailedExecutionInfo) && detailedExecutionInfo.confirmations,
-  ])
+  }, [isPending, wallet?.address, detailedExecutionInfo])
 
   if (!detailedExecutionInfo || !isMultisigExecutionDetails(detailedExecutionInfo)) {
     return null

--- a/src/components/transactions/TxSigners/index.tsx
+++ b/src/components/transactions/TxSigners/index.tsx
@@ -111,10 +111,10 @@ export const TxSigners = ({
       return []
     }
 
-    const hasExecutorConfirmation =
-      !!wallet?.address && detailedExecutionInfo.confirmations.some(({ signer }) => signer.value === wallet.address)
+    const isOwner = detailedExecutionInfo.signers.some((signer) => signer.value === wallet?.address)
+    const hasConfirmation = detailedExecutionInfo.confirmations.some(({ signer }) => signer.value === wallet?.address)
 
-    if (isPending && !hasExecutorConfirmation) {
+    if (isPending && isOwner && !hasConfirmation) {
       const EXECUTOR_CONFIRMATION: MultisigConfirmation = {
         signer: { value: wallet?.address || '' },
         submittedAt: Date.now(),

--- a/src/components/transactions/TxSigners/index.tsx
+++ b/src/components/transactions/TxSigners/index.tsx
@@ -107,7 +107,7 @@ export const TxSigners = ({
 
   // If final signer executes tx, `detailedExecutionInfo.confirmations` won't contain their confirmation
   const confirmations = useMemo(() => {
-    if (!isMultisigExecutionDetails(detailedExecutionInfo)) {
+    if (!detailedExecutionInfo || !isMultisigExecutionDetails(detailedExecutionInfo)) {
       return []
     }
 


### PR DESCRIPTION
## What it solves

Missing confirmation in stepper.

## How this PR fixes it

If the transaction is pending and `detailedExecutionInfo.confirmations` is missing the final signer/executor, it is added.

## How to test it

- Create and immediately execute a transaction on a 1/n Safe. Observe the correct number of "Confirmations" in the transaction stepper.
- Create a transaction on a 2+/n Safe. Make sure that there are `threshold - 1` signatures on said transaction. When signing and executing the transaction with the final required owner, observe the correct number of "Confirmations".

## Screenshots
![confirmations](https://user-images.githubusercontent.com/20442784/185933584-65bed8e4-5264-44a8-bf80-fbcd8d9ec1fa.gif)