### PR TITLE
refactor: use `onChange` to track events directly

### DIFF
--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react'
+import type { SyntheticEvent, ReactElement } from 'react'
 import { Accordion, AccordionDetails, AccordionSummary, Box, Skeleton } from '@mui/material'
 import { type SafeTransaction } from '@gnosis.pm/safe-core-sdk-types'
 import {
@@ -20,7 +20,6 @@ type DecodedTxProps = {
 }
 
 const DecodedTx = ({ tx, txId }: DecodedTxProps): ReactElement | null => {
-  const [isAccordionExpanded, setIsAccordionExpanded] = useState<boolean>(false)
   const chainId = useChainId()
   const encodedData = tx.data.data
   const isNativeTransfer = encodedData && isNaN(parseInt(encodedData, 16))
@@ -39,9 +38,8 @@ const DecodedTx = ({ tx, txId }: DecodedTxProps): ReactElement | null => {
     return null
   }
 
-  const onChangeExpand = () => {
-    setIsAccordionExpanded((prev) => !prev)
-    trackEvent({ ...MODALS_EVENTS.TX_DETAILS, label: isAccordionExpanded ? 'Close' : 'Open' })
+  const onChangeExpand = (_: SyntheticEvent, expanded: boolean) => {
+    trackEvent({ ...MODALS_EVENTS.TX_DETAILS, label: expanded ? 'Open' : 'Close' })
   }
 
   return (

--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, SyntheticEvent, useState } from 'react'
+import type { ReactElement, SyntheticEvent } from 'react'
 import { Accordion, AccordionDetails, AccordionSummary, Skeleton, Typography, Link, Grid } from '@mui/material'
 import { useCurrentChain } from '@/hooks/useChains'
 import { formatVisualAmount } from '@/utils/formatters'
@@ -26,11 +26,9 @@ type GasParamsProps = {
 
 const GasParams = ({ params, isExecution, onEdit }: GasParamsProps): ReactElement => {
   const { nonce, userNonce, safeTxGas, gasLimit, maxFeePerGas, maxPriorityFeePerGas } = params
-  const [isAccordionExpanded, setIsAccordionExpanded] = useState(false)
 
-  const onChangeExpand = () => {
-    setIsAccordionExpanded((prev) => !prev)
-    trackEvent({ ...MODALS_EVENTS.ESTIMATION, label: isAccordionExpanded ? 'Close' : 'Open' })
+  const onChangeExpand = (_: SyntheticEvent, expanded: boolean) => {
+    trackEvent({ ...MODALS_EVENTS.ESTIMATION, label: expanded ? 'Open' : 'Close' })
   }
 
   const chain = useCurrentChain()


### PR DESCRIPTION
## What it solves

Unnecessary use of state.

## How this PR fixes it

The second `expanded` argument of `<Accordion>` `onChange` handlers is used for tracking events.

## How to test it

Create a transaction and in the flow open/close the gas parameters/tansaction details. Observe the event tracking "Open"/"Close" correctly.

## Analytics changes

The `MODALS_EVENTS.TX_DETAILS` and `MODALS_EVENTS.ESTIMATION` events should track as before.