### PR TITLE
Fix: target blank for help link

### DIFF
--- a/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
+++ b/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
@@ -166,7 +166,7 @@ const AdvancedParamsForm = ({ params, ...props }: AdvancedParamsFormProps) => {
 
             {/* Help link */}
             <Typography mt={2}>
-              <Link href={HELP_LINK}>
+              <Link href={HELP_LINK} target="_blank" rel="noreferrer">
                 How can I configure these parameters manually?
                 <OpenInNewIcon fontSize="small" sx={{ verticalAlign: 'middle', marginLeft: 0.5 }} />
               </Link>


### PR DESCRIPTION
## What it solves
A tiny fix to the help link in Advanced params.