### PR TITLE
fix: don't allow immediate edit of gas params

### DIFF
--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -50,7 +50,7 @@ const GasParams = ({ params, isExecution, onEdit }: GasParamsProps): ReactElemen
 
   const onEditClick = (e: SyntheticEvent) => {
     e.preventDefault()
-    !isLoading && onEdit()
+    onEdit()
   }
 
   return (
@@ -92,11 +92,15 @@ const GasParams = ({ params, isExecution, onEdit }: GasParamsProps): ReactElemen
           </>
         )}
 
-        <Track {...MODALS_EVENTS.EDIT_ESTIMATION}>
-          <Link component="button" onClick={onEditClick} sx={{ mt: 2 }} fontSize="medium">
-            Edit
-          </Link>
-        </Track>
+        {!isExecution || (isExecution && !isLoading) ? (
+          <Track {...MODALS_EVENTS.EDIT_ESTIMATION}>
+            <Link component="button" onClick={onEditClick} sx={{ mt: 2 }} fontSize="medium">
+              Edit
+            </Link>
+          </Track>
+        ) : (
+          <Skeleton variant="text" sx={{ display: 'inline-block', minWidth: '2em', mt: 2 }} />
+        )}
       </AccordionDetails>
     </Accordion>
   )


### PR DESCRIPTION
## What it solves

Gas params editor not opening.

## How this PR fixes it

The edit button is now replaced with a skeleton when gas estimations are loading. Proposed transactions show the edit button immediately.

## How to test it

Create/create and execute transactions on 1/1 Safes and observe that gas params are editable. The same for 1+/n Safes.

The Safe in question that showcased these issues was `rin:0x9913B9180C20C6b0F21B6480c84422F6ebc4B808`.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/186195501-518f2df4-341f-4116-b8bd-5f522f72f225.png)