### PR TITLE
fix: Reset pages when applying tx filter

### DIFF
--- a/src/components/common/PaginatedTxns/index.tsx
+++ b/src/components/common/PaginatedTxns/index.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useState } from 'react'
+import { type ReactElement, useEffect, useState } from 'react'
 import { Box, Typography } from '@mui/material'
 import TxList from '@/components/transactions/TxList'
 import ErrorMessage from '@/components/tx/ErrorMessage'
@@ -72,6 +72,11 @@ const TxPage = ({
 
 const PaginatedTxns = ({ useTxns }: { useTxns: typeof useTxHistory | typeof useTxQueue }): ReactElement => {
   const [pages, setPages] = useState<string[]>([''])
+  const [filter] = useTxFilter()
+
+  useEffect(() => {
+    setPages([''])
+  }, [filter])
 
   const onNextPage = (pageUrl = '') => {
     setPages((prev) => [...prev, pageUrl])


### PR DESCRIPTION
## What it solves

When triggering the infinite scroll pagination on the tx list it keeps the old urls even when applying a new filter. Now we reset `pages` when applying the filter.

## How to test

1. Open the safe
2. Navigate to the tx history
3. Scroll down so more transactions are loaded
4. Scroll up and apply a filter
5. Observe the filter being applied and only relevant txs are being displayed
