### PR TITLE
fix: adjust number formatters + "Max" spending limit

### DIFF
--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -1,7 +1,7 @@
 import { SAFE_TOKEN_ADDRESSES } from '@/config/constants'
 import useBalances from '@/hooks/useBalances'
 import useChainId from '@/hooks/useChainId'
-import { toDecimals } from '@/utils/formatters'
+import { formatUnits } from 'ethers/lib/utils'
 import { Box, ButtonBase, Skeleton, Typography } from '@mui/material'
 
 import SafeTokenIcon from './safe_token.svg'
@@ -23,9 +23,8 @@ const SafeTokenWidget = () => {
 
   const safeBalance = balances.balances.items.find((balanceItem) => balanceItem.tokenInfo.address === tokenAddress)
 
-  const safeBalanceDecimals = Math.floor(
-    toDecimals(safeBalance?.balance || '0', safeBalance?.tokenInfo.decimals),
-  ).toFixed(0)
+  const safeBalanceDecimals = Number(formatUnits(safeBalance?.balance || 0, safeBalance?.tokenInfo.decimals))
+  const flooeredSafeBalance = Math.floor(safeBalanceDecimals).toFixed(0)
 
   return (
     <Box className={css.buttonContainer}>
@@ -38,7 +37,7 @@ const SafeTokenWidget = () => {
         <SafeTokenIcon />
 
         <Typography lineHeight="16px" fontWeight={700}>
-          {balances.loading ? <Skeleton variant="text" width={16} /> : safeBalanceDecimals}
+          {balances.loading ? <Skeleton variant="text" width={16} /> : flooeredSafeBalance}
         </Typography>
       </ButtonBase>
     </Box>

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -1,7 +1,7 @@
 import { SAFE_TOKEN_ADDRESSES } from '@/config/constants'
 import useBalances from '@/hooks/useBalances'
 import useChainId from '@/hooks/useChainId'
-import { formatUnits } from 'ethers/lib/utils'
+import { safeFormatUnits } from '@/utils/formatters'
 import { Box, ButtonBase, Skeleton, Typography } from '@mui/material'
 
 import SafeTokenIcon from './safe_token.svg'
@@ -23,8 +23,8 @@ const SafeTokenWidget = () => {
 
   const safeBalance = balances.balances.items.find((balanceItem) => balanceItem.tokenInfo.address === tokenAddress)
 
-  const safeBalanceDecimals = Number(formatUnits(safeBalance?.balance || 0, safeBalance?.tokenInfo.decimals))
-  const flooeredSafeBalance = Math.floor(safeBalanceDecimals).toFixed(0)
+  const safeBalanceDecimals = Number(safeFormatUnits(safeBalance?.balance || 0, safeBalance?.tokenInfo.decimals))
+  const flooredSafeBalance = Math.floor(safeBalanceDecimals).toFixed(0)
 
   return (
     <Box className={css.buttonContainer}>
@@ -37,7 +37,7 @@ const SafeTokenWidget = () => {
         <SafeTokenIcon />
 
         <Typography lineHeight="16px" fontWeight={700}>
-          {balances.loading ? <Skeleton variant="text" width={16} /> : flooeredSafeBalance}
+          {balances.loading ? <Skeleton variant="text" width={16} /> : flooredSafeBalance}
         </Typography>
       </ButtonBase>
     </Box>

--- a/src/components/common/TokenAmount/index.tsx
+++ b/src/components/common/TokenAmount/index.tsx
@@ -1,6 +1,5 @@
 import { type ReactElement } from 'react'
 import { TransferDirection } from '@gnosis.pm/safe-react-gateway-sdk'
-import { formatAmount } from '@/utils/formatNumber'
 import css from './styles.module.css'
 import { safeFormatUnits } from '@/utils/formatters'
 import ImageFallback from '../ImageFallback'
@@ -51,7 +50,7 @@ const TokenAmount = ({
 
       <span>
         {sign}
-        {formatAmount(amount)} <span className={css.symbol}>{tokenSymbol}</span>
+        {amount} <span className={css.symbol}>{tokenSymbol}</span>
       </span>
     </span>
   )

--- a/src/components/common/TokenAmount/index.tsx
+++ b/src/components/common/TokenAmount/index.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement } from 'react'
 import { TransferDirection } from '@gnosis.pm/safe-react-gateway-sdk'
 import css from './styles.module.css'
-import { safeFormatUnits } from '@/utils/formatters'
+import { safeFormatAmount } from '@/utils/formatters'
 import ImageFallback from '../ImageFallback'
 
 export const TokenIcon = ({
@@ -42,7 +42,7 @@ const TokenAmount = ({
   direction?: TransferDirection
 }): ReactElement => {
   const sign = direction === TransferDirection.OUTGOING ? '-' : ''
-  const amount = decimals ? safeFormatUnits(value, decimals) : value
+  const amount = decimals ? safeFormatAmount(value, decimals) : value
 
   return (
     <span className={css.container}>

--- a/src/components/common/TokenAmount/index.tsx
+++ b/src/components/common/TokenAmount/index.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement } from 'react'
 import { TransferDirection } from '@gnosis.pm/safe-react-gateway-sdk'
 import css from './styles.module.css'
-import { safeFormatAmount } from '@/utils/formatters'
+import { formatVisualAmount } from '@/utils/formatters'
 import ImageFallback from '../ImageFallback'
 
 export const TokenIcon = ({
@@ -42,7 +42,7 @@ const TokenAmount = ({
   direction?: TransferDirection
 }): ReactElement => {
   const sign = direction === TransferDirection.OUTGOING ? '-' : ''
-  const amount = decimals ? safeFormatAmount(value, decimals) : value
+  const amount = decimals ? formatVisualAmount(value, decimals) : value
 
   return (
     <span className={css.container}>

--- a/src/components/create-safe/steps/ReviewStep.tsx
+++ b/src/components/create-safe/steps/ReviewStep.tsx
@@ -6,7 +6,7 @@ import { StepRenderProps } from '@/components/tx/TxStepper/useTxStepper'
 import useGasPrice from '@/hooks/useGasPrice'
 import useWallet from '@/hooks/wallets/useWallet'
 import { useWeb3 } from '@/hooks/wallets/web3'
-import { safeFormatAmount } from '@/utils/formatters'
+import { formatVisualAmount } from '@/utils/formatters'
 import { Box, Button, Divider, Grid, Paper, Typography } from '@mui/material'
 import { useMemo } from 'react'
 import { useEstimateSafeCreationGas } from '../useEstimateSafeCreationGas'
@@ -39,7 +39,7 @@ const ReviewStep = ({ params, onSubmit, setStep, onBack }: Props) => {
 
   const totalFee =
     gasLimit && maxFeePerGas && maxPriorityFeePerGas
-      ? safeFormatAmount(maxFeePerGas.add(maxPriorityFeePerGas).mul(gasLimit), chain?.nativeCurrency.decimals)
+      ? formatVisualAmount(maxFeePerGas.add(maxPriorityFeePerGas).mul(gasLimit), chain?.nativeCurrency.decimals)
       : '> 0.001'
 
   const createSafe = async () => {

--- a/src/components/create-safe/steps/ReviewStep.tsx
+++ b/src/components/create-safe/steps/ReviewStep.tsx
@@ -6,7 +6,7 @@ import { StepRenderProps } from '@/components/tx/TxStepper/useTxStepper'
 import useGasPrice from '@/hooks/useGasPrice'
 import useWallet from '@/hooks/wallets/useWallet'
 import { useWeb3 } from '@/hooks/wallets/web3'
-import { safeFormatUnits } from '@/utils/formatters'
+import { safeFormatAmount } from '@/utils/formatters'
 import { Box, Button, Divider, Grid, Paper, Typography } from '@mui/material'
 import { useMemo } from 'react'
 import { useEstimateSafeCreationGas } from '../useEstimateSafeCreationGas'
@@ -39,7 +39,7 @@ const ReviewStep = ({ params, onSubmit, setStep, onBack }: Props) => {
 
   const totalFee =
     gasLimit && maxFeePerGas && maxPriorityFeePerGas
-      ? safeFormatUnits(maxFeePerGas.add(maxPriorityFeePerGas).mul(gasLimit), chain?.nativeCurrency.decimals)
+      ? safeFormatAmount(maxFeePerGas.add(maxPriorityFeePerGas).mul(gasLimit), chain?.nativeCurrency.decimals)
       : '> 0.001'
 
   const createSafe = async () => {

--- a/src/components/settings/SpendingLimits/NewSpendingLimit/steps/ReviewSpendingLimit.tsx
+++ b/src/components/settings/SpendingLimits/NewSpendingLimit/steps/ReviewSpendingLimit.tsx
@@ -12,7 +12,7 @@ import { selectSpendingLimits, SpendingLimitState } from '@/store/spendingLimits
 import { createAddDelegateTx, createResetAllowanceTx, createSetAllowanceTx } from '@/services/tx/spendingLimitParams'
 import { getResetTimeOptions } from '@/components/transactions/TxDetails/TxData/SpendingLimits'
 import { BigNumber } from '@ethersproject/bignumber'
-import { safeFormatUnits } from '@/utils/formatters'
+import { safeFormatAmount } from '@/utils/formatters'
 import { currentMinutes, relativeTime } from '@/utils/date'
 import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
@@ -125,7 +125,7 @@ export const ReviewSpendingLimit = ({ data, onSubmit }: Props) => {
           {!!existingSpendingLimit && (
             <>
               <Typography color="error" sx={{ textDecoration: 'line-through' }} component="span" fontSize={20}>
-                {safeFormatUnits(BigNumber.from(existingSpendingLimit.amount), decimals)} {symbol}
+                {safeFormatAmount(BigNumber.from(existingSpendingLimit.amount), decimals)} {symbol}
               </Typography>
               {' → '}
             </>

--- a/src/components/settings/SpendingLimits/NewSpendingLimit/steps/ReviewSpendingLimit.tsx
+++ b/src/components/settings/SpendingLimits/NewSpendingLimit/steps/ReviewSpendingLimit.tsx
@@ -12,7 +12,7 @@ import { selectSpendingLimits, SpendingLimitState } from '@/store/spendingLimits
 import { createAddDelegateTx, createResetAllowanceTx, createSetAllowanceTx } from '@/services/tx/spendingLimitParams'
 import { getResetTimeOptions } from '@/components/transactions/TxDetails/TxData/SpendingLimits'
 import { BigNumber } from '@ethersproject/bignumber'
-import { safeFormatAmount } from '@/utils/formatters'
+import { formatVisualAmount } from '@/utils/formatters'
 import { currentMinutes, relativeTime } from '@/utils/date'
 import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
@@ -125,7 +125,7 @@ export const ReviewSpendingLimit = ({ data, onSubmit }: Props) => {
           {!!existingSpendingLimit && (
             <>
               <Typography color="error" sx={{ textDecoration: 'line-through' }} component="span" fontSize={20}>
-                {safeFormatAmount(BigNumber.from(existingSpendingLimit.amount), decimals)} {symbol}
+                {formatVisualAmount(BigNumber.from(existingSpendingLimit.amount), decimals)} {symbol}
               </Typography>
               {' → '}
             </>

--- a/src/components/settings/SpendingLimits/NewSpendingLimit/steps/SpendingLimitForm.tsx
+++ b/src/components/settings/SpendingLimits/NewSpendingLimit/steps/SpendingLimitForm.tsx
@@ -16,10 +16,8 @@ import {
   FormGroup,
 } from '@mui/material'
 import AddressBookInput from '@/components/common/AddressBookInput'
-import InputValueHelper from '@/components/common/InputValueHelper'
 import { validateTokenAmount } from '@/utils/validation'
 import useBalances from '@/hooks/useBalances'
-import { formatDecimals } from '@/utils/formatters'
 import { AutocompleteItem } from '@/components/tx/modals/TokenTransferModal/SendAssetsForm'
 import useChainId from '@/hooks/useChainId'
 import { getResetTimeOptions } from '@/components/transactions/TxDetails/TxData/SpendingLimits'
@@ -52,7 +50,6 @@ export const SpendingLimitForm = ({ data, onSubmit }: Props) => {
     handleSubmit,
     setValue,
     watch,
-    trigger,
     control,
     formState: { errors },
   } = formMethods
@@ -61,12 +58,6 @@ export const SpendingLimitForm = ({ data, onSubmit }: Props) => {
   const selectedToken = tokenAddress
     ? balances.items.find((item) => item.tokenInfo.address === tokenAddress)
     : undefined
-
-  const onMaxAmountClick = () => {
-    if (!selectedToken) return
-    setValue('amount', formatDecimals(selectedToken.balance, selectedToken.tokenInfo.decimals))
-    trigger('amount')
-  }
 
   const toggleResetTime = () => {
     setValue('resetTime', showResetTime ? '0' : resetTimeOptions[0].value)
@@ -106,17 +97,6 @@ export const SpendingLimitForm = ({ data, onSubmit }: Props) => {
               label={errors.amount?.message || 'Amount'}
               error={!!errors.amount}
               autoComplete="off"
-              InputProps={{
-                endAdornment: (
-                  <InputValueHelper onClick={onMaxAmountClick} disabled={!selectedToken}>
-                    Max
-                  </InputValueHelper>
-                ),
-              }}
-              // @see https://github.com/react-hook-form/react-hook-form/issues/220
-              InputLabelProps={{
-                shrink: !!watch('amount'),
-              }}
               {...register('amount', {
                 required: true,
                 validate: (val) => validateTokenAmount(val, selectedToken),

--- a/src/components/settings/SpendingLimits/SpendingLimitsTable.tsx
+++ b/src/components/settings/SpendingLimits/SpendingLimitsTable.tsx
@@ -1,7 +1,7 @@
 import EnhancedTable from '@/components/common/EnhancedTable'
 import useBalances from '@/hooks/useBalances'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
-import { safeFormatUnits } from '@/utils/formatters'
+import { safeFormatAmount } from '@/utils/formatters'
 import { Box, IconButton } from '@mui/material'
 import { relativeTime } from '@/utils/date'
 import EthHashInfo from '@/components/common/EthHashInfo'
@@ -46,7 +46,7 @@ export const SpendingLimitsTable = ({ spendingLimits }: { spendingLimits: Spendi
       spendingLimits.map((spendingLimit) => {
         const token = balances.items.find((item) => item.tokenInfo.address === spendingLimit.token)
         const amount = BigNumber.from(spendingLimit.amount)
-        const formattedAmount = safeFormatUnits(amount, token?.tokenInfo.decimals)
+        const formattedAmount = safeFormatAmount(amount, token?.tokenInfo.decimals)
 
         return {
           beneficiary: {

--- a/src/components/settings/SpendingLimits/SpendingLimitsTable.tsx
+++ b/src/components/settings/SpendingLimits/SpendingLimitsTable.tsx
@@ -1,7 +1,7 @@
 import EnhancedTable from '@/components/common/EnhancedTable'
 import useBalances from '@/hooks/useBalances'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
-import { safeFormatAmount } from '@/utils/formatters'
+import { formatVisualAmount } from '@/utils/formatters'
 import { Box, IconButton } from '@mui/material'
 import { relativeTime } from '@/utils/date'
 import EthHashInfo from '@/components/common/EthHashInfo'
@@ -46,7 +46,7 @@ export const SpendingLimitsTable = ({ spendingLimits }: { spendingLimits: Spendi
       spendingLimits.map((spendingLimit) => {
         const token = balances.items.find((item) => item.tokenInfo.address === spendingLimit.token)
         const amount = BigNumber.from(spendingLimit.amount)
-        const formattedAmount = safeFormatAmount(amount, token?.tokenInfo.decimals)
+        const formattedAmount = formatVisualAmount(amount, token?.tokenInfo.decimals)
 
         return {
           beneficiary: {

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -2,7 +2,7 @@ import { HexEncodedData } from '@/components/transactions/HexEncodedData'
 import { MethodDetails } from '@/components/transactions/TxDetails/TxData/DecodedData/MethodDetails'
 import MultisendTxsDecoded from '@/components/transactions/TxDetails/TxData/DecodedData/Multisend/MultisendTxsDecoded'
 import { useCurrentChain } from '@/hooks/useChains'
-import { toWei } from '@/utils/formatters'
+import { safeFormatAmount } from '@/utils/formatters'
 import { TransactionData } from '@gnosis.pm/safe-react-gateway-sdk'
 import { ReactElement } from 'react'
 
@@ -30,7 +30,7 @@ export const Multisend = ({ txData }: MultisendProps): ReactElement | null => {
         const actionTitle = `Action ${index + 1}`
         const method = dataDecoded?.method || ''
         const { decimals, symbol } = chain!.nativeCurrency
-        const amount = value ? toWei(value, decimals) : 0
+        const amount = value ? safeFormatAmount(value, decimals) : 0
 
         let details
         if (dataDecoded) {

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -2,7 +2,7 @@ import { HexEncodedData } from '@/components/transactions/HexEncodedData'
 import { MethodDetails } from '@/components/transactions/TxDetails/TxData/DecodedData/MethodDetails'
 import MultisendTxsDecoded from '@/components/transactions/TxDetails/TxData/DecodedData/Multisend/MultisendTxsDecoded'
 import { useCurrentChain } from '@/hooks/useChains'
-import { safeFormatAmount } from '@/utils/formatters'
+import { formatVisualAmount } from '@/utils/formatters'
 import { TransactionData } from '@gnosis.pm/safe-react-gateway-sdk'
 import { ReactElement } from 'react'
 
@@ -30,7 +30,7 @@ export const Multisend = ({ txData }: MultisendProps): ReactElement | null => {
         const actionTitle = `Action ${index + 1}`
         const method = dataDecoded?.method || ''
         const { decimals, symbol } = chain!.nativeCurrency
-        const amount = value ? safeFormatAmount(value, decimals) : 0
+        const amount = value ? formatVisualAmount(value, decimals) : 0
 
         let details
         if (dataDecoded) {

--- a/src/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
@@ -8,7 +8,7 @@ import { useCurrentChain } from '@/hooks/useChains'
 import { selectTokens } from '@/store/balancesSlice'
 import { useAppSelector } from '@/store'
 import { sameAddress } from '@/utils/addresses'
-import { formatDecimals } from '@/utils/formatters'
+import { safeFormatAmount } from '@/utils/formatters'
 import { isSetAllowance, SpendingLimitMethods } from '@/utils/transaction-guards'
 import css from './styles.module.css'
 import chains from '@/config/chains'
@@ -71,7 +71,7 @@ export const SpendingLimits = ({ txData, txInfo, type }: SpendingLimitsProps): R
             <>
               {tokenInfo ? (
                 <Typography>
-                  {formatDecimals(amount as string, tokenInfo.decimals)} {tokenInfo.symbol}
+                  {safeFormatAmount(amount as string, tokenInfo.decimals)} {tokenInfo.symbol}
                 </Typography>
               ) : (
                 <Typography>{amount}</Typography>

--- a/src/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
@@ -8,7 +8,7 @@ import { useCurrentChain } from '@/hooks/useChains'
 import { selectTokens } from '@/store/balancesSlice'
 import { useAppSelector } from '@/store'
 import { sameAddress } from '@/utils/addresses'
-import { safeFormatAmount } from '@/utils/formatters'
+import { formatVisualAmount } from '@/utils/formatters'
 import { isSetAllowance, SpendingLimitMethods } from '@/utils/transaction-guards'
 import css from './styles.module.css'
 import chains from '@/config/chains'
@@ -71,7 +71,7 @@ export const SpendingLimits = ({ txData, txInfo, type }: SpendingLimitsProps): R
             <>
               {tokenInfo ? (
                 <Typography>
-                  {safeFormatAmount(amount as string, tokenInfo.decimals)} {tokenInfo.symbol}
+                  {formatVisualAmount(amount as string, tokenInfo.decimals)} {tokenInfo.symbol}
                 </Typography>
               ) : (
                 <Typography>{amount}</Typography>

--- a/src/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
@@ -29,7 +29,7 @@ export const SpendingLimits = ({ txData, txInfo, type }: SpendingLimitsProps): R
 
   const resetTimeLabel = useMemo(
     () => getResetTimeOptions(chain?.chainId).find(({ value }) => +value === +resetTimeMin)?.label,
-    [chain?.chainName, resetTimeMin],
+    [chain?.chainId, resetTimeMin],
   )
   const tokenInfo = useMemo(
     () => tokens.find(({ address }) => sameAddress(address, tokenAddress as string)),

--- a/src/components/transactions/TxDetails/TxData/Transfer/TransferActions.tsx
+++ b/src/components/transactions/TxDetails/TxData/Transfer/TransferActions.tsx
@@ -13,17 +13,18 @@ import css from '@/components/sidebar/SafeListContextMenu/styles.module.css'
 import TokenTransferModal from '@/components/tx/modals/TokenTransferModal'
 import { Transfer, TransferDirection } from '@gnosis.pm/safe-react-gateway-sdk'
 import { ZERO_ADDRESS } from '@gnosis.pm/safe-core-sdk/dist/src/utils/constants'
-import { formatEther } from '@ethersproject/units'
-import { formatUnits } from 'ethers/lib/utils'
 import { isERC20Transfer, isNativeTokenTransfer } from '@/utils/transaction-guards'
 import useIsGranted from '@/hooks/useIsGranted'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 import { trackEvent } from '@/services/analytics/analytics'
+import { safeFormatUnits } from '@/utils/formatters'
 
 enum ModalType {
   SEND_AGAIN = 'SEND_AGAIN',
   ADD_TO_AB = 'ADD_TO_AB',
 }
+
+const ETHER = 'ether'
 
 const defaultOpen = { [ModalType.SEND_AGAIN]: false, [ModalType.ADD_TO_AB]: false }
 
@@ -63,9 +64,9 @@ const TransferActions = ({ address, txInfo }: { address: string; txInfo: Transfe
   const tokenAddress = isNativeTokenTransfer(txInfo.transferInfo) ? ZERO_ADDRESS : txInfo.transferInfo.tokenAddress
 
   const amount = isNativeTokenTransfer(txInfo.transferInfo)
-    ? formatEther(txInfo.transferInfo.value)
+    ? safeFormatUnits(txInfo.transferInfo.value, ETHER)
     : isERC20Transfer(txInfo.transferInfo)
-    ? formatUnits(txInfo.transferInfo.value, txInfo.transferInfo.decimals)
+    ? safeFormatUnits(txInfo.transferInfo.value, txInfo.transferInfo.decimals)
     : undefined
 
   const isOutgoingTx = txInfo.direction.toUpperCase() === TransferDirection.OUTGOING

--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, SyntheticEvent, useState } from 'react'
 import { Accordion, AccordionDetails, AccordionSummary, Skeleton, Typography, Link, Grid } from '@mui/material'
 import { useCurrentChain } from '@/hooks/useChains'
-import { safeFormatAmount } from '@/utils/formatters'
+import { formatVisualAmount } from '@/utils/formatters'
 import { type AdvancedParameters } from '../AdvancedParams/types'
 import Track from '@/components/common/Track'
 import { MODALS_EVENTS } from '@/services/analytics/events/modals'
@@ -40,13 +40,13 @@ const GasParams = ({ params, isExecution, onEdit }: GasParamsProps): ReactElemen
 
   // Total gas cost
   const totalFee = !isLoading
-    ? safeFormatAmount(maxFeePerGas.add(maxPriorityFeePerGas).mul(gasLimit), chain?.nativeCurrency.decimals)
+    ? formatVisualAmount(maxFeePerGas.add(maxPriorityFeePerGas).mul(gasLimit), chain?.nativeCurrency.decimals)
     : '> 0.001'
 
   // Individual gas params
   const gasLimitString = gasLimit?.toString() || ''
-  const maxFeePerGasGwei = maxFeePerGas ? safeFormatAmount(maxFeePerGas) : ''
-  const maxPrioGasGwei = maxPriorityFeePerGas ? safeFormatAmount(maxPriorityFeePerGas) : ''
+  const maxFeePerGasGwei = maxFeePerGas ? formatVisualAmount(maxFeePerGas) : ''
+  const maxPrioGasGwei = maxPriorityFeePerGas ? formatVisualAmount(maxPriorityFeePerGas) : ''
 
   const onEditClick = (e: SyntheticEvent) => {
     e.preventDefault()

--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, SyntheticEvent, useState } from 'react'
 import { Accordion, AccordionDetails, AccordionSummary, Skeleton, Typography, Link, Grid } from '@mui/material'
 import { useCurrentChain } from '@/hooks/useChains'
-import { safeFormatUnits } from '@/utils/formatters'
+import { safeFormatAmount } from '@/utils/formatters'
 import { type AdvancedParameters } from '../AdvancedParams/types'
 import Track from '@/components/common/Track'
 import { MODALS_EVENTS } from '@/services/analytics/events/modals'
@@ -40,13 +40,13 @@ const GasParams = ({ params, isExecution, onEdit }: GasParamsProps): ReactElemen
 
   // Total gas cost
   const totalFee = !isLoading
-    ? safeFormatUnits(maxFeePerGas.add(maxPriorityFeePerGas).mul(gasLimit), chain?.nativeCurrency.decimals)
+    ? safeFormatAmount(maxFeePerGas.add(maxPriorityFeePerGas).mul(gasLimit), chain?.nativeCurrency.decimals)
     : '> 0.001'
 
   // Individual gas params
   const gasLimitString = gasLimit?.toString() || ''
-  const maxFeePerGasGwei = maxFeePerGas ? safeFormatUnits(maxFeePerGas) : ''
-  const maxPrioGasGwei = maxPriorityFeePerGas ? safeFormatUnits(maxPriorityFeePerGas) : ''
+  const maxFeePerGasGwei = maxFeePerGas ? safeFormatAmount(maxFeePerGas) : ''
+  const maxPrioGasGwei = maxPriorityFeePerGas ? safeFormatAmount(maxPriorityFeePerGas) : ''
 
   const onEditClick = (e: SyntheticEvent) => {
     e.preventDefault()

--- a/src/components/tx/SendFromBlock/index.tsx
+++ b/src/components/tx/SendFromBlock/index.tsx
@@ -2,7 +2,7 @@ import { type ReactElement } from 'react'
 import css from './styles.module.css'
 import useBalances from '@/hooks/useBalances'
 import useSafeAddress from '@/hooks/useSafeAddress'
-import { formatDecimals } from '@/utils/formatters'
+import { safeFormatAmount } from '@/utils/formatters'
 import { Box, Typography } from '@mui/material'
 import EthHashInfo from '@/components/common/EthHashInfo'
 
@@ -10,7 +10,7 @@ const SendFromBlock = (): ReactElement => {
   const address = useSafeAddress()
   const { balances } = useBalances()
   const nativeToken = balances.items.find((item) => parseInt(item.tokenInfo.address, 16) === 0)
-  const nativeTokenBalance = nativeToken ? formatDecimals(nativeToken.balance, nativeToken.tokenInfo.decimals) : '0'
+  const nativeTokenBalance = nativeToken ? safeFormatAmount(nativeToken.balance, nativeToken.tokenInfo.decimals) : '0'
 
   return (
     <Box sx={{ borderBottom: ({ palette }) => `1px solid ${palette.divider}` }} pb={2} mb={2}>

--- a/src/components/tx/SendFromBlock/index.tsx
+++ b/src/components/tx/SendFromBlock/index.tsx
@@ -2,7 +2,7 @@ import { type ReactElement } from 'react'
 import css from './styles.module.css'
 import useBalances from '@/hooks/useBalances'
 import useSafeAddress from '@/hooks/useSafeAddress'
-import { safeFormatAmount } from '@/utils/formatters'
+import { formatVisualAmount } from '@/utils/formatters'
 import { Box, Typography } from '@mui/material'
 import EthHashInfo from '@/components/common/EthHashInfo'
 
@@ -10,7 +10,7 @@ const SendFromBlock = (): ReactElement => {
   const address = useSafeAddress()
   const { balances } = useBalances()
   const nativeToken = balances.items.find((item) => parseInt(item.tokenInfo.address, 16) === 0)
-  const nativeTokenBalance = nativeToken ? safeFormatAmount(nativeToken.balance, nativeToken.tokenInfo.decimals) : '0'
+  const nativeTokenBalance = nativeToken ? formatVisualAmount(nativeToken.balance, nativeToken.tokenInfo.decimals) : '0'
 
   return (
     <Box sx={{ borderBottom: ({ palette }) => `1px solid ${palette.divider}` }} pb={2} mb={2}>

--- a/src/components/tx/SpendingLimitRow/index.tsx
+++ b/src/components/tx/SpendingLimitRow/index.tsx
@@ -1,6 +1,6 @@
 import { FormControl, FormControlLabel, Radio, RadioGroup, Typography } from '@mui/material'
 import { Controller, useFormContext } from 'react-hook-form'
-import { safeFormatUnits } from '@/utils/formatters'
+import { safeFormatAmount } from '@/utils/formatters'
 import { TokenInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { SpendingLimitState } from '@/store/spendingLimitsSlice'
 import { SendAssetsField, SendTxType } from '@/components/tx/modals/TokenTransferModal/SendAssetsForm'
@@ -14,7 +14,7 @@ const SpendingLimitRow = ({
 }) => {
   const { control } = useFormContext()
 
-  const formattedAmount = safeFormatUnits(spendingLimit.amount, selectedToken?.decimals)
+  const formattedAmount = safeFormatAmount(spendingLimit.amount, selectedToken?.decimals)
 
   return (
     <>

--- a/src/components/tx/SpendingLimitRow/index.tsx
+++ b/src/components/tx/SpendingLimitRow/index.tsx
@@ -1,6 +1,6 @@
 import { FormControl, FormControlLabel, Radio, RadioGroup, Typography } from '@mui/material'
 import { Controller, useFormContext } from 'react-hook-form'
-import { safeFormatAmount } from '@/utils/formatters'
+import { formatVisualAmount } from '@/utils/formatters'
 import { TokenInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { SpendingLimitState } from '@/store/spendingLimitsSlice'
 import { SendAssetsField, SendTxType } from '@/components/tx/modals/TokenTransferModal/SendAssetsForm'
@@ -14,7 +14,7 @@ const SpendingLimitRow = ({
 }) => {
   const { control } = useFormContext()
 
-  const formattedAmount = safeFormatAmount(spendingLimit.amount, selectedToken?.decimals)
+  const formattedAmount = formatVisualAmount(spendingLimit.amount, selectedToken?.decimals)
 
   return (
     <>

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -12,6 +12,7 @@ import {
   DialogContent,
 } from '@mui/material'
 import { type TokenInfo } from '@gnosis.pm/safe-react-gateway-sdk'
+import { formatUnits } from 'ethers/lib/utils'
 
 import { TokenIcon } from '@/components/common/TokenAmount'
 import { formatDecimals } from '@/utils/formatters'
@@ -89,7 +90,7 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
     if (!selectedToken) return
 
     const amount = spendingLimit && isSpendingLimitType ? spendingLimit.amount : selectedToken.balance
-    setValue(SendAssetsField.amount, formatDecimals(amount, selectedToken.tokenInfo.decimals))
+    setValue(SendAssetsField.amount, formatUnits(amount, selectedToken.tokenInfo.decimals))
   }
 
   return (

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -14,7 +14,7 @@ import {
 import { type TokenInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import { TokenIcon } from '@/components/common/TokenAmount'
-import { safeFormatAmount, safeFormatUnits } from '@/utils/formatters'
+import { formatVisualAmount, safeFormatUnits } from '@/utils/formatters'
 import { validateAmount, validateTokenAmount } from '@/utils/validation'
 import useBalances from '@/hooks/useBalances'
 import AddressBookInput from '@/components/common/AddressBookInput'
@@ -31,7 +31,7 @@ export const AutocompleteItem = (item: { tokenInfo: TokenInfo; balance: string }
       <Typography variant="body2">{item.tokenInfo.name}</Typography>
 
       <Typography variant="caption" component="p">
-        {safeFormatAmount(item.balance, item.tokenInfo.decimals)} {item.tokenInfo.symbol}
+        {formatVisualAmount(item.balance, item.tokenInfo.decimals)} {item.tokenInfo.symbol}
       </Typography>
     </Grid>
   </Grid>

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -12,10 +12,9 @@ import {
   DialogContent,
 } from '@mui/material'
 import { type TokenInfo } from '@gnosis.pm/safe-react-gateway-sdk'
-import { formatUnits } from 'ethers/lib/utils'
 
 import { TokenIcon } from '@/components/common/TokenAmount'
-import { formatDecimals } from '@/utils/formatters'
+import { safeFormatAmount, safeFormatUnits } from '@/utils/formatters'
 import { validateAmount, validateTokenAmount } from '@/utils/validation'
 import useBalances from '@/hooks/useBalances'
 import AddressBookInput from '@/components/common/AddressBookInput'
@@ -32,7 +31,7 @@ export const AutocompleteItem = (item: { tokenInfo: TokenInfo; balance: string }
       <Typography variant="body2">{item.tokenInfo.name}</Typography>
 
       <Typography variant="caption" component="p">
-        {formatDecimals(item.balance, item.tokenInfo.decimals)} {item.tokenInfo.symbol}
+        {safeFormatAmount(item.balance, item.tokenInfo.decimals)} {item.tokenInfo.symbol}
       </Typography>
     </Grid>
   </Grid>
@@ -90,7 +89,7 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
     if (!selectedToken) return
 
     const amount = spendingLimit && isSpendingLimitType ? spendingLimit.amount : selectedToken.balance
-    setValue(SendAssetsField.amount, formatUnits(amount, selectedToken.tokenInfo.decimals))
+    setValue(SendAssetsField.amount, safeFormatUnits(amount, selectedToken.tokenInfo.decimals))
   }
 
   return (

--- a/src/services/tx/tokenTransferParams.ts
+++ b/src/services/tx/tokenTransferParams.ts
@@ -1,4 +1,4 @@
-import { toWei } from '@/utils/formatters'
+import { safeParseUnits } from '@/utils/formatters'
 import { Interface } from '@ethersproject/abi'
 import { MetaTransactionData } from '@gnosis.pm/safe-core-sdk-types'
 import chains from '@/config/chains'
@@ -32,7 +32,7 @@ export const createTokenTransferParams = (
   tokenAddress: string,
 ): MetaTransactionData => {
   const isNativeToken = parseInt(tokenAddress, 16) === 0
-  const value = toWei(amount, decimals).toString()
+  const value = safeParseUnits(amount, decimals)?.toString() || '0'
 
   return isNativeToken
     ? {

--- a/src/store/addedSafesSlice.ts
+++ b/src/store/addedSafesSlice.ts
@@ -3,7 +3,7 @@ import { AddressEx, SafeBalanceResponse, SafeInfo, TokenType } from '@gnosis.pm/
 import type { RootState } from '.'
 import { selectSafeInfo, safeInfoSlice } from '@/store/safeInfoSlice'
 import { balancesSlice } from './balancesSlice'
-import { formatUnits } from 'ethers/lib/utils'
+import { safeFormatUnits } from '@/utils/formatters'
 import { Loadable } from './common'
 import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
 import { selectChainById } from '@/store/chainsSlice'
@@ -63,7 +63,7 @@ export const addedSafesSlice = createSlice({
           continue
         }
 
-        state[chainId][address].ethBalance = formatUnits(item.balance, item.tokenInfo.decimals)
+        state[chainId][address].ethBalance = safeFormatUnits(item.balance, item.tokenInfo.decimals)
 
         return
       }

--- a/src/store/addedSafesSlice.ts
+++ b/src/store/addedSafesSlice.ts
@@ -3,8 +3,7 @@ import { AddressEx, SafeBalanceResponse, SafeInfo, TokenType } from '@gnosis.pm/
 import type { RootState } from '.'
 import { selectSafeInfo, safeInfoSlice } from '@/store/safeInfoSlice'
 import { balancesSlice } from './balancesSlice'
-import { formatDecimals } from '@/utils/formatters'
-import { formatAmount } from '@/utils/formatNumber'
+import { formatUnits } from 'ethers/lib/utils'
 import { Loadable } from './common'
 import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
 import { selectChainById } from '@/store/chainsSlice'
@@ -64,7 +63,7 @@ export const addedSafesSlice = createSlice({
           continue
         }
 
-        state[chainId][address].ethBalance = formatAmount(formatDecimals(item.balance, item.tokenInfo.decimals))
+        state[chainId][address].ethBalance = formatUnits(item.balance, item.tokenInfo.decimals)
 
         return
       }

--- a/src/utils/__tests__/formatters.test.ts
+++ b/src/utils/__tests__/formatters.test.ts
@@ -34,13 +34,3 @@ describe('toWei', () => {
     expect(formatters.toWei('3', 6)).toEqual(BigNumber.from('3000000'))
   })
 })
-
-describe('toDecimals', () => {
-  it('should convert to decimals', () => {
-    expect(formatters.toDecimals('2010000000000000000')).toEqual(2.01)
-  })
-
-  it('should convert to decimals with custom decimals', () => {
-    expect(formatters.toDecimals('3000000', 6)).toEqual(3)
-  })
-})

--- a/src/utils/__tests__/formatters.test.ts
+++ b/src/utils/__tests__/formatters.test.ts
@@ -1,5 +1,4 @@
 import * as formatters from '@/utils/formatters'
-import { BigNumber } from 'ethers'
 
 describe('shortenAddress', () => {
   it('should shorten an address', () => {
@@ -8,29 +7,5 @@ describe('shortenAddress', () => {
 
   it('should shorten an address with custom length', () => {
     expect(formatters.shortenAddress('0x1234567890123456789012345678901234567890', 5)).toEqual('0x12345...67890')
-  })
-})
-
-describe('formatDecimals', () => {
-  it('should format decimals', () => {
-    expect(formatters.formatDecimals('100000000000000000')).toEqual('0.1')
-  })
-
-  it('should format a big number with custom decimals', () => {
-    expect(formatters.formatDecimals('99999910000000000000000', 6)).toEqual('> 999T')
-  })
-
-  it('should format a fractional number with custom decimals', () => {
-    expect(formatters.formatDecimals('120007', 6)).toEqual('0.12001')
-  })
-})
-
-describe('toWei', () => {
-  it('should convert to wei', () => {
-    expect(formatters.toWei('2.01')).toEqual(BigNumber.from('2010000000000000000'))
-  })
-
-  it('should convert to wei with custom decimals', () => {
-    expect(formatters.toWei('3', 6)).toEqual(BigNumber.from('3000000'))
   })
 })

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -2,12 +2,8 @@ import { BigNumberish, type BigNumber } from 'ethers'
 import { formatUnits, parseUnits } from 'ethers/lib/utils'
 import { formatAmount } from './formatNumber'
 
-export const toDecimals = (value: BigNumberish, decimals?: number | string): number => {
-  return Number(formatUnits(value, decimals))
-}
-
 export const formatDecimals = (value: BigNumberish, decimals?: number | string): string => {
-  return formatAmount(toDecimals(value, decimals))
+  return formatAmount(formatUnits(value, decimals))
 }
 
 export const toWei = (value: string, decimals?: number | string): BigNumber => {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -18,8 +18,8 @@ export const safeFormatUnits = (value: BigNumberish, decimals: number | string =
   }
 }
 
-// safeFormatAmount => -< 0.00001
-export const safeFormatAmount = (value: BigNumberish, decimals: number | string = GWEI): string => {
+// formatVisualAmount => -< 0.00001
+export const formatVisualAmount = (value: BigNumberish, decimals: number | string = GWEI): string => {
   return formatAmount(safeFormatUnits(value, decimals))
 }
 

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -4,13 +4,17 @@ import { formatAmount } from './formatNumber'
 
 const GWEI = 'gwei'
 
-// safeFormatUnits => "0.000000000001"
+/**
+ * Converts value to raw, specified decimal precision
+ * @param value value in unspecified unit
+ * @param decimals decimals of the specified value or unit name
+ * @returns value at specified decimals, i.e. 0.000000000000000001
+ */
 export const safeFormatUnits = (value: BigNumberish, decimals: number | string = GWEI): string => {
   try {
     const formattedAmount = formatUnits(value, decimals)
 
     // FIXME: Temporary fix to as ethers' `formatFixed` doesn't strip trailing 0s
-    // https://github.com/5afe/safe/wiki/How-to-format-amounts
     return parseFloat(formattedAmount).toString()
   } catch (err) {
     console.error('Error formatting units', err)
@@ -18,7 +22,12 @@ export const safeFormatUnits = (value: BigNumberish, decimals: number | string =
   }
 }
 
-// formatVisualAmount => -< 0.00001
+/**
+ * Converts value to formatted (https://github.com/5afe/safe/wiki/How-to-format-amounts), specified decimal precision
+ * @param value value in unspecified unit
+ * @param decimals decimals of the specified value or unit name
+ * @returns value at specified decimals, formatted, i.e. -< 0.00001
+ */
 export const formatVisualAmount = (value: BigNumberish, decimals: number | string = GWEI): string => {
   return formatAmount(safeFormatUnits(value, decimals))
 }

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -2,23 +2,25 @@ import { BigNumberish, type BigNumber } from 'ethers'
 import { formatUnits, parseUnits } from 'ethers/lib/utils'
 import { formatAmount } from './formatNumber'
 
-export const formatDecimals = (value: BigNumberish, decimals?: number | string): string => {
-  return formatAmount(formatUnits(value, decimals))
-}
-
-export const toWei = (value: string, decimals?: number | string): BigNumber => {
-  return parseUnits(value, decimals)
-}
-
 const GWEI = 'gwei'
 
+// safeFormatUnits => "0.000000000001"
 export const safeFormatUnits = (value: BigNumberish, decimals: number | string = GWEI): string => {
   try {
-    return formatDecimals(value, decimals)
+    const formattedAmount = formatUnits(value, decimals)
+
+    // FIXME: Temporary fix to as ethers' `formatFixed` doesn't strip trailing 0s
+    // https://github.com/5afe/safe/wiki/How-to-format-amounts
+    return parseFloat(formattedAmount).toString()
   } catch (err) {
     console.error('Error formatting units', err)
     return ''
   }
+}
+
+// safeFormatAmount => -< 0.00001
+export const safeFormatAmount = (value: BigNumberish, decimals: number | string = GWEI): string => {
+  return formatAmount(safeFormatUnits(value, decimals))
 }
 
 export const safeParseUnits = (value: string, decimals: number | string = GWEI): BigNumber | undefined => {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -2,7 +2,7 @@ import chains from '@/config/chains'
 import { isAddress } from '@ethersproject/address'
 import { type TokenInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { parsePrefixedAddress, sameAddress } from './addresses'
-import { formatDecimals, toWei } from './formatters'
+import { safeFormatUnits, safeParseUnits } from './formatters'
 
 export const validateAddress = (address: string) => {
   const ADDRESS_RE = /^0x[0-9a-zA-Z]{40}$/
@@ -68,8 +68,8 @@ export const validateTokenAmount = (amount: string, token?: { balance: string; t
     return 'The amount must be greater than 0'
   }
 
-  if (toWei(amount, token.tokenInfo.decimals).gt(token.balance)) {
-    return `Maximum value is ${formatDecimals(token.balance, token.tokenInfo.decimals)}`
+  if (safeParseUnits(amount, token.tokenInfo.decimals)?.gt(token.balance)) {
+    return `Maximum value is ${safeFormatUnits(token.balance, token.tokenInfo.decimals)}`
   }
 }
 
@@ -84,8 +84,8 @@ export const validateAmount = (amount: string, decimals?: number, max?: string) 
     return 'The amount must be greater than 0'
   }
 
-  if (toWei(amount, decimals).gt(max)) {
-    return `Maximum value is ${formatDecimals(max, decimals)}`
+  if (safeParseUnits(amount, decimals)?.gt(max)) {
+    return `Maximum value is ${safeFormatUnits(max, decimals)}`
   }
 }
 


### PR DESCRIPTION
## What it solves

Number formatting and "Max" spending limit.

## How this PR fixes it

The number formatters have been updated to use `ethers`' `formatUnits` instead of `toDecimals` and the "Max" token amount has been removed from the `<SpendingLimitForm>` field as it's possible to set higher amounts than that which is in the Safe.

## How to test it

1. Observe all numbers formatted correctly across the Safe, i.e. in the assets list, in high and low amount transactions and in modals. Choosing the "Max" amount when the current transaction has high or low amounts, formatted with `>` or `<` should not copy these symbols into their respective amount fields.
2. The "Max" button should no longer exist in the spending limits form.