### PR TITLE
fix: limit max to balance

### DIFF
--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -89,7 +89,11 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
   const onMaxAmountClick = () => {
     if (!selectedToken) return
 
-    const amount = spendingLimit && isSpendingLimitType ? spendingLimit.amount : selectedToken.balance
+    const amount =
+      spendingLimit && isSpendingLimitType
+        ? Math.min(+spendingLimit.amount, +selectedToken.balance).toString()
+        : selectedToken.balance
+
     setValue(SendAssetsField.amount, safeFormatUnits(amount, selectedToken.tokenInfo.decimals))
   }
 


### PR DESCRIPTION
## What it solves

Resolves #457

## How this PR fixes it

When setting the "Max" amount of assets to send, it selects either the highest amount (if it is within the spending limit) or spending limit (if it is less than the amount).

## How to test it

Create a spending limit that is higher than the asset amount in the Safe. Create a transaction, selecting the "Max" amount. Observe that it selects the max amount of the asset, not the spending limit.

## Screenshots
![spending limit](https://user-images.githubusercontent.com/20442784/187130837-f513b9c2-7b58-4e37-a2de-b224862c94be.gif)
