### PR TITLE
fix: add "New owner" label to owner replacement

### DIFF
--- a/src/components/settings/owner/AddOwnerDialog/DialogSteps/ChooseOwnerStep.tsx
+++ b/src/components/settings/owner/AddOwnerDialog/DialogSteps/ChooseOwnerStep.tsx
@@ -69,6 +69,7 @@ export const ChooseOwnerStep = ({
           )}
 
           <Box display="flex" flexDirection="column" gap={2} paddingTop={2}>
+            <Typography>New owner</Typography>
             <FormControl>
               <NameInput
                 label="Owner name"


### PR DESCRIPTION
## What it solves

Unclear owner replacement

## How this PR fixes it

A "New owner" label has been added above the relevant fields.

## How to test it

Open the owner replacement modal and observe the new label.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/186203062-f2b0b454-4c16-49fc-8124-878fcdb4e085.png)
