### PR TITLE
Update `safe-core-sdk` to v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "@emotion/server": "^11.10.0",
     "@emotion/styled": "^11.10.0",
     "@gnosis.pm/safe-apps-sdk": "^7.7.0",
-    "@gnosis.pm/safe-core-sdk": "^2.4.1",
+    "@gnosis.pm/safe-core-sdk": "^3.0.0",
     "@gnosis.pm/safe-deployments": "^1.15.0",
-    "@gnosis.pm/safe-ethers-lib": "^1.4.0",
+    "@gnosis.pm/safe-ethers-lib": "^1.5.0",
     "@gnosis.pm/safe-modules-deployments": "^1.0.0",
     "@gnosis.pm/safe-react-gateway-sdk": "^3.3.5",
     "@mui/icons-material": "^5.8.4",
@@ -83,7 +83,7 @@
     "semver": "^7.3.7"
   },
   "devDependencies": {
-    "@gnosis.pm/safe-core-sdk-types": "^1.4.0",
+    "@gnosis.pm/safe-core-sdk-types": "^1.5.0",
     "@next/bundle-analyzer": "^12.2.4",
     "@sentry/types": "^7.8.1",
     "@svgr/webpack": "^6.3.1",

--- a/src/components/settings/SafeModules/RemoveModule/steps/ReviewRemoveModule.tsx
+++ b/src/components/settings/SafeModules/RemoveModule/steps/ReviewRemoveModule.tsx
@@ -16,7 +16,7 @@ export const ReviewRemoveModule = ({ data, onSubmit }: { data: RemoveModuleData;
   const sdk = useSafeSDK()
 
   const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
-    return sdk?.getDisableModuleTx(data.address).then((tx) => createTx(tx.data))
+    return sdk?.createDisableModuleTx(data.address).then((tx) => createTx(tx.data))
   }, [sdk, data.address])
 
   useEffect(() => {

--- a/src/components/settings/SpendingLimits/NewSpendingLimit/steps/ReviewSpendingLimit.tsx
+++ b/src/components/settings/SpendingLimits/NewSpendingLimit/steps/ReviewSpendingLimit.tsx
@@ -37,7 +37,7 @@ export const createNewSpendingLimitTx = async (
 
   const isSpendingLimitEnabled = await sdk.isModuleEnabled(spendingLimitAddress)
   if (!isSpendingLimitEnabled) {
-    const enableModuleTx = await sdk.getEnableModuleTx(spendingLimitAddress)
+    const enableModuleTx = await sdk.createEnableModuleTx(spendingLimitAddress)
 
     const tx = {
       to: enableModuleTx.data.to,

--- a/src/services/tx/__tests__/spendingLimitParams.test.ts
+++ b/src/services/tx/__tests__/spendingLimitParams.test.ts
@@ -16,13 +16,13 @@ const mockData: NewSpendingLimitData = {
 }
 
 describe('createNewSpendingLimitTx', () => {
-  let mockGetEnableModuleTx: any
+  let mockCreateEnableModuleTx: any
   let mockSDK: Safe
 
   beforeEach(() => {
     jest.resetAllMocks()
 
-    mockGetEnableModuleTx = jest.fn(() => ({
+    mockCreateEnableModuleTx = jest.fn(() => ({
       data: {
         data: '0x',
         to: '0x',
@@ -31,7 +31,7 @@ describe('createNewSpendingLimitTx', () => {
 
     mockSDK = {
       isModuleEnabled: jest.fn(() => false),
-      getEnableModuleTx: mockGetEnableModuleTx,
+      createEnableModuleTx: mockCreateEnableModuleTx,
       createTransaction: jest.fn(() => 'asd'),
     } as unknown as Safe
 
@@ -58,7 +58,7 @@ describe('createNewSpendingLimitTx', () => {
   it('creates a tx to enable the spending limit module if its not registered yet', async () => {
     await createNewSpendingLimitTx(mockData, [], '4', 18)
 
-    expect(mockGetEnableModuleTx).toHaveBeenCalledTimes(1)
+    expect(mockCreateEnableModuleTx).toHaveBeenCalledTimes(1)
   })
 
   it('creates a tx to add a delegate if beneficiary is not a delegate yet', async () => {

--- a/src/services/tx/__tests__/txSender.test.ts
+++ b/src/services/tx/__tests__/txSender.test.ts
@@ -66,13 +66,14 @@ describe('txSender', () => {
       }
       await createTx(txParams)
 
-      expect(mockSafeSDK.createTransaction).toHaveBeenCalledWith({
+      const safeTransactionData = {
         to: '0x123',
         value: '1',
         data: '0x0',
         nonce: 17,
         safeTxGas: 60000,
-      })
+      }
+      expect(mockSafeSDK.createTransaction).toHaveBeenCalledWith({ safeTransactionData })
     })
 
     it('should create a tx with a given nonce', async () => {
@@ -84,12 +85,13 @@ describe('txSender', () => {
       }
       await createTx(txParams, 18)
 
-      expect(mockSafeSDK.createTransaction).toHaveBeenCalledWith({
+      const safeTransactionData = {
         to: '0x123',
         value: '1',
         data: '0x0',
         nonce: 18,
-      })
+      }
+      expect(mockSafeSDK.createTransaction).toHaveBeenCalledWith({ safeTransactionData })
     })
   })
 

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -61,7 +61,7 @@ export const createTx = async (txParams: SafeTransactionDataPartial, nonce?: num
     txParams = { ...txParams, nonce }
   }
 
-  return safeSDK.createTransaction(txParams)
+  return safeSDK.createTransaction({ safeTransactionData: txParams })
 }
 
 /**
@@ -70,7 +70,7 @@ export const createTx = async (txParams: SafeTransactionDataPartial, nonce?: num
  * If only one tx is passed it will be created without multiSend.
  */
 export const createMultiSendTx = async (txParams: MetaTransactionData[]): Promise<SafeTransaction> => {
-  return withRecommendedNonce((safeSDK) => safeSDK.createTransaction(txParams))
+  return withRecommendedNonce((safeSDK) => safeSDK.createTransaction({ safeTransactionData: txParams }))
 }
 
 const withRecommendedNonce = async (
@@ -82,19 +82,19 @@ const withRecommendedNonce = async (
 }
 
 export const createRemoveOwnerTx = async (txParams: RemoveOwnerTxParams): Promise<SafeTransaction> => {
-  return withRecommendedNonce((safeSDK) => safeSDK.getRemoveOwnerTx(txParams))
+  return withRecommendedNonce((safeSDK) => safeSDK.createRemoveOwnerTx(txParams))
 }
 
 export const createAddOwnerTx = async (txParams: AddOwnerTxParams): Promise<SafeTransaction> => {
-  return withRecommendedNonce((safeSDK) => safeSDK.getAddOwnerTx(txParams))
+  return withRecommendedNonce((safeSDK) => safeSDK.createAddOwnerTx(txParams))
 }
 
 export const createSwapOwnerTx = async (txParams: SwapOwnerTxParams): Promise<SafeTransaction> => {
-  return withRecommendedNonce((safeSDK) => safeSDK.getSwapOwnerTx(txParams))
+  return withRecommendedNonce((safeSDK) => safeSDK.createSwapOwnerTx(txParams))
 }
 
 export const createUpdateThresholdTx = async (threshold: number): Promise<SafeTransaction> => {
-  return withRecommendedNonce((safeSDK) => safeSDK.getChangeThresholdTx(threshold))
+  return withRecommendedNonce((safeSDK) => safeSDK.createChangeThresholdTx(threshold))
 }
 
 /**

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -139,6 +139,7 @@ export const getSafeTxs = (txs: TransactionDetails[], chainId: string, safeAddre
 }
 
 export const getTxOptions = (params: AdvancedParameters, currentChain: ChainInfo | undefined): TransactionOptions => {
+  // TODO: The `nonce` type will be updated to `number | string` in the next Core SDK release
   const txOptions: TransactionOptions = {
     gasLimit: params.gasLimit?.toString(),
     maxFeePerGas: params.maxFeePerGas?.toString(),

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -139,12 +139,12 @@ export const getSafeTxs = (txs: TransactionDetails[], chainId: string, safeAddre
 }
 
 export const getTxOptions = (params: AdvancedParameters, currentChain: ChainInfo | undefined): TransactionOptions => {
-  const txOptions = {
+  const txOptions: TransactionOptions = {
     gasLimit: params.gasLimit?.toString(),
     maxFeePerGas: params.maxFeePerGas?.toString(),
     maxPriorityFeePerGas: params.maxPriorityFeePerGas?.toString(),
-    nonce: params.userNonce?.toString(),
-  } as TransactionOptions
+    nonce: params.userNonce,
+  }
 
   // Some chains don't support EIP-1559 gas price params
   if (currentChain && !hasFeature(currentChain, FEATURES.EIP1559)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1476,6 +1476,21 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.1"
 
+"@ethersproject/abi@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.7.0.tgz#b3f3e045bbbeed1af3947335c247ad625a44e449"
+  integrity sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==
+  dependencies:
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
 "@ethersproject/abstract-provider@5.5.1":
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz#2f1f6e8a3ab7d378d8ad0b5718460f85649710c5"
@@ -1515,6 +1530,19 @@
     "@ethersproject/transactions" "^5.6.2"
     "@ethersproject/web" "^5.6.1"
 
+"@ethersproject/abstract-provider@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz#b0a8550f88b6bf9d51f90e4795d48294630cb9ef"
+  integrity sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+
 "@ethersproject/abstract-signer@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz#590ff6693370c60ae376bf1c7ada59eb2a8dd08d"
@@ -1547,6 +1575,17 @@
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
+
+"@ethersproject/abstract-signer@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz#13f4f32117868452191a4649723cb086d2b596b2"
+  integrity sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
 
 "@ethersproject/address@5.5.0":
   version "5.5.0"
@@ -1581,6 +1620,17 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/rlp" "^5.6.1"
 
+"@ethersproject/address@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.7.0.tgz#19b56c4d74a3b0a46bfdbb6cfcc0a153fc697f37"
+  integrity sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+
 "@ethersproject/base64@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.5.0.tgz#881e8544e47ed976930836986e5eb8fab259c090"
@@ -1601,6 +1651,13 @@
   integrity sha512-qB76rjop6a0RIYYMiB4Eh/8n+Hxu2NIZm8S/Q7kNo5pmZfXhHGHmS4MinUainiBC54SCyRnwzL+KZjj8zbsSsw==
   dependencies:
     "@ethersproject/bytes" "^5.6.1"
+
+"@ethersproject/base64@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.7.0.tgz#ac4ee92aa36c1628173e221d0d01f53692059e1c"
+  integrity sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
 
 "@ethersproject/basex@5.5.0":
   version "5.5.0"
@@ -1653,6 +1710,15 @@
     "@ethersproject/logger" "^5.6.0"
     bn.js "^5.2.1"
 
+"@ethersproject/bignumber@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
+  integrity sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    bn.js "^5.2.1"
+
 "@ethersproject/bytes@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.5.0.tgz#cb11c526de657e7b45d2e0f0246fb3b9d29a601c"
@@ -1666,6 +1732,13 @@
   integrity sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==
   dependencies:
     "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/bytes@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
+  integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/constants@5.5.0":
   version "5.5.0"
@@ -1687,6 +1760,13 @@
   integrity sha512-QSq9WVnZbxXYFftrjSjZDUshp6/eKp6qrtdBtUCm0QxCV5z1fG/w3kdlcsjMCQuQHUnAclKoK7XpXMezhRDOLg==
   dependencies:
     "@ethersproject/bignumber" "^5.6.2"
+
+"@ethersproject/constants@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
+  integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
 
 "@ethersproject/contracts@5.5.0":
   version "5.5.0"
@@ -1720,7 +1800,7 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/transactions" "^5.6.0"
 
-"@ethersproject/contracts@5.6.2", "@ethersproject/contracts@^5.6.0":
+"@ethersproject/contracts@5.6.2":
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.6.2.tgz#20b52e69ebc1b74274ff8e3d4e508de971c287bc"
   integrity sha512-hguUA57BIKi6WY0kHvZp6PwPlWF87MCeB4B7Z7AbUpTxfFXFdn/3b0GmjZPagIHS+3yhcBJDnuEfU4Xz+Ks/8g==
@@ -1735,6 +1815,22 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/transactions" "^5.6.2"
+
+"@ethersproject/contracts@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.7.0.tgz#c305e775abd07e48aa590e1a877ed5c316f8bd1e"
+  integrity sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==
+  dependencies:
+    "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
 
 "@ethersproject/hash@5.5.0":
   version "5.5.0"
@@ -1777,6 +1873,21 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.1"
+
+"@ethersproject/hash@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.7.0.tgz#eb7aca84a588508369562e16e514b539ba5240a7"
+  integrity sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
 
 "@ethersproject/hdnode@5.5.0":
   version "5.5.0"
@@ -1913,6 +2024,14 @@
     "@ethersproject/bytes" "^5.6.1"
     js-sha3 "0.8.0"
 
+"@ethersproject/keccak256@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.7.0.tgz#3186350c6e1cd6aba7940384ec7d6d9db01f335a"
+  integrity sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/logger@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
@@ -1922,6 +2041,11 @@
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.6.0.tgz#d7db1bfcc22fd2e4ab574cba0bb6ad779a9a3e7a"
   integrity sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==
+
+"@ethersproject/logger@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
+  integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
 
 "@ethersproject/networks@5.5.2":
   version "5.5.2"
@@ -1943,6 +2067,13 @@
   integrity sha512-KShHeHPahHI2UlWdtDMn2lJETcbtaJge4k7XSjDR9h79QTd6yQJmv6Cp2ZA4JdqWnhszAOLSuJEd9C0PRw7hSQ==
   dependencies:
     "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/networks@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.7.0.tgz#df72a392f1a63a57f87210515695a31a245845ad"
+  integrity sha512-MG6oHSQHd4ebvJrleEQQ4HhVu8Ichr0RDYEfHzsVAVjHNM+w36x9wp9r+hf1JstMXtseXDtkiVoARAG6M959AA==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/pbkdf2@5.5.0":
   version "5.5.0"
@@ -1981,6 +2112,13 @@
   integrity sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==
   dependencies:
     "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/properties@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.7.0.tgz#a6e12cb0439b878aaf470f1902a176033067ed30"
+  integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/providers@5.5.2":
   version "5.5.2"
@@ -2131,6 +2269,14 @@
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
 
+"@ethersproject/rlp@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.7.0.tgz#de39e4d5918b9d74d46de93af80b7685a9c21304"
+  integrity sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
 "@ethersproject/sha2@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.5.0.tgz#a40a054c61f98fd9eee99af2c3cc6ff57ec24db7"
@@ -2156,6 +2302,15 @@
   dependencies:
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
+    hash.js "1.1.7"
+
+"@ethersproject/sha2@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.7.0.tgz#9a5f7a7824ef784f7f7680984e593a800480c9fb"
+  integrity sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
     hash.js "1.1.7"
 
 "@ethersproject/signing-key@5.5.0":
@@ -2194,6 +2349,18 @@
     elliptic "6.5.4"
     hash.js "1.1.7"
 
+"@ethersproject/signing-key@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.7.0.tgz#06b2df39411b00bc57c7c09b01d1e41cf1b16ab3"
+  integrity sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    bn.js "^5.2.1"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
 "@ethersproject/solidity@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.5.0.tgz#2662eb3e5da471b85a20531e420054278362f93f"
@@ -2218,7 +2385,7 @@
     "@ethersproject/sha2" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
-"@ethersproject/solidity@5.6.1", "@ethersproject/solidity@^5.6.0":
+"@ethersproject/solidity@5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.6.1.tgz#5845e71182c66d32e6ec5eefd041fca091a473e2"
   integrity sha512-KWqVLkUUoLBfL1iwdzUVlkNqAUIFMpbbeH0rgCfKmJp0vFtY4AsaN91gHKo9ZZLkC4UOm3cI3BmMV4N53BOq4g==
@@ -2229,6 +2396,18 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/sha2" "^5.6.1"
     "@ethersproject/strings" "^5.6.1"
+
+"@ethersproject/solidity@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.7.0.tgz#5e9c911d8a2acce2a5ebb48a5e2e0af20b631cb8"
+  integrity sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
 
 "@ethersproject/strings@5.5.0":
   version "5.5.0"
@@ -2256,6 +2435,15 @@
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/constants" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/strings@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.7.0.tgz#54c9d2a7c57ae8f1205c88a9d3a56471e14d5ed2"
+  integrity sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/transactions@5.5.0":
   version "5.5.0"
@@ -2301,6 +2489,21 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/rlp" "^5.6.1"
     "@ethersproject/signing-key" "^5.6.2"
+
+"@ethersproject/transactions@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.7.0.tgz#91318fc24063e057885a6af13fdb703e1f993d3b"
+  integrity sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==
+  dependencies:
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
 
 "@ethersproject/units@5.5.0":
   version "5.5.0"
@@ -2425,6 +2628,17 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.1"
 
+"@ethersproject/web@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.7.0.tgz#40850c05260edad8b54827923bbad23d96aac0bc"
+  integrity sha512-ApHcbbj+muRASVDSCl/tgxaH2LBkRMEYfLOLVa0COipx0+nlu0QKet7U2lEg0vdkh8XRSLf2nd1f1Uk9SrVSGA==
+  dependencies:
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
 "@ethersproject/wordlists@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.5.0.tgz#aac74963aa43e643638e5172353d931b347d584f"
@@ -2505,58 +2719,51 @@
     "@gnosis.pm/safe-react-gateway-sdk" "^3.1.3"
     ethers "^5.6.8"
 
-"@gnosis.pm/safe-core-sdk-types@^1.2.1", "@gnosis.pm/safe-core-sdk-types@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk-types/-/safe-core-sdk-types-1.4.0.tgz#c6615333177765b58f03cd77e165d4d36b9d2c91"
-  integrity sha512-v+V6wqfFVgBl2sZ8FqCMwL/qFnr6wBCcJ/gllo4OvItYw/dmXlMCkxUrERoILSeHDezLkrWnnzA4tHfkEwYuwg==
+"@gnosis.pm/safe-core-sdk-types@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk-types/-/safe-core-sdk-types-1.5.0.tgz#7940fe1e14c427181889cb699f97793faaec515c"
+  integrity sha512-kpCjxvl6VFlxdlwVNbNcna4V0tuh8KYjz3d/+wqVQtpw0EtJqJypbENIwdftH6APlRoRpIevtBTnrLlUutXhRA==
   dependencies:
-    "@ethersproject/bignumber" "^5.6.0"
-    "@ethersproject/contracts" "^5.6.0"
-    "@gnosis.pm/safe-deployments" "1.15.0"
-    web3-core "^1.7.1"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/contracts" "^5.7.0"
+    "@gnosis.pm/safe-deployments" "1.16.0"
+    web3-core "^1.7.5"
 
-"@gnosis.pm/safe-core-sdk-utils@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk-utils/-/safe-core-sdk-utils-1.2.1.tgz#1cc9de8187e724c02104a8c15c14fb77796d1240"
-  integrity sha512-VPnSLayGR4omwcNHPwzx8/aDyGXrWULKSF+ENeiWbmwgIhwQnB7T2gzhArNeUgt4BxmYft/HFm1MRSqiQnIQJw==
+"@gnosis.pm/safe-core-sdk-utils@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk-utils/-/safe-core-sdk-utils-1.3.0.tgz#693b970564f20ad6a39d04974eb889049de13079"
+  integrity sha512-lusi0Lx3O3388uGqmji1y+Z2Csr2+cUDYMcQVzhnG0xMqaVApuU5zVLU/AJD0rG4oItFk9rdGCH1op0QmNLufQ==
   dependencies:
-    "@gnosis.pm/safe-core-sdk-types" "^1.2.1"
+    "@gnosis.pm/safe-core-sdk-types" "^1.5.0"
     semver "^7.3.7"
-    web3-utils "^1.7.1"
+    web3-utils "^1.7.5"
 
-"@gnosis.pm/safe-core-sdk@^2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk/-/safe-core-sdk-2.4.1.tgz#55b0764dc6968a683841fb07ac7d930f96357b41"
-  integrity sha512-FlpHW+jzKNtO9HMFF+R7IbdvJM5J4R4JW76jSe3MAbUA5KlmAW9BFDl/sgdQTREttIZMG2dr9A94RU9YcsljXw==
+"@gnosis.pm/safe-core-sdk@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk/-/safe-core-sdk-3.0.0.tgz#0a5aee7cad91e49d768c3f174f337caf8d14e3cc"
+  integrity sha512-FUraH0TADWvyVI9PZa7/yGJwtr3RAgn/eZnieUgvfqg7uSzXbCdYKXT+911IVmgevYuJIyQ3wMp1SjM9VWsXvA==
   dependencies:
-    "@ethersproject/solidity" "^5.6.0"
-    "@gnosis.pm/safe-core-sdk-types" "^1.4.0"
-    "@gnosis.pm/safe-deployments" "1.15.0"
-    ethereumjs-util "^7.1.4"
-    semver "^7.3.5"
-    web3-utils "^1.7.1"
-
-"@gnosis.pm/safe-deployments@1.15.0":
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.15.0.tgz#71ed9a37437a3080443c49aa65308f2d8839d751"
-  integrity sha512-twfC5HNuj+TKS2gOowf6A1FGZfOLBHAV2JhYpmOCf2MKsfcG+Fe4TrSRgQg605MhWdwFiaGVpNkcwjvpxhGuew==
-  dependencies:
+    "@ethersproject/solidity" "^5.7.0"
+    "@gnosis.pm/safe-core-sdk-types" "^1.5.0"
+    "@gnosis.pm/safe-deployments" "1.16.0"
+    ethereumjs-util "^7.1.5"
     semver "^7.3.7"
+    web3-utils "^1.7.5"
 
-"@gnosis.pm/safe-deployments@^1.15.0":
+"@gnosis.pm/safe-deployments@1.16.0", "@gnosis.pm/safe-deployments@^1.15.0":
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.16.0.tgz#78b1fb400934ff117f7d9c8e66398503bd772eeb"
   integrity sha512-5Wakso6SiulstuZfz3gH6yME8Q50BT5dVxIfgWz4vzOmyyqmAVstMd0VIwyw6IDee0gU4mHKZjhD3UXPKEvRCw==
   dependencies:
     semver "^7.3.7"
 
-"@gnosis.pm/safe-ethers-lib@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-ethers-lib/-/safe-ethers-lib-1.4.0.tgz#5d884c8c083c811f753a2602fba3decf73b3a5f9"
-  integrity sha512-ImKNocwoJB19g9nEcorLG1FuYQZyK+llcCIShSw0R7f3OHi30gjcQJek/rJv+wKetM66s7Dz26xtb2X9ARN3Gg==
+"@gnosis.pm/safe-ethers-lib@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-ethers-lib/-/safe-ethers-lib-1.5.0.tgz#cd4e152c842fd375bb622a6c4e8adaa614fa460a"
+  integrity sha512-MDhKcgLsIPk60PGWE/ZQidTG8+OJ/LyFUlPlSOp4vaGv1IX6be+RgNUYJN/LHtupExndjyx6G+vX9qQWwNNKCQ==
   dependencies:
-    "@gnosis.pm/safe-core-sdk-types" "^1.4.0"
-    "@gnosis.pm/safe-core-sdk-utils" "^1.2.1"
+    "@gnosis.pm/safe-core-sdk-types" "^1.5.0"
+    "@gnosis.pm/safe-core-sdk-utils" "^1.3.0"
 
 "@gnosis.pm/safe-modules-deployments@^1.0.0":
   version "1.0.0"
@@ -11637,7 +11844,7 @@ web3-core-subscriptions@1.7.5:
     eventemitter3 "4.0.4"
     web3-core-helpers "1.7.5"
 
-web3-core@1.7.5, web3-core@^1.7.1:
+web3-core@1.7.5, web3-core@^1.7.5:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.7.5.tgz#8ee2ca490230a30ca970cb9f308eb65b76405e1d"
   integrity sha512-UgOWXZr1fR/3cUQJKWbfMwRxj1/N7o6RSd/dHqdXBlOD+62EjNZItFmLRg5veq5kp9YfXzrNw9bnDkXfsL+nKQ==
@@ -11735,7 +11942,7 @@ web3-providers-ws@1.7.5:
     web3-core-helpers "1.7.5"
     websocket "^1.0.32"
 
-web3-utils@1.7.5, web3-utils@^1.7.1, web3-utils@^1.7.4:
+web3-utils@1.7.5, web3-utils@^1.7.4, web3-utils@^1.7.5:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.7.5.tgz#081a952ac6e0322e25ac97b37358a43c7372ef6a"
   integrity sha512-9AqNOziQky4wNQadEwEfHiBdOZqopIHzQQVzmvvv6fJwDSMhP+khqmAZC7YTiGjs0MboyZ8tWNivqSO1699XQw==


### PR DESCRIPTION
## What it solves
- Updates `safe-core-sdk` packages dependencies
- Renames methods
- Removes `TransactionOptions` casting

Notes: Will update the `nonce` type in `TransactionOptions` i nthe next Core SDK release to `number | string` instead of just `number`