### PR TITLE
fix: copy prefix checkbox

### DIFF
--- a/src/pages/safe/settings/appearance.tsx
+++ b/src/pages/safe/settings/appearance.tsx
@@ -70,7 +70,7 @@ const Appearance: NextPage = () => {
                 control={
                   <Checkbox
                     checked={settings.shortName.copy}
-                    onChange={handleToggle(setShowShortName, SETTINGS_EVENTS.APPEARANCE.COPY_PREFIXES)}
+                    onChange={handleToggle(setCopyShortName, SETTINGS_EVENTS.APPEARANCE.COPY_PREFIXES)}
                   />
                 }
                 label="Copy addresses with chain prefix"


### PR DESCRIPTION
## What it solves

Resolves #459

## How this PR fixes it

(Un-)checking the prefix copy preference checkbox now toggles the setting.

## How to test it

Open the apperance settings and toggle the prefix copying setting. Observe the checkbox (un-)checks and copying the address from the sidebar prepends the prefix accodingly.

## Screenshots
![prefix](https://user-images.githubusercontent.com/20442784/187130312-fca472d7-60d3-4991-94a8-75a1c002f3b3.gif)