### PR TITLE
fix: remove upper limit for spending limit tokens

### DIFF
--- a/src/components/settings/SpendingLimits/NewSpendingLimit/steps/SpendingLimitForm.tsx
+++ b/src/components/settings/SpendingLimits/NewSpendingLimit/steps/SpendingLimitForm.tsx
@@ -17,7 +17,7 @@ import {
 } from '@mui/material'
 import AddressBookInput from '@/components/common/AddressBookInput'
 import InputValueHelper from '@/components/common/InputValueHelper'
-import { validateNumber } from '@/utils/validation'
+import { validateAmount } from '@/utils/validation'
 import useBalances from '@/hooks/useBalances'
 import { formatDecimals } from '@/utils/formatters'
 import { AutocompleteItem } from '@/components/tx/modals/TokenTransferModal/SendAssetsForm'
@@ -119,7 +119,7 @@ export const SpendingLimitForm = ({ data, onSubmit }: Props) => {
               }}
               {...register('amount', {
                 required: true,
-                validate: validateNumber,
+                validate: validateAmount,
               })}
             />
           </FormControl>

--- a/src/components/settings/SpendingLimits/NewSpendingLimit/steps/SpendingLimitForm.tsx
+++ b/src/components/settings/SpendingLimits/NewSpendingLimit/steps/SpendingLimitForm.tsx
@@ -17,7 +17,7 @@ import {
 } from '@mui/material'
 import AddressBookInput from '@/components/common/AddressBookInput'
 import InputValueHelper from '@/components/common/InputValueHelper'
-import { validateTokenAmount } from '@/utils/validation'
+import { validateNumber } from '@/utils/validation'
 import useBalances from '@/hooks/useBalances'
 import { formatDecimals } from '@/utils/formatters'
 import { AutocompleteItem } from '@/components/tx/modals/TokenTransferModal/SendAssetsForm'
@@ -119,7 +119,7 @@ export const SpendingLimitForm = ({ data, onSubmit }: Props) => {
               }}
               {...register('amount', {
                 required: true,
-                validate: (val) => validateTokenAmount(val, selectedToken),
+                validate: validateNumber,
               })}
             />
           </FormControl>

--- a/src/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
@@ -29,7 +29,7 @@ export const SpendingLimits = ({ txData, txInfo, type }: SpendingLimitsProps): R
 
   const resetTimeLabel = useMemo(
     () => getResetTimeOptions(chain?.chainId).find(({ value }) => +value === +resetTimeMin)?.label,
-    [chain?.chainName, resetTimeMin],
+    [chain?.chainId, resetTimeMin],
   )
   const tokenInfo = useMemo(
     () => tokens.find(({ address }) => sameAddress(address, tokenAddress as string)),

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -15,7 +15,7 @@ import { type TokenInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import { TokenIcon } from '@/components/common/TokenAmount'
 import { formatDecimals } from '@/utils/formatters'
-import { validateAmount, validateTokenAmount } from '@/utils/validation'
+import { validateLimitedAmount } from '@/utils/validation'
 import useBalances from '@/hooks/useBalances'
 import AddressBookInput from '@/components/common/AddressBookInput'
 import InputValueHelper from '@/components/common/InputValueHelper'
@@ -144,10 +144,7 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
               }}
               {...register(SendAssetsField.amount, {
                 required: true,
-                validate: (val) =>
-                  isSpendingLimitType
-                    ? validateAmount(val, selectedToken?.tokenInfo.decimals, spendingLimit?.amount)
-                    : validateTokenAmount(val, selectedToken),
+                validate: (val) => validateLimitedAmount(val, selectedToken?.tokenInfo.decimals, spendingLimit?.amount),
               })}
             />
           </FormControl>

--- a/src/utils/__tests__/validation.test.ts
+++ b/src/utils/__tests__/validation.test.ts
@@ -1,8 +1,8 @@
 import {
   validateAddress,
-  validateAmount,
+  validateLimitedAmount,
   validateChainId,
-  validateNumber,
+  validateAmount,
   validatePrefixedAddress,
 } from '@/utils/validation'
 
@@ -51,37 +51,37 @@ describe('validation', () => {
 
   describe('Number validation', () => {
     it('returns an error if its not a number', () => {
-      const result = validateNumber('abc')
+      const result = validateAmount('abc')
 
       expect(result).toBe('The amount must be a number')
     })
 
     it('returns an error if its a number smaller than or equal 0', () => {
-      const result1 = validateNumber('0')
+      const result1 = validateAmount('0')
       expect(result1).toBe('The amount must be greater than 0')
 
-      const result2 = validateNumber('-1')
+      const result2 = validateAmount('-1')
       expect(result2).toBe('The amount must be greater than 0')
     })
   })
 
   describe('Token amount validation', () => {
     it('returns an error if its not a number', () => {
-      const result = validateAmount('abc', 18, '100')
+      const result = validateLimitedAmount('abc', 18, '100')
 
       expect(result).toBe('The amount must be a number')
     })
 
     it('returns an error if its a number smaller than or equal 0', () => {
-      const result1 = validateAmount('0', 18, '100')
+      const result1 = validateLimitedAmount('0', 18, '100')
       expect(result1).toBe('The amount must be greater than 0')
 
-      const result2 = validateAmount('-1', 18, '100')
+      const result2 = validateLimitedAmount('-1', 18, '100')
       expect(result2).toBe('The amount must be greater than 0')
     })
 
     it('returns an error if its larger than the max', () => {
-      const result = validateAmount('101', 18, '100000000000000000000')
+      const result = validateLimitedAmount('101', 18, '100000000000000000000')
       expect(result).toBe('Maximum value is 100')
     })
   })

--- a/src/utils/__tests__/validation.test.ts
+++ b/src/utils/__tests__/validation.test.ts
@@ -1,4 +1,10 @@
-import { validateAddress, validateAmount, validateChainId, validatePrefixedAddress } from '@/utils/validation'
+import {
+  validateAddress,
+  validateAmount,
+  validateChainId,
+  validateNumber,
+  validatePrefixedAddress,
+} from '@/utils/validation'
 
 describe('validation', () => {
   describe('Ethereum address validation', () => {
@@ -40,6 +46,22 @@ describe('validation', () => {
 
     it('should pass validation is the address has the correct prefix', () => {
       expect(validate('rin:0x1234567890123456789012345678901234567890')).toBe(undefined)
+    })
+  })
+
+  describe('Number validation', () => {
+    it('returns an error if its not a number', () => {
+      const result = validateNumber('abc')
+
+      expect(result).toBe('The amount must be a number')
+    })
+
+    it('returns an error if its a number smaller than or equal 0', () => {
+      const result1 = validateNumber('0')
+      expect(result1).toBe('The amount must be greater than 0')
+
+      const result2 = validateNumber('-1')
+      expect(result2).toBe('The amount must be greater than 0')
     })
   })
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,6 +1,5 @@
 import chains from '@/config/chains'
 import { isAddress } from '@ethersproject/address'
-import { type TokenInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { parsePrefixedAddress, sameAddress } from './addresses'
 import { formatDecimals, toWei } from './formatters'
 
@@ -57,7 +56,7 @@ export const addressIsNotCurrentSafe =
 
 export const FLOAT_REGEX = /^[0-9]+([,.][0-9]+)?$/
 
-export const validateNumber = (amount: string) => {
+export const validateAmount = (amount: string) => {
   if (isNaN(Number(amount))) {
     return 'The amount must be a number'
   }
@@ -67,23 +66,10 @@ export const validateNumber = (amount: string) => {
   }
 }
 
-export const validateTokenAmount = (amount: string, token?: { balance: string; tokenInfo: TokenInfo }) => {
-  if (!token) return
-
-  const numberError = validateNumber(amount)
-  if (numberError) {
-    return numberError
-  }
-
-  if (toWei(amount, token.tokenInfo.decimals).gt(token.balance)) {
-    return `Maximum value is ${formatDecimals(token.balance, token.tokenInfo.decimals)}`
-  }
-}
-
-export const validateAmount = (amount: string, decimals?: number, max?: string) => {
+export const validateLimitedAmount = (amount: string, decimals?: number, max?: string) => {
   if (!decimals || !max) return
 
-  const numberError = validateNumber(amount)
+  const numberError = validateAmount(amount)
   if (numberError) {
     return numberError
   }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -57,15 +57,22 @@ export const addressIsNotCurrentSafe =
 
 export const FLOAT_REGEX = /^[0-9]+([,.][0-9]+)?$/
 
-export const validateTokenAmount = (amount: string, token?: { balance: string; tokenInfo: TokenInfo }) => {
-  if (!token) return
-
+export const validateNumber = (amount: string) => {
   if (isNaN(Number(amount))) {
     return 'The amount must be a number'
   }
 
   if (parseFloat(amount) <= 0) {
     return 'The amount must be greater than 0'
+  }
+}
+
+export const validateTokenAmount = (amount: string, token?: { balance: string; tokenInfo: TokenInfo }) => {
+  if (!token) return
+
+  const numberError = validateNumber(amount)
+  if (numberError) {
+    return numberError
   }
 
   if (toWei(amount, token.tokenInfo.decimals).gt(token.balance)) {
@@ -76,12 +83,9 @@ export const validateTokenAmount = (amount: string, token?: { balance: string; t
 export const validateAmount = (amount: string, decimals?: number, max?: string) => {
   if (!decimals || !max) return
 
-  if (isNaN(Number(amount))) {
-    return 'The amount must be a number'
-  }
-
-  if (parseFloat(amount) <= 0) {
-    return 'The amount must be greater than 0'
+  const numberError = validateNumber(amount)
+  if (numberError) {
+    return numberError
   }
 
   if (toWei(amount, decimals).gt(max)) {


### PR DESCRIPTION
## What it solves

Limited spending limits.

## How this PR fixes it

There is now no upper limit to the token amount when adding a spending limit.

## How to test it

Add a spending limit, select a token and enter an amount higher than that that currently is in the Safe. Observe no error.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/186199460-71b48c34-4a1c-4175-b03b-552c1213efb7.png)