### PR TITLE
fix: log events as `info` outside of prod.

### DIFF
--- a/src/services/analytics/analytics.ts
+++ b/src/services/analytics/analytics.ts
@@ -13,7 +13,7 @@ export const trackEvent = ({
   label?: EventLabel
 }) => {
   if (!IS_PRODUCTION) {
-    console.info({ event, ...rest })
+    console.info('[Analytics]', { event, ...rest })
   }
 }
 

--- a/src/services/analytics/analytics.ts
+++ b/src/services/analytics/analytics.ts
@@ -1,3 +1,4 @@
+import { IS_PRODUCTION } from '@/config/constants'
 import { ConnectedWallet } from '../onboard'
 import { WALLET_EVENTS } from './events/wallet'
 import { GTM_EVENT, EventLabel } from './types'
@@ -11,7 +12,9 @@ export const trackEvent = ({
   action: string
   label?: EventLabel
 }) => {
-  console.log({ event, ...rest })
+  if (!IS_PRODUCTION) {
+    console.info({ event, ...rest })
+  }
 }
 
 export const trackWalletType = async ({ label, provider }: ConnectedWallet) => {

--- a/src/services/beamer/index.ts
+++ b/src/services/beamer/index.ts
@@ -14,7 +14,7 @@ export const loadBeamer = async (): Promise<void> => {
   const BEAMER_URL = 'https://app.getbeamer.com/js/beamer-embed.js'
 
   if (!BEAMER_ID) {
-    console.warn('[Beamer] - In order to use Beamer you need to add a `product_id`')
+    console.warn('[Beamer] In order to use Beamer you need to add a `product_id`')
     return
   }
 


### PR DESCRIPTION
## What it solves

Loggin events on prod.

## How this PR fixes it

Events are now logged as `info` when `!IS_PRODUCTION`,

Note: is is possible to turn off `info` logs in the console and they therefore won't interfere with debugging.

## How to test it

Navigate the Safe and observe the events loggin as `info` instead of a normal `log`.

## Analytics changes

Console logging only occurs outside of prod.