### PR TITLE
fix: display module names

### DIFF
--- a/src/components/settings/SafeModules/index.tsx
+++ b/src/components/settings/SafeModules/index.tsx
@@ -7,7 +7,6 @@ import { RemoveModule } from '@/components/settings/SafeModules/RemoveModule'
 import useIsGranted from '@/hooks/useIsGranted'
 import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
 import { sameAddress } from '@/utils/addresses'
-import { useMemo } from 'react'
 
 const NoModules = () => {
   return (
@@ -25,14 +24,13 @@ const getModuleName = (chainId: string, address: string): string => {
   return 'Unknown module'
 }
 
-const ModuleDisplay = ({ moduleAddress, chainId }: { moduleAddress: string; chainId: string }) => {
-  const moduleName = useMemo(() => getModuleName(chainId, moduleAddress), [chainId, moduleAddress])
+const ModuleDisplay = ({ moduleAddress, chainId, name }: { moduleAddress: string; chainId: string; name: string }) => {
   const isGranted = useIsGranted()
 
   return (
     <Box className={css.container}>
       <EthHashInfo
-        name={moduleName}
+        name={name}
         shortAddress={false}
         address={moduleAddress}
         showCopyButton
@@ -71,7 +69,12 @@ const SafeModules = () => {
               <NoModules />
             ) : (
               safeModules.map((module) => (
-                <ModuleDisplay key={module.value} chainId={safe.chainId} moduleAddress={module.value} />
+                <ModuleDisplay
+                  key={module.value}
+                  chainId={safe.chainId}
+                  moduleAddress={module.value}
+                  name={module.name || getModuleName(safe.chainId, module.value)}
+                />
               ))
             )}
           </Box>

--- a/src/components/settings/SafeModules/index.tsx
+++ b/src/components/settings/SafeModules/index.tsx
@@ -5,6 +5,9 @@ import { Paper, Grid, Typography, Box, Link } from '@mui/material'
 import css from './styles.module.css'
 import { RemoveModule } from '@/components/settings/SafeModules/RemoveModule'
 import useIsGranted from '@/hooks/useIsGranted'
+import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
+import { sameAddress } from '@/utils/addresses'
+import { useMemo } from 'react'
 
 const NoModules = () => {
   return (
@@ -14,12 +17,22 @@ const NoModules = () => {
   )
 }
 
+const getModuleName = (chainId: string, address: string): string => {
+  if (sameAddress(getSpendingLimitModuleAddress(chainId), address)) {
+    return 'Spending limit module'
+  }
+
+  return 'Unknown module'
+}
+
 const ModuleDisplay = ({ moduleAddress, chainId }: { moduleAddress: string; chainId: string }) => {
+  const moduleName = useMemo(() => getModuleName(chainId, moduleAddress), [chainId, moduleAddress])
   const isGranted = useIsGranted()
 
   return (
     <Box className={css.container}>
       <EthHashInfo
+        name={moduleName}
         shortAddress={false}
         address={moduleAddress}
         showCopyButton


### PR DESCRIPTION
## What it solves

Unnamed modules

## How this PR fixes it

When a known module is added, i.e. spending limit module, they are listed without a name. This means that the module could theoretically be removed, removing set spending limits in turn. This adds either "Spending limit module", or "Unknown module" in the module list (if there is no address book entry for said address).

## How to test it

Enable a spending limit and navigate to the modules settings of the Safe. Observe the "Spending limit module" name now shown.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/186343709-ac84f91a-1b35-4286-93f4-bab7e764c58b.png)