### PR TITLE
fix: add token to remove spending limit modal

### DIFF
--- a/src/components/settings/SpendingLimits/RemoveSpendingLimit/index.tsx
+++ b/src/components/settings/SpendingLimits/RemoveSpendingLimit/index.tsx
@@ -12,6 +12,9 @@ import { SpendingLimitState } from '@/store/spendingLimitsSlice'
 import { relativeTime } from '@/utils/date'
 import { SETTINGS_EVENTS } from '@/services/analytics/events/settings'
 import { trackEvent } from '@/services/analytics/analytics'
+import useBalances from '@/hooks/useBalances'
+import { TokenTransferReview } from '@/components/tx/modals/TokenTransferModal/ReviewTokenTx'
+import { safeFormatUnits } from '@/utils/formatters'
 
 export const RemoveSpendingLimit = ({
   data,
@@ -23,6 +26,8 @@ export const RemoveSpendingLimit = ({
   const { safe } = useSafeInfo()
   const chainId = useChainId()
   const provider = useWeb3()
+  const { balances } = useBalances()
+  const token = balances.items.find((item) => item.tokenInfo.address === data.token)
 
   const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
     const spendingLimitAddress = getSpendingLimitModuleAddress(chainId)
@@ -48,6 +53,12 @@ export const RemoveSpendingLimit = ({
 
   return (
     <SignOrExecuteForm safeTx={safeTx} isExecutable={safe.threshold === 1} onSubmit={onFormSubmit} error={safeTxError}>
+      {token && (
+        <TokenTransferReview
+          amount={safeFormatUnits(data.amount, token.tokenInfo.decimals)}
+          tokenInfo={token.tokenInfo}
+        />
+      )}
       <Typography sx={({ palette }) => ({ color: palette.secondary.light })}>Beneficiary</Typography>
       <EthHashInfo address={data.beneficiary} showCopyButton hasExplorer shortAddress={false} />
       <Typography mt={2} sx={({ palette }) => ({ color: palette.secondary.light })}>


### PR DESCRIPTION
## What it solves

Token not displayed in spending limit removal modal

## How this PR fixes it

The formatted amount of, as well as token logo, is now displayed in the spending limit removal modal.

## How to test it

Remove a spending limit and observe the token at the top of the modal.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/186201678-7f5d90f7-d84d-4bc3-9ce6-8c3511d4eafb.png)