### PR TITLE
Fix: small text/UI adjustments in tx modals

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,16 +15,17 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
+      - name: Yarn cache
+        uses: actions/cache@v2
         with:
-          node-version: 16
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Yarn install
         run: |
-          rm -rf .yarncache
-          yarn cache clean
-          yarn install
+          mkdir .yarncache
+          yarn install --cache-folder ./.yarncache  --immutable
+          ./node_modules/.bin/cypress install
 
       - name: Build
         run: yarn build && yarn export

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,10 +19,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          cache: 'yarn'
 
       - name: Yarn install
-        run: yarn install
+        run: |
+          rm -rf .yarncache
+          yarn cache clean
+          yarn install
 
       - name: Build
         run: yarn build && yarn export

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,8 +22,6 @@ jobs:
         run: |
           mkdir .yarncache
           yarn install --cache-folder ./.yarncache --immutable
-          rm -rf .yarncache
-          yarn cache clean
 
       - uses: Maggi64/eslint-plus-action@master
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16
-
       - name: Yarn cache
         uses: actions/cache@v2
         with:
@@ -29,8 +24,6 @@ jobs:
         run: |
           mkdir .yarncache
           yarn install --cache-folder ./.yarncache  --immutable
-          rm -rf .yarncache
-          yarn cache clean
 
       - name: Run tests
         run: 'yarn test:ci'

--- a/src/components/tx/AdvancedParamsForm/index.tsx
+++ b/src/components/tx/AdvancedParamsForm/index.tsx
@@ -1,4 +1,15 @@
-import { Button, DialogTitle, DialogActions, FormControl, Grid, Paper, TextField } from '@mui/material'
+import {
+  Button,
+  DialogTitle,
+  DialogActions,
+  FormControl,
+  Grid,
+  Paper,
+  TextField,
+  Link,
+  Typography,
+} from '@mui/material'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import { BigNumber } from 'ethers'
 import { FormProvider, useForm } from 'react-hook-form'
 import { safeFormatUnits, safeParseUnits } from '@/utils/formatters'
@@ -183,6 +194,13 @@ const AdvancedParamsForm = (props: AdvancedParamsFormProps) => {
               </>
             )}
           </Grid>
+
+          <Typography mt={2}>
+            <Link href="https://help.gnosis-safe.io/en/articles/4738445-advanced-transaction-parameters">
+              How can I configure these parameters manually?
+              <OpenInNewIcon fontSize="small" sx={{ verticalAlign: 'middle', marginLeft: 0.5 }} />
+            </Link>
+          </Typography>
 
           <DialogActions className={css.actions}>
             <Button color="inherit" onClick={onBack}>

--- a/src/components/tx/AdvancedParamsForm/index.tsx
+++ b/src/components/tx/AdvancedParamsForm/index.tsx
@@ -18,7 +18,8 @@ import { FLOAT_REGEX } from '@/utils/validation'
 import NonceForm from '../NonceForm'
 import InputValueHelper from '@/components/common/InputValueHelper'
 import { BASE_TX_GAS } from '@/config/constants'
-import useSafeInfo from '@/hooks/useSafeInfo'
+
+const HELP_LINK = 'https://help.gnosis-safe.io/en/articles/4738445-advanced-transaction-parameters'
 
 enum AdvancedField {
   nonce = 'nonce',
@@ -53,8 +54,6 @@ type FormData = {
 }
 
 const AdvancedParamsForm = (props: AdvancedParamsFormProps) => {
-  const { safe } = useSafeInfo()
-
   const formMethods = useForm<FormData>({
     mode: 'onChange',
     defaultValues: {
@@ -196,7 +195,7 @@ const AdvancedParamsForm = (props: AdvancedParamsFormProps) => {
           </Grid>
 
           <Typography mt={2}>
-            <Link href="https://help.gnosis-safe.io/en/articles/4738445-advanced-transaction-parameters">
+            <Link href={HELP_LINK}>
               How can I configure these parameters manually?
               <OpenInNewIcon fontSize="small" sx={{ verticalAlign: 'middle', marginLeft: 0.5 }} />
             </Link>

--- a/src/components/tx/ExecuteCheckbox/index.tsx
+++ b/src/components/tx/ExecuteCheckbox/index.tsx
@@ -17,7 +17,7 @@ const ExecuteToggle = ({
   }
 
   const infoIcon = (
-    <Tooltip title="If you want to sign the transaction now but manually execute it later, uncheck the box.">
+    <Tooltip title="If you want to sign the transaction now but manually execute it later, uncheck this box.">
       <InfoIcon fontSize="small" sx={{ verticalAlign: 'middle', marginLeft: 0.5 }} />
     </Tooltip>
   )

--- a/src/components/tx/ExecuteCheckbox/index.tsx
+++ b/src/components/tx/ExecuteCheckbox/index.tsx
@@ -1,5 +1,6 @@
 import type { ChangeEvent, ReactElement } from 'react'
-import { Checkbox, FormControlLabel } from '@mui/material'
+import { Checkbox, FormControlLabel, Tooltip } from '@mui/material'
+import InfoIcon from '@mui/icons-material/Info'
 import { trackEvent } from '@/services/analytics/analytics'
 import { MODALS_EVENTS } from '@/services/analytics/events/modals'
 
@@ -15,10 +16,16 @@ const ExecuteToggle = ({
     onChange(checked)
   }
 
+  const infoIcon = (
+    <Tooltip title="If you want to sign the transaction now but manually execute it later, uncheck the box.">
+      <InfoIcon fontSize="small" sx={{ verticalAlign: 'middle', marginLeft: 0.5 }} />
+    </Tooltip>
+  )
+
   return (
     <FormControlLabel
       control={<Checkbox checked={checked} onChange={handleChange} />}
-      label="Execute transaction"
+      label={<>Execute transaction {infoIcon}</>}
       sx={{ mb: 1 }}
     />
   )

--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -75,7 +75,7 @@ const GasParams = ({
             </Typography>
           ) : (
             <Typography>
-              Signing transaction with nonce&nbsp;
+              Signing the transaction with nonce&nbsp;
               {nonce || <Skeleton variant="text" sx={{ display: 'inline-block', minWidth: '2em' }} />}
             </Typography>
           )}

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -225,8 +225,9 @@ const SignOrExecuteForm = ({
         )}
 
         <Typography variant="body2" color="text.disabled" textAlign="center" mt={3}>
-          You&apos;re about to {txId ? '' : 'create and'} {willExecute ? 'execute' : 'sign'} a transaction and will need
-          to confirm it with your currently connected wallet.
+          You&apos;re about to {txId ? '' : 'create and '}
+          {willExecute ? 'execute' : 'sign'} a transaction and will need to confirm it with your currently connected
+          wallet.
         </Typography>
 
         <Button variant="contained" type="submit" disabled={submitDisabled}>

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement, type ReactNode, type SyntheticEvent, useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import type { SafeTransaction, TransactionOptions } from '@gnosis.pm/safe-core-sdk-types'
-import { Button, DialogContent } from '@mui/material'
+import { Button, DialogContent, Typography } from '@mui/material'
 import { FEATURES } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import { dispatchTxExecution, dispatchTxProposal, dispatchTxSigning, createTx } from '@/services/tx/txSender'
@@ -223,6 +223,11 @@ const SignOrExecuteForm = ({
         {submitError && (
           <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
         )}
+
+        <Typography variant="body2" color="text.disabled" textAlign="center" mt={3}>
+          You&apos;re about to {txId ? '' : 'create and'} {willExecute ? 'execute' : 'sign'} a transaction and will need
+          to confirm it with your currently connected wallet.
+        </Typography>
 
         <Button variant="contained" type="submit" disabled={submitDisabled}>
           {isEstimating ? 'Estimating...' : 'Submit'}

--- a/src/components/tx/TxStepper/index.tsx
+++ b/src/components/tx/TxStepper/index.tsx
@@ -18,11 +18,13 @@ const TxStepper = ({ steps, initialData, initialStep, onClose }: TxStepperProps)
         <Grid container px={1} alignItems="center" gap={2}>
           <Grid item>{steps[activeStep].label}</Grid>
 
-          <Grid item>
-            <Typography className={css.stepIndicator} variant="caption" color="border.main">
-              Step {activeStep + 1} out of {steps.length}
-            </Typography>
-          </Grid>
+          {steps.length > 1 && (
+            <Grid item>
+              <Typography className={css.stepIndicator} variant="caption" color="border.main">
+                Step {activeStep + 1} out of {steps.length}
+              </Typography>
+            </Grid>
+          )}
         </Grid>
       </ModalDialogTitle>
 

--- a/src/components/tx/modals/ConfirmTxModal/ConfirmProposedTx.tsx
+++ b/src/components/tx/modals/ConfirmTxModal/ConfirmProposedTx.tsx
@@ -9,11 +9,16 @@ import useAsync from '@/hooks/useAsync'
 import useWallet from '@/hooks/wallets/useWallet'
 import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import { isExecutable, isSignableBy } from '@/utils/transaction-guards'
+import { Skeleton, Typography } from '@mui/material'
 
 type ConfirmProposedTxProps = {
   txSummary: TransactionSummary
   onSubmit: (data: null) => void
 }
+
+const SIGN_TEXT = 'Sign this transaction.'
+const EXECUTE_TEXT = 'Submit the form to execute this transaction.'
+const SIGN_EXECUTE_TEXT = 'Sign or immediately execute this transaction.'
 
 const ConfirmProposedTx = ({ txSummary, onSubmit }: ConfirmProposedTxProps): ReactElement => {
   const wallet = useWallet()
@@ -27,6 +32,8 @@ const ConfirmProposedTx = ({ txSummary, onSubmit }: ConfirmProposedTxProps): Rea
     return createExistingTx(chainId, safeAddress, txId)
   }, [txId, safeAddress, chainId])
 
+  const text = canSign ? (canExecute ? SIGN_EXECUTE_TEXT : SIGN_TEXT) : EXECUTE_TEXT
+
   return (
     <SignOrExecuteForm
       safeTx={safeTx}
@@ -35,7 +42,18 @@ const ConfirmProposedTx = ({ txSummary, onSubmit }: ConfirmProposedTxProps): Rea
       isExecutable={canExecute}
       onlyExecute={!canSign}
       error={safeTxError}
-    />
+    >
+      <Typography mb={2}>{text}</Typography>
+
+      <Typography mb={3}>
+        Transaction nonce:&nbsp;
+        {safeTx ? (
+          <b>{safeTx?.data.nonce}</b>
+        ) : (
+          <Skeleton variant="text" sx={{ display: 'inline-block', minWidth: '2em' }} />
+        )}
+      </Typography>
+    </SignOrExecuteForm>
   )
 }
 

--- a/src/components/tx/modals/RejectTxModal/RejectTx.tsx
+++ b/src/components/tx/modals/RejectTxModal/RejectTx.tsx
@@ -32,7 +32,7 @@ const RejectTx = ({ txSummary, onSubmit }: RejectTxProps): ReactElement => {
       error={rejectError}
     >
       <Typography mb={2}>
-        This action will reject this transaction. A separate transaction will be performed to submit the rejection.
+        To reject the transaction, a separate rejection transaction will be created to replace the original one.
       </Typography>
 
       <Typography mb={2}>
@@ -40,8 +40,7 @@ const RejectTx = ({ txSummary, onSubmit }: RejectTxProps): ReactElement => {
       </Typography>
 
       <Typography mb={2}>
-        You are about to create a rejection transaction and will have to confirm it with your currently connected
-        wallet.
+        You will need to confirm the rejection transaction with your currently connected wallet.
       </Typography>
     </SignOrExecuteForm>
   )


### PR DESCRIPTION
A help link in the Advanced params:
<img width="664" alt="Screenshot 2022-08-22 at 16 22 59" src="https://user-images.githubusercontent.com/381895/185945076-a3b91fa3-2e45-4135-93d9-49a3aeea0618.png">

An info icon + tooltip for the Execute checkbox:
<img width="639" alt="Screenshot 2022-08-22 at 16 23 06" src="https://user-images.githubusercontent.com/381895/185945142-fd1be9fb-392d-47ba-b8bf-04e76759e06b.png">

The text in the Execution modal:
<img width="650" alt="Screenshot 2022-08-22 at 16 23 15" src="https://user-images.githubusercontent.com/381895/185945284-1753f7fe-d1f6-4c15-93b7-0d9cfbc220eb.png">

The signing text in the rejectio
<img width="638" alt="Screenshot 2022-08-22 at 16 23 31" src="https://user-images.githubusercontent.com/381895/185945436-912e6380-f6d6-42e2-b64e-a74cb264dd44.png">
n modal:

