### PR TITLE
fix: add scroll to long select lists

### DIFF
--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -353,6 +353,17 @@ const initTheme = (darkMode: boolean) => {
           }),
         },
       },
+      MuiSelect: {
+        defaultProps: {
+          MenuProps: {
+            sx: {
+              '& .MuiPaper-root': {
+                overflow: 'auto',
+              },
+            },
+          },
+        },
+      },
     },
   })
 }


### PR DESCRIPTION
## What it solves

Unselectable tokens

## How this PR fixes it

Long `<Select>` `<MenuItem>`s now show a scrollbar.

## How to test it

Open a Safe with a large amount of asset types. Open the currency selector and observe the scrollbar. Attempt to send assets and observe the scrollbar in the asset list. The same with the asset list when creating a spending limit.

## Screenshots
![select scroll](https://user-images.githubusercontent.com/20442784/186622577-17e34345-b04c-445f-b654-e48e521cec02.gif)
![image](https://user-images.githubusercontent.com/20442784/186622797-2998d736-217d-40f7-abae-e9d2b52d72b9.png)