### PR TITLE
fix: prevent "Show more" from submitting form

### DIFF
--- a/src/components/transactions/HexEncodedData/index.tsx
+++ b/src/components/transactions/HexEncodedData/index.tsx
@@ -1,6 +1,6 @@
 import { shortenText } from '@/utils/formatters'
 import { Box, Link } from '@mui/material'
-import { ReactElement, useState, SyntheticEvent } from 'react'
+import { ReactElement, useState } from 'react'
 import css from './styles.module.css'
 
 interface Props {
@@ -13,8 +13,7 @@ export const HexEncodedData = ({ hexData, title, limit = 20 }: Props): ReactElem
   const [showTxData, setShowTxData] = useState(false)
   const showExpandBtn = hexData.length > limit
 
-  const toggleExpanded = (e: SyntheticEvent) => {
-    e.preventDefault()
+  const toggleExpanded = () => {
     setShowTxData((val) => !val)
   }
 
@@ -28,7 +27,7 @@ export const HexEncodedData = ({ hexData, title, limit = 20 }: Props): ReactElem
       {showExpandBtn ? (
         <>
           {showTxData ? hexData : shortenText(hexData, 25)}{' '}
-          <Link component="button" onClick={toggleExpanded}>
+          <Link component="button" onClick={toggleExpanded} type="button">
             Show {showTxData ? 'less' : 'more'}
           </Link>
         </>

--- a/src/components/transactions/HexEncodedData/index.tsx
+++ b/src/components/transactions/HexEncodedData/index.tsx
@@ -31,7 +31,7 @@ export const HexEncodedData = ({ hexData, title, limit = 20 }: Props): ReactElem
         <>
           {showTxData ? hexData : shortenText(hexData, 25)}{' '}
           <Link component="button" onClick={toggleExpanded}>
-            Show {showTxData ? 'Less' : 'More'}
+            Show {showTxData ? 'less' : 'more'}
           </Link>
         </>
       ) : (

--- a/src/components/transactions/HexEncodedData/index.tsx
+++ b/src/components/transactions/HexEncodedData/index.tsx
@@ -1,6 +1,6 @@
 import { shortenText } from '@/utils/formatters'
 import { Box, Link } from '@mui/material'
-import { ReactElement, useState, MouseEvent } from 'react'
+import { ReactElement, useState, SyntheticEvent } from 'react'
 import css from './styles.module.css'
 
 interface Props {
@@ -13,9 +13,7 @@ export const HexEncodedData = ({ hexData, title, limit = 20 }: Props): ReactElem
   const [showTxData, setShowTxData] = useState(false)
   const showExpandBtn = hexData.length > limit
 
-  const toggleExpanded = (
-    e: MouseEvent<HTMLSpanElement, globalThis.MouseEvent> | MouseEvent<HTMLAnchorElement, globalThis.MouseEvent>,
-  ) => {
+  const toggleExpanded = (e: SyntheticEvent) => {
     e.preventDefault()
     setShowTxData((val) => !val)
   }

--- a/src/components/transactions/HexEncodedData/index.tsx
+++ b/src/components/transactions/HexEncodedData/index.tsx
@@ -1,6 +1,6 @@
 import { shortenText } from '@/utils/formatters'
 import { Box, Link } from '@mui/material'
-import { ReactElement, useState } from 'react'
+import { ReactElement, useState, MouseEvent } from 'react'
 import css from './styles.module.css'
 
 interface Props {
@@ -13,7 +13,10 @@ export const HexEncodedData = ({ hexData, title, limit = 20 }: Props): ReactElem
   const [showTxData, setShowTxData] = useState(false)
   const showExpandBtn = hexData.length > limit
 
-  const toggleExpanded = () => {
+  const toggleExpanded = (
+    e: MouseEvent<HTMLSpanElement, globalThis.MouseEvent> | MouseEvent<HTMLAnchorElement, globalThis.MouseEvent>,
+  ) => {
+    e.preventDefault()
     setShowTxData((val) => !val)
   }
 


### PR DESCRIPTION
## What it solves

Expanding hex data submitting transactions.

## How this PR fixes it

The `onClick` handler for showing/hiding hex data calls `preventDefault` before toggling.

## How to test it

Open the spending limit creation modal and on the review step open the "Transaction details" accodion, clicking on "Show more"/"Show less" won't submit the form.

## Screenshots
![submit tx](https://user-images.githubusercontent.com/20442784/186403912-ba69dd49-d512-482f-85fc-177ea195f398.gif)