### PR TITLE
fix: unread badge

### DIFF
--- a/src/components/common/Notifications/index.tsx
+++ b/src/components/common/Notifications/index.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, SyntheticEvent, useCallback, useEffect } from 'react'
 import groupBy from 'lodash/groupBy'
 import { useAppDispatch, useAppSelector } from '@/store'
-import { closeNotification, Notification, selectNotifications } from '@/store/notificationsSlice'
+import { closeNotification, Notification, readNotification, selectNotifications } from '@/store/notificationsSlice'
 import { Alert, AlertColor, Link, Snackbar, SnackbarCloseReason } from '@mui/material'
 import css from './styles.module.css'
 import NextLink from 'next/link'
@@ -38,14 +38,21 @@ const Toast = ({
   variant,
   link,
   onClose,
+  id,
 }: {
-  message: string
   variant: AlertColor
-  link?: Notification['link']
   onClose: () => void
-}) => {
+} & Notification) => {
+  const dispatch = useAppDispatch()
+
   const handleClose = (_: Event | SyntheticEvent, reason?: SnackbarCloseReason) => {
     if (reason === 'clickaway') return
+
+    // Manually closed
+    if (!reason) {
+      dispatch(readNotification({ id }))
+    }
+
     onClose()
   }
 

--- a/src/components/notification-center/NotificationCenter/index.tsx
+++ b/src/components/notification-center/NotificationCenter/index.tsx
@@ -43,10 +43,7 @@ const NotificationCenter = (): ReactElement => {
   const notificationsToShow =
     canExpand && showAll ? chronologicalNotifications : chronologicalNotifications.slice(0, NOTIFICATION_CENTER_LIMIT)
 
-  const unreadCount = useMemo(
-    () => notifications.filter(({ isRead, isDismissed }) => !isRead && isDismissed).length,
-    [notifications],
-  )
+  const unreadCount = useMemo(() => notifications.filter(({ isRead }) => !isRead).length, [notifications])
   const hasUnread = unreadCount > 0
 
   const handleRead = () => {


### PR DESCRIPTION
## What it solves

Closing notifications toggling unread badge.

## How this PR fixes it

Notification center only shows the unread badge if a notification is `!isRead`. When manually closing a notification, it reads a it.

## How to test it

-Open a Safe that requires an update. When the notification opens, observe the unread badge on the notification centre badge. Either opening the notification center or manually closing the notification directly removes the badge.
-Dispatch an autohiding notification (via a transaction) and observe the badge persisting when the notification autohides. Manually closing it removes the badge.

## Screenshots
![notifications](https://user-images.githubusercontent.com/20442784/186341598-a52fd01a-146d-4296-80a4-a6d339917aac.gif)