### PR TITLE
PoC: refactor: breadcrumbs

### DIFF
--- a/src/components/common/Breadcrumbs/index.tsx
+++ b/src/components/common/Breadcrumbs/index.tsx
@@ -2,21 +2,33 @@ import React from 'react'
 import { Typography } from '@mui/material'
 import css from './styles.module.css'
 import Link from 'next/link'
+import { NextRouter, useRouter } from 'next/router'
+
+const getParentPath = ({ pathname, query }: NextRouter) => {
+  const parent = pathname.split('/')?.slice(0, -1).join('/')
+  return {
+    pathname: parent,
+    query,
+  }
+}
 
 type Props = {
   Icon: React.FC<React.SVGProps<SVGSVGElement>>
   first: string
   second?: string
-  firstLink?: string
 }
-export const Breadcrumbs = ({ Icon, first, second, firstLink }: Props) => {
+export const Breadcrumbs = ({ Icon, first, second }: Props) => {
+  const router = useRouter()
+
+  const link = second ? getParentPath(router) : undefined
+
   return (
     <div className={css.container}>
       <Icon className={css.icon} />
 
       <Typography className={css.text}>
-        {firstLink ? (
-          <Link href={firstLink} passHref>
+        {link ? (
+          <Link href={link} passHref>
             <a>{first}</a>
           </Link>
         ) : (

--- a/src/components/common/Redirect/index.tsx
+++ b/src/components/common/Redirect/index.tsx
@@ -1,0 +1,14 @@
+import { useLayoutEffect } from 'react'
+import { useRouter } from 'next/router'
+
+const Redirect = ({ pathname }: { pathname: string }) => {
+  const router = useRouter()
+
+  useLayoutEffect(() => {
+    router.replace({ pathname, query: router.query })
+  }, [])
+
+  return null
+}
+
+export default Redirect

--- a/src/components/common/Redirect/index.tsx
+++ b/src/components/common/Redirect/index.tsx
@@ -6,7 +6,7 @@ const Redirect = ({ pathname }: { pathname: string }) => {
 
   useLayoutEffect(() => {
     router.replace({ pathname, query: router.query })
-  }, [])
+  }, [pathname, router])
 
   return null
 }

--- a/src/pages/safe/settings/index.tsx
+++ b/src/pages/safe/settings/index.tsx
@@ -1,3 +1,10 @@
-import SetupPage from './setup'
+import type { ReactElement } from 'react'
 
-export default SetupPage
+import Redirect from '@/components/common/Redirect'
+import { AppRoutes } from '@/config/routes'
+
+const Settings = (): ReactElement => {
+  return <Redirect pathname={AppRoutes.safe.settings.setup} />
+}
+
+export default Settings

--- a/src/pages/safe/transactions/index.tsx
+++ b/src/pages/safe/transactions/index.tsx
@@ -1,3 +1,10 @@
-import HistoryPage from './history'
+import type { ReactElement } from 'react'
 
-export default HistoryPage
+import Redirect from '@/components/common/Redirect'
+import { AppRoutes } from '@/config/routes'
+
+const Transactions = (): ReactElement => {
+  return <Redirect pathname={AppRoutes.safe.transactions.history} />
+}
+
+export default Transactions

--- a/src/pages/safe/transactions/tx.tsx
+++ b/src/pages/safe/transactions/tx.tsx
@@ -21,7 +21,6 @@ import { Breadcrumbs } from '@/components/common/Breadcrumbs'
 import TransactionsIcon from '@/public/images/sidebar/transactions.svg'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { sameAddress } from '@/utils/addresses'
-import { AppRoutes } from '@/config/routes'
 
 const SingleTxGrid = ({ txDetails }: { txDetails: TransactionDetails }): ReactElement => {
   const tx: Transaction = makeTxFromDetails(txDetails)
@@ -51,7 +50,6 @@ const SingleTransaction: NextPage = () => {
   )
 
   const isCurrentSafeTx = sameAddress(txDetails?.safeAddress, safeAddress)
-  const breadcrumbsLink = `${AppRoutes.safe.transactions.index}?safe=${safeAddress}`
 
   return (
     <main>
@@ -59,7 +57,7 @@ const SingleTransaction: NextPage = () => {
         <title>Safe – Transaction details</title>
       </Head>
 
-      <Breadcrumbs Icon={TransactionsIcon} first="Transactions" second="Details" firstLink={breadcrumbsLink} />
+      <Breadcrumbs Icon={TransactionsIcon} first="Transactions" second="Details" />
 
       {(error || !isCurrentSafeTx) && !loading ? (
         <ErrorMessage error={error}>Failed to load transaction {transactionId}</ErrorMessage>


### PR DESCRIPTION
## What it solves

Automatic breadcrumb links

## How this PR fixes it

If a `props.second` exists in the `<Breadcrumb>` component, the parent `pathname` is programmatically determined and assigned as the `props.first` `link`.

A `<Redirect>` component is also responsible for navigating the user to default pages.

## How to test it

- Click on the "Transactions" breadcrumb in the queue, history and singular transaction view. Observe that the destination is the history list.
- Click on the "Settings" breadcrumb in the settings. Observe that the destination is the setup settings.

## Screenshots
![breadcrumbs](https://user-images.githubusercontent.com/20442784/186345723-098d95b9-01bd-41ce-a5cc-da4bcf4f7b47.gif)