### PR TITLE
fix: wallet-dependent awaiting confirmation status

### DIFF
--- a/src/hooks/useTransactionStatus.ts
+++ b/src/hooks/useTransactionStatus.ts
@@ -1,22 +1,39 @@
 import { useAppSelector } from '@/store'
 import { PendingStatus, selectPendingTxById } from '@/store/pendingTxsSlice'
+import { sameAddress } from '@/utils/addresses'
+import { isMultisigExecutionInfo } from '@/utils/transaction-guards'
 import { TransactionSummary, TransactionStatus } from '@gnosis.pm/safe-react-gateway-sdk'
+import { useMemo } from 'react'
+import useWallet from './wallets/useWallet'
 
 type TxLocalStatus = TransactionStatus | PendingStatus
 
-const STATUS_LABELS: Record<TxLocalStatus, string> = {
-  [TransactionStatus.AWAITING_CONFIRMATIONS]: 'Awaiting confirmations',
-  [TransactionStatus.AWAITING_EXECUTION]: 'Awaiting execution',
-  [TransactionStatus.CANCELLED]: 'Cancelled',
-  [TransactionStatus.FAILED]: 'Failed',
-  [TransactionStatus.SUCCESS]: 'Success',
-  [PendingStatus.SUBMITTING]: 'Submitting',
-  [PendingStatus.MINING]: 'Mining',
-  [PendingStatus.INDEXING]: 'Indexing',
+const hasSignature = (executionInfo: TransactionSummary['executionInfo'], address?: string) => {
+  return isMultisigExecutionInfo(executionInfo)
+    ? executionInfo.missingSigners?.some((signer) => sameAddress(signer.value, address))
+    : false
 }
 
-const useTransactionStatus = ({ txStatus, id }: TransactionSummary): string => {
+const useTransactionStatus = ({ txStatus, id, executionInfo }: TransactionSummary): string => {
+  const wallet = useWallet()
   const pendingTx = useAppSelector((state) => selectPendingTxById(state, id))
+
+  const STATUS_LABELS: Record<TxLocalStatus, string> = useMemo(
+    () => ({
+      [TransactionStatus.AWAITING_CONFIRMATIONS]: hasSignature(executionInfo, wallet?.address)
+        ? 'Needs your confirmation'
+        : 'Needs confirmations',
+      [TransactionStatus.AWAITING_EXECUTION]: 'Awaiting execution',
+      [TransactionStatus.CANCELLED]: 'Cancelled',
+      [TransactionStatus.FAILED]: 'Failed',
+      [TransactionStatus.SUCCESS]: 'Success',
+      [PendingStatus.SUBMITTING]: 'Submitting',
+      [PendingStatus.MINING]: 'Mining',
+      [PendingStatus.INDEXING]: 'Indexing',
+    }),
+    [executionInfo, wallet?.address],
+  )
+
   return STATUS_LABELS[pendingTx?.status || txStatus] || ''
 }
 

--- a/src/hooks/useTransactionStatus.ts
+++ b/src/hooks/useTransactionStatus.ts
@@ -1,28 +1,22 @@
 import { useAppSelector } from '@/store'
 import { PendingStatus, selectPendingTxById } from '@/store/pendingTxsSlice'
-import { sameAddress } from '@/utils/addresses'
-import { isMultisigExecutionInfo } from '@/utils/transaction-guards'
+import { isSignableBy } from '@/utils/transaction-guards'
 import { TransactionSummary, TransactionStatus } from '@gnosis.pm/safe-react-gateway-sdk'
 import { useMemo } from 'react'
 import useWallet from './wallets/useWallet'
 
 type TxLocalStatus = TransactionStatus | PendingStatus
 
-const hasSignature = (executionInfo: TransactionSummary['executionInfo'], address?: string) => {
-  return isMultisigExecutionInfo(executionInfo)
-    ? executionInfo.missingSigners?.some((signer) => sameAddress(signer.value, address))
-    : false
-}
+const useTransactionStatus = (txSummary: TransactionSummary): string => {
+  const { txStatus, id } = txSummary
 
-const useTransactionStatus = ({ txStatus, id, executionInfo }: TransactionSummary): string => {
   const wallet = useWallet()
   const pendingTx = useAppSelector((state) => selectPendingTxById(state, id))
 
   const STATUS_LABELS: Record<TxLocalStatus, string> = useMemo(
     () => ({
-      [TransactionStatus.AWAITING_CONFIRMATIONS]: hasSignature(executionInfo, wallet?.address)
-        ? 'Needs your confirmation'
-        : 'Needs confirmations',
+      [TransactionStatus.AWAITING_CONFIRMATIONS]:
+        wallet?.address && isSignableBy(txSummary, wallet.address) ? 'Needs your confirmation' : 'Needs confirmations',
       [TransactionStatus.AWAITING_EXECUTION]: 'Awaiting execution',
       [TransactionStatus.CANCELLED]: 'Cancelled',
       [TransactionStatus.FAILED]: 'Failed',
@@ -31,7 +25,7 @@ const useTransactionStatus = ({ txStatus, id, executionInfo }: TransactionSummar
       [PendingStatus.MINING]: 'Mining',
       [PendingStatus.INDEXING]: 'Indexing',
     }),
-    [executionInfo, wallet?.address],
+    [txSummary, wallet?.address],
   )
 
   return STATUS_LABELS[pendingTx?.status || txStatus] || ''

--- a/src/hooks/useTransactionStatus.ts
+++ b/src/hooks/useTransactionStatus.ts
@@ -2,10 +2,25 @@ import { useAppSelector } from '@/store'
 import { PendingStatus, selectPendingTxById } from '@/store/pendingTxsSlice'
 import { isSignableBy } from '@/utils/transaction-guards'
 import { TransactionSummary, TransactionStatus } from '@gnosis.pm/safe-react-gateway-sdk'
-import { useMemo } from 'react'
 import useWallet from './wallets/useWallet'
 
 type TxLocalStatus = TransactionStatus | PendingStatus
+
+const STATUS_LABELS: Record<TxLocalStatus, string> = {
+  [TransactionStatus.AWAITING_CONFIRMATIONS]: 'Awaiting confirmations',
+  [TransactionStatus.AWAITING_EXECUTION]: 'Awaiting execution',
+  [TransactionStatus.CANCELLED]: 'Cancelled',
+  [TransactionStatus.FAILED]: 'Failed',
+  [TransactionStatus.SUCCESS]: 'Success',
+  [PendingStatus.SUBMITTING]: 'Submitting',
+  [PendingStatus.MINING]: 'Mining',
+  [PendingStatus.INDEXING]: 'Indexing',
+}
+
+const WALLET_STATUS_LABELS: Record<TxLocalStatus, string> = {
+  ...STATUS_LABELS,
+  [TransactionStatus.AWAITING_CONFIRMATIONS]: 'Needs your confirmation',
+}
 
 const useTransactionStatus = (txSummary: TransactionSummary): string => {
   const { txStatus, id } = txSummary
@@ -13,22 +28,9 @@ const useTransactionStatus = (txSummary: TransactionSummary): string => {
   const wallet = useWallet()
   const pendingTx = useAppSelector((state) => selectPendingTxById(state, id))
 
-  const STATUS_LABELS: Record<TxLocalStatus, string> = useMemo(
-    () => ({
-      [TransactionStatus.AWAITING_CONFIRMATIONS]:
-        wallet?.address && isSignableBy(txSummary, wallet.address) ? 'Needs your confirmation' : 'Needs confirmations',
-      [TransactionStatus.AWAITING_EXECUTION]: 'Awaiting execution',
-      [TransactionStatus.CANCELLED]: 'Cancelled',
-      [TransactionStatus.FAILED]: 'Failed',
-      [TransactionStatus.SUCCESS]: 'Success',
-      [PendingStatus.SUBMITTING]: 'Submitting',
-      [PendingStatus.MINING]: 'Mining',
-      [PendingStatus.INDEXING]: 'Indexing',
-    }),
-    [txSummary, wallet?.address],
-  )
+  const statuses = wallet?.address && isSignableBy(txSummary, wallet.address) ? WALLET_STATUS_LABELS : STATUS_LABELS
 
-  return STATUS_LABELS[pendingTx?.status || txStatus] || ''
+  return statuses[pendingTx?.status || txStatus] || ''
 }
 
 export default useTransactionStatus


### PR DESCRIPTION
## What it solves

Signer specific `AWAITING_CONFIRMATIONS` statuses.

## How this PR fixes it

If the currently connected wallet exists in the `missingSigners` array, the status is "Needs your confirmation" as opposed to "Needs confirmations" when it isn't.

## How to test it

Create a transaction on a 2+/n Safe. Observe how the status differs between the creator and the other required signers.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/185941360-47668a9f-9040-49d9-b187-987e918baaf6.png)
![image](https://user-images.githubusercontent.com/20442784/185941373-84fa16c3-432c-47a3-b7d3-7101f3aa5a2a.png)
