### PR TITLE
fix: reset spending limit module if none is set

### DIFF
--- a/src/hooks/loadables/useLoadSpendingLimits.ts
+++ b/src/hooks/loadables/useLoadSpendingLimits.ts
@@ -84,9 +84,9 @@ export const useLoadSpendingLimits = (): AsyncResult<SpendingLimitState[]> => {
 
   const [data, error, loading] = useAsync<SpendingLimitState[] | undefined>(
     () => {
-      if (!provider || !safeLoaded || !safe.modules) return
+      if (!provider || !safeLoaded) return
 
-      return getSpendingLimits(provider, safe.modules, safeAddress, chainId)
+      return safe.modules ? getSpendingLimits(provider, safe.modules, safeAddress, chainId) : Promise.resolve([])
     },
     [provider, safeLoaded, safe.modules?.length, safeAddress, chainId, updateSpendingLimitsTag],
     false,

--- a/src/hooks/loadables/useLoadSpendingLimits.ts
+++ b/src/hooks/loadables/useLoadSpendingLimits.ts
@@ -82,15 +82,11 @@ export const useLoadSpendingLimits = (): AsyncResult<SpendingLimitState[]> => {
     return txSubscribe(TxEvent.SUCCESS, () => setUpdateSpendingLimitsTag(Date.now()))
   }, [])
 
-  const [data, error, loading] = useAsync<SpendingLimitState[] | undefined>(
-    () => {
-      if (!provider || !safeLoaded) return
+  const [data, error, loading] = useAsync<SpendingLimitState[] | undefined>(() => {
+    if (!provider || !safeLoaded || !safe.modules) return
 
-      return safe.modules ? getSpendingLimits(provider, safe.modules, safeAddress, chainId) : Promise.resolve([])
-    },
-    [provider, safeLoaded, safe.modules?.length, safeAddress, chainId, updateSpendingLimitsTag],
-    false,
-  )
+    return getSpendingLimits(provider, safe.modules, safeAddress, chainId)
+  }, [provider, safeLoaded, safe.modules?.length, safeAddress, chainId, updateSpendingLimitsTag])
 
   useEffect(() => {
     if (error) {


### PR DESCRIPTION
## What it solves

Spending limit not resetting

## How this PR fixes it

When changing from a Safe that has a spending limit to another that has none, the `spendingLimits` slice is reset to an empty array.

## How to test it

Open a Safe with a spending limit and observe it set in the settings. Switch to a Safe that has none set and observe none in the settings.