### PR TITLE
Use MultiSendCallOnly

### DIFF
--- a/src/components/settings/ContractVersion/UpdateSafeDialog.tsx
+++ b/src/components/settings/ContractVersion/UpdateSafeDialog.tsx
@@ -5,7 +5,7 @@ import { LATEST_SAFE_VERSION } from '@/config/constants'
 
 import TxModal from '@/components/tx/TxModal'
 
-import { createMultiSendTx } from '@/services/tx/txSender'
+import { createMultiSendCallOnlyTx } from '@/services/tx/txSender'
 import useAsync from '@/hooks/useAsync'
 
 import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
@@ -48,7 +48,7 @@ const ReviewUpdateSafeStep = ({ onSubmit }: { onSubmit: (data: null) => void }) 
     if (!chain || !safeLoaded) return
 
     const txs = createUpdateSafeTxs(safe, chain)
-    return createMultiSendTx(txs)
+    return createMultiSendCallOnlyTx(txs)
   }, [chain, safe, safeLoaded])
 
   return (

--- a/src/components/settings/SpendingLimits/NewSpendingLimit/steps/ReviewSpendingLimit.tsx
+++ b/src/components/settings/SpendingLimits/NewSpendingLimit/steps/ReviewSpendingLimit.tsx
@@ -17,7 +17,7 @@ import { currentMinutes, relativeTime } from '@/utils/date'
 import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
 import { parseUnits } from '@ethersproject/units'
-import { createMultiSendTx } from '@/services/tx/txSender'
+import { createMultiSendCallOnlyTx } from '@/services/tx/txSender'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import { TokenTransferReview } from '@/components/tx/modals/TokenTransferModal/ReviewTokenTx'
 import SpendingLimitLabel from '@/components/common/SpendingLimitLabel'
@@ -67,7 +67,7 @@ export const createNewSpendingLimitTx = async (
 
   txs.push(tx)
 
-  return createMultiSendTx(txs)
+  return createMultiSendCallOnlyTx(txs)
 }
 
 export type NewSpendingLimitData = {

--- a/src/services/tx/__tests__/spendingLimitParams.test.ts
+++ b/src/services/tx/__tests__/spendingLimitParams.test.ts
@@ -35,7 +35,7 @@ describe('createNewSpendingLimitTx', () => {
       createTransaction: jest.fn(() => 'asd'),
     } as unknown as Safe
 
-    jest.spyOn(txSender, 'createMultiSendTx').mockImplementation(jest.fn())
+    jest.spyOn(txSender, 'createMultiSendCallOnlyTx').mockImplementation(jest.fn())
     jest.spyOn(safeCoreSDK, 'getSafeSDK').mockReturnValue(mockSDK)
     jest.spyOn(spendingLimit, 'getSpendingLimitModuleAddress').mockReturnValue(ZERO_ADDRESS)
   })
@@ -128,7 +128,7 @@ describe('createNewSpendingLimitTx', () => {
     expect(spy).toHaveBeenCalled()
   })
   it('encodes all txs as a single multiSend tx', async () => {
-    const spy = jest.spyOn(txSender, 'createMultiSendTx')
+    const spy = jest.spyOn(txSender, 'createMultiSendCallOnlyTx')
     await createNewSpendingLimitTx(mockData, [], '4', 18)
 
     expect(spy).toHaveBeenCalled()

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -65,12 +65,17 @@ export const createTx = async (txParams: SafeTransactionDataPartial, nonce?: num
 }
 
 /**
- * Create a multiSend transaction from an array of MetaTransactionData and options
+ * Create a multiSendCallOnly transaction from an array of MetaTransactionData and options
  *
- * If only one tx is passed it will be created without multiSend.
+ * If only one tx is passed it will be created without multiSend and without onlyCalls.
  */
-export const createMultiSendTx = async (txParams: MetaTransactionData[]): Promise<SafeTransaction> => {
-  return withRecommendedNonce((safeSDK) => safeSDK.createTransaction({ safeTransactionData: txParams }))
+export const createMultiSendCallOnlyTx = async (txParams: MetaTransactionData[]): Promise<SafeTransaction> => {
+  return withRecommendedNonce((safeSDK) =>
+    safeSDK.createTransaction({
+      safeTransactionData: txParams,
+      onlyCalls: true,
+    }),
+  )
 }
 
 const withRecommendedNonce = async (


### PR DESCRIPTION
## What it solves

Replaces the use of MultiSend contract with the use of the MultiSendCallOnly contract using the Safe Core SDK