### PR TITLE
fix: validate spending limits `onChange`

### DIFF
--- a/src/components/settings/SpendingLimits/NewSpendingLimit/steps/SpendingLimitForm.tsx
+++ b/src/components/settings/SpendingLimits/NewSpendingLimit/steps/SpendingLimitForm.tsx
@@ -46,6 +46,7 @@ export const SpendingLimitForm = ({ data, onSubmit }: Props) => {
 
   const formMethods = useForm<NewSpendingLimitData>({
     defaultValues: { ...data, resetTime: '0' },
+    mode: 'onChange',
   })
   const {
     register,


### PR DESCRIPTION
## What it solves

Immediate validation of spending limit amounts

## How this PR fixes it

The spending limits form not validates fields `onChange`.

## How to test it

Open the modal to add a new spending limit and select an asset then attempt to enter a negative amount. When the input loses focus, observe the validation error message.