### PR TITLE
fix: cleanup palette

### DIFF
--- a/src/components/common/Header/styles.module.css
+++ b/src/components/common/Header/styles.module.css
@@ -6,7 +6,7 @@
   align-items: center;
   position: relative;
   border-radius: 0 !important;
-  background-color: var(--color-background-paper);
+  background-color: var(--color-background-main);
 }
 
 .element {
@@ -28,7 +28,11 @@
 .logo svg {
   width: auto;
   display: block;
-  color: var(--color-logo-main);
+  color: '#000';
+}
+
+[data-theme='dark'] .logo svg {
+  color: '#fff';
 }
 
 .menuButton {

--- a/src/components/common/PageLayout/styles.module.css
+++ b/src/components/common/PageLayout/styles.module.css
@@ -7,7 +7,7 @@
 }
 
 .main {
-  background-color: var(--color-background-main);
+  background-color: var(--color-background-dark);
   padding-left: 230px;
   padding-top: var(--header-height);
   min-height: 100vh;

--- a/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
@@ -11,7 +11,7 @@ import TxType from '@/components/transactions/TxType'
 const StyledContainer = styled.div`
   width: 100%;
   text-decoration: none;
-  background-color: var(--color-background-paper);
+  background-color: var(--color-background-main);
   border: 2px solid var(--color-border-light);
   border-radius: 8px;
   box-sizing: border-box;

--- a/src/components/dashboard/styled.tsx
+++ b/src/components/dashboard/styled.tsx
@@ -21,7 +21,7 @@ export const WidgetBody = styled.div`
 `
 
 export const Card = styled.div`
-  background: var(--color-background-paper);
+  background: var(--color-background-main);
   padding: var(--space-3);
   border-radius: 8px;
   flex-grow: 1;

--- a/src/components/nfts/NftCard/styles.module.css
+++ b/src/components/nfts/NftCard/styles.module.css
@@ -20,7 +20,7 @@
 
 .card::after {
   content: '';
-  background: var(--color-background-paper);
+  background: var(--color-background-main);
   position: absolute;
   top: 0;
   left: 0;

--- a/src/components/notification-center/NotificationCenter/styles.module.css
+++ b/src/components/notification-center/NotificationCenter/styles.module.css
@@ -13,7 +13,7 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--space-3);
-  border-bottom: 2px solid var(--color-background-main);
+  border-bottom: 2px solid var(--color-background-dark);
 }
 
 .popoverFooter {

--- a/src/components/safe-apps/SafeAppsHeader/styles.module.css
+++ b/src/components/safe-apps/SafeAppsHeader/styles.module.css
@@ -1,4 +1,4 @@
 .header {
-  background: var(--color-background-paper);
+  background: var(--color-background-main);
   padding: var(--space-2) var(--space-3);
 }

--- a/src/components/settings/owner/AddOwnerDialog/DialogSteps/styles.module.css
+++ b/src/components/settings/owner/AddOwnerDialog/DialogSteps/styles.module.css
@@ -1,5 +1,5 @@
 .info {
-  background-color: var(--color-background-main);
+  background-color: var(--color-background-dark);
   align-items: center;
   display: flex;
   flex-direction: column;

--- a/src/components/settings/owner/RemoveOwnerDialog/DialogSteps/styles.module.css
+++ b/src/components/settings/owner/RemoveOwnerDialog/DialogSteps/styles.module.css
@@ -1,5 +1,5 @@
 .info {
-  background-color: var(--color-background-main);
+  background-color: var(--color-background-dark);
   align-items: center;
   display: flex;
   flex-direction: column;

--- a/src/components/sidebar/Sidebar/styles.module.css
+++ b/src/components/sidebar/Sidebar/styles.module.css
@@ -4,7 +4,7 @@
   display: flex;
   overflow: hidden;
   flex-direction: column;
-  background-color: var(--color-background-paper);
+  background-color: var(--color-background-main);
 }
 
 .container {

--- a/src/components/sidebar/SidebarNavigation/styles.module.css
+++ b/src/components/sidebar/SidebarNavigation/styles.module.css
@@ -13,7 +13,7 @@
   position: absolute;
   bottom: 0;
   left: -1px;
-  background-color: var(--color-background-paper);
+  background-color: var(--color-background-main);
 }
 
 .sublistItem {

--- a/src/styles/colors-dark.ts
+++ b/src/styles/colors-dark.ts
@@ -48,9 +48,6 @@ const darkPalette = {
     main: '#1e1f20',
     light: '#282e2d',
   },
-  logo: {
-    main: '#ffffff',
-  },
 }
 
 export default darkPalette

--- a/src/styles/colors-dark.ts
+++ b/src/styles/colors-dark.ts
@@ -4,9 +4,6 @@ const darkPalette = {
     secondary: '#ffffff',
     disabled: '#ffffff4d',
   },
-  action: {
-    active: '#ffffff',
-  },
   primary: {
     dark: '#0E7361',
     main: '#008C73',
@@ -47,9 +44,8 @@ const darkPalette = {
     background: '#FFF4E3',
   },
   background: {
-    default: '#121212',
-    main: '#121212',
-    paper: '#1e1f20',
+    dark: '#121212',
+    main: '#1e1f20',
     light: '#282e2d',
   },
   logo: {

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -48,9 +48,6 @@ const palette = {
     main: '#FFFFFF',
     light: '#F1FAF8',
   },
-  logo: {
-    main: '#000000',
-  },
 }
 
 export default palette

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -44,9 +44,8 @@ const palette = {
     background: '#FFF4E3',
   },
   background: {
-    default: '#F6F7F8',
-    main: '#F6F7F8',
-    paper: '#FFFFFF',
+    dark: '#F6F7F8',
+    main: '#FFFFFF',
     light: '#F1FAF8',
   },
   logo: {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -20,7 +20,7 @@ body {
   padding: 0;
   margin: 0;
   font-family: DM Sans, sans-serif;
-  background-color: var(--color-background-paper);
+  background-color: var(--color-background-main);
 }
 
 main {

--- a/src/styles/onboard.css
+++ b/src/styles/onboard.css
@@ -1,5 +1,5 @@
 :root {
-  --onboard-white: var(--color-background-paper);
+  --onboard-white: var(--color-background-main);
   --onboard-black: var(--color-secondary-main);
   --onboard-primary-1: var(--color-primary-main);
   --onboard-primary-100: var(--color-primary-background);
@@ -26,7 +26,7 @@
   --onboard-warning-600: var(--color-warning-main);
   --onboard-warning-700: var(--color-warning-dark);
 
-  --account-select-modal-white: var(--color-background-paper);
+  --account-select-modal-white: var(--color-background-main);
   --account-select-modal-black: var(--color-secondary-main);
   --account-select-modal-primary-100: var(--color-primary-background);
   --account-select-modal-primary-200: var(--color-background-light);

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -56,9 +56,9 @@ const initTheme = (darkMode: boolean) => {
     shadows: [
       'none',
       darkMode ? `0 0 2px ${shadowColor}` : `0 1px 4px ${shadowColor}0a, 0 4px 10px ${shadowColor}14`,
-      darkMode ? '0 0 2px ${shadowColor}' : `0 1px 4px ${shadowColor}0a, 0 4px 10px ${shadowColor}14`,
-      darkMode ? '0 0 2px ${shadowColor}' : `0 2px 20px ${shadowColor}0a, 0 8px 32px ${shadowColor}14`,
-      darkMode ? '0 0 2px ${shadowColor}' : `0 8px 32px ${shadowColor}0a, 0 24px 60px ${shadowColor}14`,
+      darkMode ? `0 0 2px ${shadowColor}` : `0 1px 4px ${shadowColor}0a, 0 4px 10px ${shadowColor}14`,
+      darkMode ? `0 0 2px ${shadowColor}` : `0 2px 20px ${shadowColor}0a, 0 8px 32px ${shadowColor}14`,
+      darkMode ? `0 0 2px ${shadowColor}` : `0 8px 32px ${shadowColor}0a, 0 24px 60px ${shadowColor}14`,
       ...Array(20).fill('none'),
     ] as Shadows,
     typography: {

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -29,9 +29,8 @@
   --color-warning-main: #ffc05f;
   --color-warning-light: #fbe5c5;
   --color-warning-background: #fff4e3;
-  --color-background-default: #f6f7f8;
-  --color-background-main: #f6f7f8;
-  --color-background-paper: #ffffff;
+  --color-background-dark: #f6f7f8;
+  --color-background-main: #ffffff;
   --color-background-light: #f1faf8;
   --color-logo-main: #000000;
   --space-1: 8px;
@@ -52,7 +51,6 @@
   --color-text-primary: #ffffff;
   --color-text-secondary: #ffffff;
   --color-text-disabled: #ffffff4d;
-  --color-action-active: #ffffff;
   --color-primary-dark: #0e7361;
   --color-primary-main: #008c73;
   --color-primary-light: #92c9be;
@@ -78,9 +76,8 @@
   --color-warning-main: #ffc05f;
   --color-warning-light: #fbe5c5;
   --color-warning-background: #fff4e3;
-  --color-background-default: #121212;
-  --color-background-main: #121212;
-  --color-background-paper: #1e1f20;
+  --color-background-dark: #121212;
+  --color-background-main: #1e1f20;
   --color-background-light: #282e2d;
   --color-logo-main: #ffffff;
 }

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -32,7 +32,6 @@
   --color-background-dark: #f6f7f8;
   --color-background-main: #ffffff;
   --color-background-light: #f1faf8;
-  --color-logo-main: #000000;
   --space-1: 8px;
   --space-2: 16px;
   --space-3: 24px;
@@ -79,5 +78,4 @@
   --color-background-dark: #121212;
   --color-background-main: #1e1f20;
   --color-background-light: #282e2d;
-  --color-logo-main: #ffffff;
 }


### PR DESCRIPTION
## What it solves

Uniform colour palette.

## How this PR fixes it

Unused, unnecessary or non-`interface` conforming colours have been removed/adjusted accordingly.

- `logo.main` has been removed as it is only referenced in one place.
- `background.paper` has been changed to `background.main` to confirm to the `interface` of theme colours.
- What was `background.main`/`background.default` have been condensed into `background.dark` as they were the same and are the darker shade.
- `active` was removed as it is not being used (and was only present in the dark colours).
- `shadowColor` template literal string was fixed.

## How to test it

The interface should not have any visible changes.