### PR TITLE
fix: use diff. reset for Rinkeby spending limits

### DIFF
--- a/src/components/settings/SpendingLimits/NewSpendingLimit/steps/ReviewSpendingLimit.tsx
+++ b/src/components/settings/SpendingLimits/NewSpendingLimit/steps/ReviewSpendingLimit.tsx
@@ -1,6 +1,6 @@
 import { Typography, Box } from '@mui/material'
 import useBalances from '@/hooks/useBalances'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useAsync from '@/hooks/useAsync'
 import { MetaTransactionData, SafeTransaction } from '@gnosis.pm/safe-core-sdk-types'
@@ -10,7 +10,7 @@ import useChainId from '@/hooks/useChainId'
 import { useSelector } from 'react-redux'
 import { selectSpendingLimits, SpendingLimitState } from '@/store/spendingLimitsSlice'
 import { createAddDelegateTx, createResetAllowanceTx, createSetAllowanceTx } from '@/services/tx/spendingLimitParams'
-import { RESET_TIME_OPTIONS } from '@/components/settings/SpendingLimits/NewSpendingLimit/steps/SpendingLimitForm'
+import { getResetTimeOptions } from '@/components/transactions/TxDetails/TxData/SpendingLimits'
 import { TokenIcon } from '@/components/common/TokenAmount'
 import { BigNumber } from '@ethersproject/bignumber'
 import { formatUnits } from 'ethers/lib/utils'
@@ -99,10 +99,11 @@ export const ReviewSpendingLimit = ({ data, onSubmit }: Props) => {
   const token = balances.items.find((item) => item.tokenInfo.address === data.tokenAddress)
   const { decimals, logoUri, symbol } = token?.tokenInfo || {}
 
-  const resetTime =
-    data.resetTime === '0'
+  const resetTime = useMemo(() => {
+    return data.resetTime === '0'
       ? 'One-time spending limit'
-      : RESET_TIME_OPTIONS.find((time) => time.value === data.resetTime)?.label
+      : getResetTimeOptions(chainId).find((time) => time.value === data.resetTime)?.label
+  }, [data.resetTime, chainId])
 
   const [safeTx, safeTxError] = useAsync<SafeTransaction | undefined>(() => {
     return createNewSpendingLimitTx(data, spendingLimits, chainId, decimals, existingSpendingLimit)

--- a/src/components/settings/SpendingLimits/NewSpendingLimit/steps/SpendingLimitForm.tsx
+++ b/src/components/settings/SpendingLimits/NewSpendingLimit/steps/SpendingLimitForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { FormProvider, useForm, Controller } from 'react-hook-form'
 import {
   Button,
@@ -21,12 +21,8 @@ import { validateTokenAmount } from '@/utils/validation'
 import useBalances from '@/hooks/useBalances'
 import { formatDecimals } from '@/utils/formatters'
 import { AutocompleteItem } from '@/components/tx/modals/TokenTransferModal/SendAssetsForm'
-
-export const RESET_TIME_OPTIONS = [
-  { label: '1 day', value: '1440' }, // 1 day x 24h x 60min
-  { label: '1 week', value: '10080' }, // 7 days x 24h x 60min
-  { label: '1 month', value: '43200' }, // 30 days x 24h x 60min
-]
+import useChainId from '@/hooks/useChainId'
+import { getResetTimeOptions } from '@/components/transactions/TxDetails/TxData/SpendingLimits'
 
 export type NewSpendingLimitData = {
   beneficiary: string
@@ -41,8 +37,11 @@ type Props = {
 }
 
 export const SpendingLimitForm = ({ data, onSubmit }: Props) => {
+  const chainId = useChainId()
   const [showResetTime, setShowResetTime] = useState<boolean>(false)
   const { balances } = useBalances()
+
+  const resetTimeOptions = useMemo(() => getResetTimeOptions(chainId), [chainId])
 
   const formMethods = useForm<NewSpendingLimitData>({
     defaultValues: { ...data, resetTime: '0' },
@@ -69,7 +68,7 @@ export const SpendingLimitForm = ({ data, onSubmit }: Props) => {
   }
 
   const toggleResetTime = () => {
-    setValue('resetTime', showResetTime ? '0' : RESET_TIME_OPTIONS[0].value)
+    setValue('resetTime', showResetTime ? '0' : resetTimeOptions[0].value)
     setShowResetTime((prev) => !prev)
   }
 
@@ -141,8 +140,8 @@ export const SpendingLimitForm = ({ data, onSubmit }: Props) => {
                 control={control}
                 name="resetTime"
                 render={({ field }) => (
-                  <RadioGroup {...field} defaultValue={RESET_TIME_OPTIONS[0].value} name="radio-buttons-group">
-                    {RESET_TIME_OPTIONS.map((resetTime) => (
+                  <RadioGroup {...field} defaultValue={resetTimeOptions[0].value} name="radio-buttons-group">
+                    {resetTimeOptions.map((resetTime) => (
                       <FormControlLabel
                         key={resetTime.value}
                         value={resetTime.value}

--- a/src/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
@@ -11,6 +11,7 @@ import { sameAddress } from '@/utils/addresses'
 import { formatDecimals } from '@/utils/formatters'
 import { isSetAllowance, SpendingLimitMethods } from '@/utils/transaction-guards'
 import css from './styles.module.css'
+import chains from '@/config/chains'
 
 type SpendingLimitsProps = {
   txData?: TransactionData
@@ -108,9 +109,8 @@ const RINKEBY_RESET_TIME_OPTIONS = [
   { label: '1 hour', value: '60' },
 ]
 
-const getResetTimeOptions = (chainName = ''): { label: string; value: string }[] => {
-  const currentNetwork = chainName.toLowerCase()
-  return currentNetwork !== 'rinkeby' ? RESET_TIME_OPTIONS : RINKEBY_RESET_TIME_OPTIONS
+export const getResetTimeOptions = (chainId = ''): { label: string; value: string }[] => {
+  return chainId !== chains.rin ? RESET_TIME_OPTIONS : RINKEBY_RESET_TIME_OPTIONS
 }
 
 export default SpendingLimits

--- a/src/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
@@ -28,7 +28,7 @@ export const SpendingLimits = ({ txData, txInfo, type }: SpendingLimitsProps): R
     txData?.dataDecoded?.parameters?.map(({ value }) => value) || []
 
   const resetTimeLabel = useMemo(
-    () => getResetTimeOptions(chain?.chainName).find(({ value }) => +value === +resetTimeMin)?.label,
+    () => getResetTimeOptions(chain?.chainId).find(({ value }) => +value === +resetTimeMin)?.label,
     [chain?.chainName, resetTimeMin],
   )
   const tokenInfo = useMemo(


### PR DESCRIPTION
## What it solves

Adding test spending limit periods for Rinkeby.

## How this PR fixes it

The spending limit periods depending on the current `chainId`. Rinkeby now has shorter spending limit periods.

## How to test it

- Add a new spending limit on Rinkeby. Observe the periods of 5 minutes, 30 minutes and 1 hours.
- Add a new spending limit on a non-Rinkeby chain. Observe the periods of 1 day, 1 week and 1 month.

## Screenshots

Rinkeby:
![image](https://user-images.githubusercontent.com/20442784/186134278-9e56c9b2-2905-4090-9b1b-372303638ec4.png)

Polygon:
![image](https://user-images.githubusercontent.com/20442784/186134272-789c7e99-7ec9-45b3-92dd-9e5197ea9d89.png)