### PR TITLE
fix: empty named entries added to address book

### DIFF
--- a/src/components/common/EthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/index.tsx
@@ -83,8 +83,8 @@ const PrefixedEthHashInfo = ({
   const settings = useAppSelector(selectSettings)
   const chain = useCurrentChain()
   const addressBook = useAddressBook()
-  // prefer address book name
-  const name = showName ? addressBook[props.address] || props.name : undefined
+
+  const name = showName ? props.name || addressBook[props.address] : undefined
   const prefix = settings.shortName.show ? chain?.shortName : undefined
 
   return <EthHashInfo prefix={prefix} {...props} name={name} />

--- a/src/components/create-safe/status/useSafeCreation.ts
+++ b/src/components/create-safe/status/useSafeCreation.ts
@@ -42,7 +42,9 @@ export const addSafeAndOwnersToAddressBook = (pendingSafe: PendingSafeData, chai
     )
 
     pendingSafe.owners.forEach((owner) => {
-      dispatch(upsertAddressBookEntry({ chainId: chainId, address: owner.address, name: owner.name }))
+      if (owner.name) {
+        dispatch(upsertAddressBookEntry({ chainId, address: owner.address, name: owner.name }))
+      }
     })
 
     dispatch(

--- a/src/components/create-safe/status/useSafeCreation.ts
+++ b/src/components/create-safe/status/useSafeCreation.ts
@@ -42,8 +42,9 @@ export const addSafeAndOwnersToAddressBook = (pendingSafe: PendingSafeData, chai
     )
 
     pendingSafe.owners.forEach((owner) => {
-      if (owner.name) {
-        dispatch(upsertAddressBookEntry({ chainId, address: owner.address, name: owner.name }))
+      const entryName = owner.name || owner.ens
+      if (entryName) {
+        dispatch(upsertAddressBookEntry({ chainId, address: owner.address, name: entryName }))
       }
     })
 
@@ -55,7 +56,7 @@ export const addSafeAndOwnersToAddressBook = (pendingSafe: PendingSafeData, chai
           threshold: pendingSafe.threshold,
           owners: pendingSafe.owners.map((owner) => ({
             value: owner.address,
-            name: owner.name,
+            name: owner.name || owner.ens,
           })),
           chainId: chainId,
           nonce: 0,

--- a/src/components/create-safe/steps/OwnerPolicyStep.tsx
+++ b/src/components/create-safe/steps/OwnerPolicyStep.tsx
@@ -54,13 +54,7 @@ const OwnerPolicyStep = ({ params, onSubmit, setStep, onBack }: Props): ReactEle
   }
 
   const onFormSubmit = handleSubmit((data: SafeFormData) => {
-    onSubmit({
-      ...data,
-      owners: data.owners.map((owner) => ({
-        name: owner.name || owner.fallbackName,
-        address: owner.address,
-      })),
-    })
+    onSubmit(data)
 
     trackEvent({
       ...CREATE_SAFE_EVENTS.OWNERS,
@@ -108,7 +102,7 @@ const OwnerPolicyStep = ({ params, onSubmit, setStep, onBack }: Props): ReactEle
 
           <Box padding={3}>
             {fields.map((field, index) => (
-              <OwnerRow key={field.id} field={field} index={index} remove={remove} />
+              <OwnerRow key={field.id} index={index} remove={remove} />
             ))}
 
             <Button onClick={addOwner} sx={{ fontWeight: 'normal' }}>

--- a/src/components/create-safe/steps/OwnerRow.tsx
+++ b/src/components/create-safe/steps/OwnerRow.tsx
@@ -34,13 +34,17 @@ export const OwnerRow = ({
     [getValues],
   )
 
-  const { ens, resolving } = useAddressResolver(owner.address)
+  const { ens, name, resolving } = useAddressResolver(owner.address)
 
   useEffect(() => {
     if (ens) {
       setValue(`owners.${index}.ens`, ens)
     }
-  }, [ens, setValue, index])
+
+    if (name) {
+      setValue(`owners.${index}.name`, name)
+    }
+  }, [ens, setValue, index, name])
 
   return (
     <Grid container spacing={3} alignItems="center" marginBottom={3} flexWrap={['wrap', undefined, 'nowrap']}>

--- a/src/components/create-safe/steps/OwnerRow.tsx
+++ b/src/components/create-safe/steps/OwnerRow.tsx
@@ -4,18 +4,16 @@ import NameInput from '@/components/common/NameInput'
 import InputAdornment from '@mui/material/InputAdornment'
 import AddressBookInput from '@/components/common/AddressBookInput'
 import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined'
-import { FieldArrayWithId, UseFieldArrayRemove, useFormContext, useWatch } from 'react-hook-form'
+import { UseFieldArrayRemove, useFormContext, useWatch } from 'react-hook-form'
 import { useAddressResolver } from '@/hooks/useAddressResolver'
 import EthHashInfo from '@/components/common/EthHashInfo'
-import { NamedAddress, SafeFormData } from '@/components/create-safe/types'
+import { NamedAddress } from '@/components/create-safe/types'
 
 export const OwnerRow = ({
-  field,
   index,
   remove,
   readOnly = false,
 }: {
-  field: FieldArrayWithId<SafeFormData, 'owners', 'id'>
   index: number
   remove?: UseFieldArrayRemove
   readOnly?: boolean
@@ -36,30 +34,23 @@ export const OwnerRow = ({
     [getValues],
   )
 
-  const { name: fallbackName, resolving } = useAddressResolver(owner.address)
+  const { ens, resolving } = useAddressResolver(owner.address)
 
   useEffect(() => {
-    if (!owner.name && fallbackName) {
-      setValue(`owners.${index}.fallbackName`, fallbackName)
+    if (ens) {
+      setValue(`owners.${index}.ens`, ens)
     }
-  }, [fallbackName, setValue, owner.name, index])
+  }, [ens, setValue, index])
 
   return (
-    <Grid
-      container
-      key={field.id}
-      spacing={3}
-      alignItems="center"
-      marginBottom={3}
-      flexWrap={['wrap', undefined, 'nowrap']}
-    >
+    <Grid container spacing={3} alignItems="center" marginBottom={3} flexWrap={['wrap', undefined, 'nowrap']}>
       <Grid item xs={12} md={4}>
         <FormControl fullWidth>
           <NameInput
             name={`owners.${index}.name`}
             label="Owner name"
             InputLabelProps={{ shrink: true }}
-            placeholder={fallbackName}
+            placeholder={ens || `Owner ${index + 1}`}
             InputProps={{
               endAdornment: resolving ? (
                 <InputAdornment position="end">

--- a/src/components/create-safe/steps/ReviewStep.tsx
+++ b/src/components/create-safe/steps/ReviewStep.tsx
@@ -92,7 +92,7 @@ const ReviewStep = ({ params, onSubmit, setStep, onBack }: Props) => {
             {params.owners.map((owner) => {
               return (
                 <Box key={owner.address} mb={1}>
-                  <EthHashInfo address={owner.address} name={owner.name} shortAddress={false} showName />
+                  <EthHashInfo address={owner.address} name={owner.name || owner.ens} shortAddress={false} showName />
                 </Box>
               )
             })}

--- a/src/components/create-safe/types.d.ts
+++ b/src/components/create-safe/types.d.ts
@@ -1,7 +1,7 @@
 export type NamedAddress = {
   name: string
   address: string
-  fallbackName?: string
+  ens?: string
 }
 
 export type SafeFormData = NamedAddress & {

--- a/src/components/load-safe/steps/SafeOwnersStep.tsx
+++ b/src/components/load-safe/steps/SafeOwnersStep.tsx
@@ -20,9 +20,9 @@ type Props = {
 const SafeOwnersStep = ({ params, onSubmit, onBack }: Props): ReactElement => {
   const chainId = useChainId()
   const formMethods = useForm<SafeFormData>({ defaultValues: params, mode: 'onChange' })
-  const { handleSubmit, setValue, control, formState } = formMethods
+  const { handleSubmit, setValue, control, formState, getValues } = formMethods
 
-  const { fields } = useFieldArray({
+  const { fields, append } = useFieldArray({
     control,
     name: 'owners',
   })
@@ -37,10 +37,13 @@ const SafeOwnersStep = ({ params, onSubmit, onBack }: Props): ReactElement => {
     if (!safeInfo) return
 
     setValue('threshold', safeInfo.threshold)
-    setValue(
-      'owners',
-      safeInfo.owners.map((owner) => ({ address: owner.value, name: '' })),
-    )
+
+    const owners = safeInfo.owners.map((owner, i) => ({
+      address: owner.value,
+      name: getValues(`owners.${i}.name`) || '',
+    }))
+
+    setValue('owners', owners)
   }, [safeInfo, setValue])
 
   return (

--- a/src/components/load-safe/steps/SafeOwnersStep.tsx
+++ b/src/components/load-safe/steps/SafeOwnersStep.tsx
@@ -22,7 +22,7 @@ const SafeOwnersStep = ({ params, onSubmit, onBack }: Props): ReactElement => {
   const formMethods = useForm<SafeFormData>({ defaultValues: params, mode: 'onChange' })
   const { handleSubmit, setValue, control, formState, getValues } = formMethods
 
-  const { fields, append } = useFieldArray({
+  const { fields } = useFieldArray({
     control,
     name: 'owners',
   })
@@ -44,7 +44,7 @@ const SafeOwnersStep = ({ params, onSubmit, onBack }: Props): ReactElement => {
     }))
 
     setValue('owners', owners)
-  }, [safeInfo, setValue])
+  }, [getValues, safeInfo, setValue])
 
   return (
     <Paper>

--- a/src/components/load-safe/steps/SafeOwnersStep.tsx
+++ b/src/components/load-safe/steps/SafeOwnersStep.tsx
@@ -39,24 +39,14 @@ const SafeOwnersStep = ({ params, onSubmit, onBack }: Props): ReactElement => {
     setValue('threshold', safeInfo.threshold)
     setValue(
       'owners',
-      safeInfo.owners.map((owner) => ({ address: owner.value, name: '', resolving: false })),
+      safeInfo.owners.map((owner) => ({ address: owner.value, name: '' })),
     )
   }, [safeInfo, setValue])
-
-  const onFormSubmit = handleSubmit((data: SafeFormData) => {
-    onSubmit({
-      ...data,
-      owners: data.owners.map((owner) => ({
-        name: owner.name || owner.fallbackName,
-        address: owner.address,
-      })),
-    })
-  })
 
   return (
     <Paper>
       <FormProvider {...formMethods}>
-        <form onSubmit={onFormSubmit}>
+        <form onSubmit={handleSubmit(onSubmit)}>
           <Box padding={3}>
             <Typography mb={2}>
               This Safe on <ChainIndicator inline /> has {safeInfo?.owners.length} owners. Optional: Provide a name for
@@ -75,7 +65,7 @@ const SafeOwnersStep = ({ params, onSubmit, onBack }: Props): ReactElement => {
           <Divider />
           <Box padding={3}>
             {fields.map((field, index) => (
-              <OwnerRow key={field.id} field={field} index={index} readOnly />
+              <OwnerRow key={field.id} index={index} readOnly />
             ))}
             <Grid container alignItems="center" justifyContent="center" spacing={3}>
               <Grid item>

--- a/src/components/load-safe/steps/SafeReviewStep.tsx
+++ b/src/components/load-safe/steps/SafeReviewStep.tsx
@@ -56,16 +56,16 @@ const SafeReviewStep = ({ params, onBack }: Props) => {
       }),
     )
 
-    for (const { address, name, fallbackName } of params.owners) {
-      if (name === fallbackName) {
+    for (const { address, name } of params.owners) {
+      if (!name) {
         continue
       }
 
       dispatch(
         upsertAddressBookEntry({
           chainId,
-          address: address,
-          name: name ?? '',
+          address,
+          name,
         }),
       )
     }

--- a/src/components/load-safe/steps/SafeReviewStep.tsx
+++ b/src/components/load-safe/steps/SafeReviewStep.tsx
@@ -143,7 +143,7 @@ const SafeReviewStep = ({ params, onBack }: Props) => {
             {params.owners.map((owner) => {
               return (
                 <Box key={owner.address} mb={1}>
-                  <EthHashInfo address={owner.address} name={owner.name} shortAddress={false} />
+                  <EthHashInfo address={owner.address} name={owner.name || owner.ens} shortAddress={false} />
                 </Box>
               )
             })}

--- a/src/components/load-safe/steps/SafeReviewStep.tsx
+++ b/src/components/load-safe/steps/SafeReviewStep.tsx
@@ -41,7 +41,7 @@ const SafeReviewStep = ({ params, onBack }: Props) => {
           threshold: params.threshold,
           owners: params.owners.map((owner) => ({
             value: owner.address,
-            name: owner.name,
+            name: owner.name || owner.ens,
           })),
           chainId,
         },
@@ -56,8 +56,10 @@ const SafeReviewStep = ({ params, onBack }: Props) => {
       }),
     )
 
-    for (const { address, name } of params.owners) {
-      if (!name) {
+    for (const { address, name, ens } of params.owners) {
+      const entryName = name || ens
+
+      if (!entryName) {
         continue
       }
 
@@ -65,7 +67,7 @@ const SafeReviewStep = ({ params, onBack }: Props) => {
         upsertAddressBookEntry({
           chainId,
           address,
-          name,
+          name: entryName,
         }),
       )
     }

--- a/src/components/load-safe/steps/SetAddressStep.tsx
+++ b/src/components/load-safe/steps/SetAddressStep.tsx
@@ -41,7 +41,11 @@ const SetAddressStep = ({ params, onSubmit, onBack }: Props) => {
 
   const safeAddress = watch('address')
 
-  const { name: fallbackName, resolving } = useAddressResolver(safeAddress, useMnemonicSafeName())
+  const defaultName = useMnemonicSafeName()
+  const { ens, name, resolving } = useAddressResolver(safeAddress)
+
+  // Address book, ENS, mnemonic
+  const fallbackName = name || ens || defaultName
 
   const validateSafeAddress = async (address: string) => {
     if (addedSafes && Object.keys(addedSafes).includes(address)) {

--- a/src/components/load-safe/steps/SetAddressStep.tsx
+++ b/src/components/load-safe/steps/SetAddressStep.tsx
@@ -41,11 +41,11 @@ const SetAddressStep = ({ params, onSubmit, onBack }: Props) => {
 
   const safeAddress = watch('address')
 
-  const defaultName = useMnemonicSafeName()
+  const randomName = useMnemonicSafeName()
   const { ens, name, resolving } = useAddressResolver(safeAddress)
 
   // Address book, ENS, mnemonic
-  const fallbackName = name || ens || defaultName
+  const fallbackName = name || ens || randomName
 
   const validateSafeAddress = async (address: string) => {
     if (addedSafes && Object.keys(addedSafes).includes(address)) {

--- a/src/components/settings/owner/AddOwnerDialog/DialogSteps/ChooseOwnerStep.tsx
+++ b/src/components/settings/owner/AddOwnerDialog/DialogSteps/ChooseOwnerStep.tsx
@@ -7,7 +7,6 @@ import { addressIsNotCurrentSafe, uniqueAddress } from '@/utils/validation'
 import { Box, Button, CircularProgress, DialogContent, FormControl, InputAdornment, Typography } from '@mui/material'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useAddressResolver } from '@/hooks/useAddressResolver'
-import { useMnemonicName } from '@/hooks/useMnemonicName'
 
 export const ChooseOwnerStep = ({
   data,
@@ -40,11 +39,10 @@ export const ChooseOwnerStep = ({
 
   const address = watch('address')
 
-  const randomName = useMnemonicName()
   const { name, ens, resolving } = useAddressResolver(address)
 
   // Address book, ENS, mnemonic
-  const fallbackName = name || ens || randomName
+  const fallbackName = name || ens
 
   const onFormSubmit = handleSubmit((formData: OwnerData) => {
     onSubmit({
@@ -79,7 +77,7 @@ export const ChooseOwnerStep = ({
               <NameInput
                 label="Owner name"
                 name="name"
-                placeholder={fallbackName}
+                placeholder={fallbackName || 'New owner'}
                 InputLabelProps={{ shrink: true }}
                 InputProps={{
                   endAdornment: resolving && (

--- a/src/components/settings/owner/AddOwnerDialog/DialogSteps/ChooseOwnerStep.tsx
+++ b/src/components/settings/owner/AddOwnerDialog/DialogSteps/ChooseOwnerStep.tsx
@@ -41,7 +41,7 @@ export const ChooseOwnerStep = ({
 
   const { name, ens, resolving } = useAddressResolver(address)
 
-  // Address book, ENS, mnemonic
+  // Address book, ENS
   const fallbackName = name || ens
 
   const onFormSubmit = handleSubmit((formData: OwnerData) => {

--- a/src/components/settings/owner/AddOwnerDialog/DialogSteps/ChooseOwnerStep.tsx
+++ b/src/components/settings/owner/AddOwnerDialog/DialogSteps/ChooseOwnerStep.tsx
@@ -7,6 +7,7 @@ import { addressIsNotCurrentSafe, uniqueAddress } from '@/utils/validation'
 import { Box, Button, CircularProgress, DialogContent, FormControl, InputAdornment, Typography } from '@mui/material'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useAddressResolver } from '@/hooks/useAddressResolver'
+import { useMnemonicName } from '@/hooks/useMnemonicName'
 
 export const ChooseOwnerStep = ({
   data,
@@ -39,7 +40,11 @@ export const ChooseOwnerStep = ({
 
   const address = watch('address')
 
-  const { name: fallbackName, resolving } = useAddressResolver(address)
+  const randomName = useMnemonicName()
+  const { name, ens, resolving } = useAddressResolver(address)
+
+  // Address book, ENS, mnemonic
+  const fallbackName = name || ens || randomName
 
   const onFormSubmit = handleSubmit((formData: OwnerData) => {
     onSubmit({

--- a/src/hooks/__tests__/useAddressResolver.test.ts
+++ b/src/hooks/__tests__/useAddressResolver.test.ts
@@ -4,7 +4,7 @@ import { ethers } from 'ethers'
 import * as domains from '@/services/domains'
 import * as web3 from '@/hooks/wallets/web3'
 import * as useChains from '@/hooks/useChains'
-import { act, renderHook, waitFor } from '@/tests/test-utils'
+import { renderHook, waitFor } from '@/tests/test-utils'
 import { ChainInfo, FEATURES } from '@gnosis.pm/safe-react-gateway-sdk'
 import { JsonRpcProvider } from '@ethersproject/providers'
 
@@ -17,28 +17,25 @@ describe('useAddressResolver', () => {
     jest.spyOn(web3, 'useWeb3ReadOnly').mockImplementation(() => mockProvider)
   })
 
-  it('returns a fallback for an empty address', async () => {
-    const { result } = renderHook(() => useAddressResolver('', 'feisty-lion-fallback'))
-
-    await act(() => Promise.resolve())
-
-    expect(result.current.resolving).toBe(false)
-    expect(result.current.name).toBe('feisty-lion-fallback')
-  })
-
-  it('resolves name from address book if found', async () => {
+  it('returns address book name if found, not resolving ENS domain', async () => {
     jest.spyOn(addressBook, 'default').mockReturnValue({
       [ADDRESS1]: 'Testname',
     })
+    const domainsMock = jest.spyOn(domains, 'lookupAddress').mockImplementation(() => {
+      return Promise.resolve('test.eth')
+    })
+
     const { result } = renderHook(() => useAddressResolver(ADDRESS1))
 
     await waitFor(() => {
+      expect(result.current.ens).toBeUndefined()
       expect(result.current.name).toBe('Testname')
       expect(result.current.resolving).toBe(false)
+      expect(domainsMock).toHaveBeenCalledTimes(0)
     })
   })
 
-  it('resolves to ens name if no address book name is found', async () => {
+  it('resolves ENS domain if no address book name is found', async () => {
     jest.spyOn(addressBook, 'default').mockReturnValue({})
     const domainsMock = jest.spyOn(domains, 'lookupAddress').mockImplementation(() => {
       return Promise.resolve('test.eth')
@@ -51,13 +48,14 @@ describe('useAddressResolver', () => {
     const { result } = renderHook(() => useAddressResolver(ADDRESS1))
 
     await waitFor(() => {
-      expect(result.current.name).toBe('test.eth')
+      expect(result.current.ens).toBe('test.eth')
+      expect(result.current.name).toBeUndefined()
       expect(result.current.resolving).toBe(false)
       expect(domainsMock).toHaveBeenCalledTimes(1)
     })
   })
 
-  it('does not resolve ens name if feature is disabled', async () => {
+  it('does not resolve ENS domain if feature is disabled', async () => {
     jest.spyOn(addressBook, 'default').mockReturnValue({})
     const domainsMock = jest.spyOn(domains, 'lookupAddress').mockImplementation(() => {
       return Promise.resolve('test.eth')
@@ -67,10 +65,11 @@ describe('useAddressResolver', () => {
       chainId: '1',
     } as ChainInfo)
 
-    const { result } = renderHook(() => useAddressResolver(ADDRESS1, 'fallback-caracal'))
+    const { result } = renderHook(() => useAddressResolver(ADDRESS1))
 
     await waitFor(() => {
-      expect(result.current.name).toBe('fallback-caracal')
+      expect(result.current.ens).toBeUndefined()
+      expect(result.current.name).toBeUndefined()
       expect(result.current.resolving).toBe(false)
       expect(domainsMock).toHaveBeenCalledTimes(0)
     })

--- a/src/hooks/useAddressResolver.ts
+++ b/src/hooks/useAddressResolver.ts
@@ -7,11 +7,8 @@ import { useMemo } from 'react'
 import { useCurrentChain } from './useChains'
 import useAsync from '@/hooks/useAsync'
 import useDebounce from './useDebounce'
-import { useMnemonicName } from './useMnemonicName'
 
-export const useAddressResolver = (address: string, fallback?: string) => {
-  const defaultFallback = useMnemonicName()
-  fallback = fallback ?? defaultFallback
+export const useAddressResolver = (address: string) => {
   const addressBook = useAddressBook()
   const ethersProvider = useWeb3ReadOnly()
   const debouncedValue = useDebounce(address, 200)
@@ -20,19 +17,19 @@ export const useAddressResolver = (address: string, fallback?: string) => {
   const isDomainLookupEnabled = !!currentChain && hasFeature(currentChain, FEATURES.DOMAIN_LOOKUP)
   const shouldResolve = !addressBookName && isDomainLookupEnabled && !!ethersProvider && !!debouncedValue
 
-  const [ensName, _, isResolving] = useAsync<string | undefined>(() => {
+  const [ens, _, isResolving] = useAsync<string | undefined>(() => {
     if (!shouldResolve) return
     return lookupAddress(ethersProvider, debouncedValue)
   }, [ethersProvider, debouncedValue, shouldResolve])
 
   const resolving = shouldResolve && isResolving
-  const name = addressBookName || ensName || (resolving ? '' : fallback)
 
   return useMemo(
     () => ({
-      name,
+      ens,
+      name: addressBookName,
       resolving,
     }),
-    [name, resolving],
+    [ens, addressBookName, resolving],
   )
 }


### PR DESCRIPTION
## What it solves

Empty entries in address book

## How this PR fixes it

- `NamedAddress['fallbackName']` has been changed to `NamedAddress['ens']` and the create/load Safe flow updated accordingly. `placeholder`s are heirachically:
1. Address book name
2. ENS domain
3. Random mnemonic (only when loading a Safe or adding an owner)

- The above are used as sequential fallbacks when loading Safes or adding owners to existing Safes.

- `useAddressResolver` has been adjusted to not return fallbacks from `useMnemonicName` as it is not required everywhere. The hook now returns:
```ts
  {
    name: string, // Current address book name
    ens?: string, // Resolved ENS domain, if no address book entry found
    resolving: boolean // Resolving status
  }
```

## How to test it

1. Create a Safe, define/don't define a name. Observe that it is added to the address book with a custom name/mnemonic name.
2. Create a Safe, choosing owners that have/don't have ENS domains. Observe that they aren't added to the address book unless you define their name.
3. Load a Safe that has/doesn't have an ENS name but do not define a custom name. Observe that it is added to the address book with a mnemonic name/ENS name accodingly.
4. Add an owner, providing names in the hierachy defined above. Observe that they are added in such a manner: custom name, address book name, ENS domain, mnemonic name.