### PR TITLE
fix: standardise unknown module names  + simplify `useTransactionType`

### DIFF
--- a/src/components/settings/SafeModules/index.tsx
+++ b/src/components/settings/SafeModules/index.tsx
@@ -8,6 +8,8 @@ import useIsGranted from '@/hooks/useIsGranted'
 import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
 import { sameAddress } from '@/utils/addresses'
 
+export const DEFAULT_MODULE_NAME = 'Unknown module'
+
 const NoModules = () => {
   return (
     <Typography mt={2} color={(theme) => theme.palette.secondary.light}>
@@ -21,7 +23,7 @@ const getModuleName = (chainId: string, address: string): string => {
     return 'Spending limit module'
   }
 
-  return 'Unknown module'
+  return DEFAULT_MODULE_NAME
 }
 
 const ModuleDisplay = ({ moduleAddress, chainId, name }: { moduleAddress: string; chainId: string; name: string }) => {

--- a/src/hooks/useTransactionType.ts
+++ b/src/hooks/useTransactionType.ts
@@ -1,90 +1,108 @@
-import { useEffect, useState } from 'react'
-import { AddressEx, SettingsInfoType, TransactionSummary, TransferDirection } from '@gnosis.pm/safe-react-gateway-sdk'
-import { isCancellationTxInfo, isModuleExecutionInfo, isTxQueued } from '@/utils/transaction-guards'
+import { useMemo } from 'react'
+import {
+  SettingsInfoType,
+  TransferDirection,
+  type AddressEx,
+  type TransactionSummary,
+} from '@gnosis.pm/safe-react-gateway-sdk'
 
-type TxTypeProps = {
-  icon?: string
-  fallbackIcon?: string
-  text?: string
-}
+import {
+  isCancellationTxInfo,
+  isModuleExecutionInfo,
+  hasSafeAppInfo,
+  isTxQueued,
+  TransactionInfoType,
+} from '@/utils/transaction-guards'
+import { DEFAULT_MODULE_NAME } from '@/components/settings/SafeModules'
 
 const getTxTo = ({ txInfo }: Pick<TransactionSummary, 'txInfo'>): AddressEx | undefined => {
   switch (txInfo.type) {
-    case 'Transfer': {
+    case TransactionInfoType.CREATION: {
+      return txInfo.factory
+    }
+    case TransactionInfoType.TRANSFER: {
       return txInfo.recipient
     }
-    case 'SettingsChange': {
+    case TransactionInfoType.SETTINGS_CHANGE: {
       return undefined
     }
-    case 'Custom': {
+    case TransactionInfoType.CUSTOM: {
       return txInfo.to
-    }
-    case 'Creation': {
-      return txInfo.factory
     }
   }
 }
 
-export const useTransactionType = (tx: TransactionSummary): TxTypeProps => {
-  const [type, setType] = useState<TxTypeProps>({ icon: '/images/custom.svg', text: 'Contract interaction' })
+type TxType = {
+  icon: string
+  text: string
+}
+
+const getTxType = (tx: TransactionSummary): TxType => {
   const toAddress = getTxTo(tx)
 
-  useEffect(() => {
-    switch (tx.txInfo.type) {
-      case 'Creation': {
-        setType({
-          icon: toAddress?.logoUri || '/images/settings.svg',
-          text: 'Safe created',
-        })
-        break
-      }
-      case 'Transfer': {
-        const isSendTx = tx.txInfo.direction === TransferDirection.OUTGOING
-
-        setType({
-          icon: isSendTx ? '/images/outgoing.svg' : '/images/incoming.svg',
-          text: isSendTx ? (isTxQueued(tx.txStatus) ? 'Send' : 'Sent') : 'Received',
-        })
-        break
-      }
-      case 'SettingsChange': {
-        // deleteGuard doesn't exist in Solidity
-        // It is decoded as 'setGuard' with a settingsInfo.type of 'DELETE_GUARD'
-        const isDeleteGuard = tx.txInfo.settingsInfo?.type === SettingsInfoType.DELETE_GUARD
-        setType({ icon: '/images/settings.svg', text: isDeleteGuard ? 'deleteGuard' : tx.txInfo.dataDecoded.method })
-        break
-      }
-      case 'Custom': {
-        if (isModuleExecutionInfo(tx.executionInfo)) {
-          const DEFAULT_MODULE_NAME = 'Module'
-
-          const { logoUri, name } = tx.txInfo.to
-
-          setType({
-            icon: logoUri || '/images/settings.svg',
-            text: name || DEFAULT_MODULE_NAME,
-          })
-          break
-        }
-
-        if (isCancellationTxInfo(tx.txInfo)) {
-          setType({ icon: '/images/circle-cross-red.svg', text: 'On-chain rejection' })
-          break
-        }
-
-        if (tx.safeAppInfo) {
-          setType({ icon: tx.safeAppInfo.logoUri, text: tx.safeAppInfo.name })
-          break
-        }
-
-        setType({
-          icon: toAddress?.logoUri || '/images/custom.svg',
-          text: toAddress?.name || 'Contract interaction',
-        })
-        break
+  switch (tx.txInfo.type) {
+    case TransactionInfoType.CREATION: {
+      return {
+        icon: toAddress?.logoUri || '/images/settings.svg',
+        text: 'Safe created',
       }
     }
-  }, [tx, toAddress?.logoUri, toAddress?.name])
+    case TransactionInfoType.TRANSFER: {
+      const isSendTx = tx.txInfo.direction === TransferDirection.OUTGOING
 
-  return type
+      return {
+        icon: isSendTx ? '/images/outgoing.svg' : '/images/incoming.svg',
+        text: isSendTx ? (isTxQueued(tx.txStatus) ? 'Send' : 'Sent') : 'Received',
+      }
+    }
+    case TransactionInfoType.SETTINGS_CHANGE: {
+      // deleteGuard doesn't exist in Solidity
+      // It is decoded as 'setGuard' with a settingsInfo.type of 'DELETE_GUARD'
+      const isDeleteGuard = tx.txInfo.settingsInfo?.type === SettingsInfoType.DELETE_GUARD
+
+      return {
+        icon: '/images/settings.svg',
+        text: isDeleteGuard ? 'deleteGuard' : tx.txInfo.dataDecoded.method,
+      }
+    }
+    case TransactionInfoType.CUSTOM: {
+      if (isModuleExecutionInfo(tx.executionInfo)) {
+        return {
+          icon: toAddress?.logoUri || '/images/settings.svg',
+          text: toAddress?.name || DEFAULT_MODULE_NAME,
+        }
+      }
+
+      if (isCancellationTxInfo(tx.txInfo)) {
+        return {
+          icon: '/images/circle-cross-red.svg',
+          text: 'On-chain rejection',
+        }
+      }
+
+      if (hasSafeAppInfo(tx)) {
+        return {
+          icon: tx.safeAppInfo.logoUri,
+          text: tx.safeAppInfo.name,
+        }
+      }
+
+      return {
+        icon: toAddress?.logoUri || '/images/custom.svg',
+        text: toAddress?.name || 'Contract interaction',
+      }
+    }
+    default: {
+      return {
+        icon: '/images/custom.svg',
+        text: 'Contract interaction',
+      }
+    }
+  }
+}
+
+export const useTransactionType = (tx: TransactionSummary): TxType => {
+  return useMemo(() => {
+    return getTxType(tx)
+  }, [tx])
 }

--- a/src/hooks/useTransactionType.ts
+++ b/src/hooks/useTransactionType.ts
@@ -9,7 +9,6 @@ import {
 import {
   isCancellationTxInfo,
   isModuleExecutionInfo,
-  hasSafeAppInfo,
   isTxQueued,
   TransactionInfoType,
 } from '@/utils/transaction-guards'
@@ -80,7 +79,7 @@ const getTxType = (tx: TransactionSummary): TxType => {
         }
       }
 
-      if (hasSafeAppInfo(tx)) {
+      if (tx.safeAppInfo) {
         return {
           icon: tx.safeAppInfo.logoUri,
           text: tx.safeAppInfo.name,

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -25,11 +25,7 @@ import {
 import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
 import { sameAddress } from '@/utils/addresses'
 import { getMultiSendCallOnlyContractAddress, getMultiSendContractAddress } from '@/services/contracts/safeContracts'
-import {
-  NativeCoinTransfer,
-  SafeAppInfo,
-  TransferInfo,
-} from '@gnosis.pm/safe-react-gateway-sdk/dist/types/transactions'
+import { NativeCoinTransfer, TransferInfo } from '@gnosis.pm/safe-react-gateway-sdk/dist/types/transactions'
 import { NamedAddress } from '@/components/create-safe/types'
 
 export const isTxQueued = (value: TransactionStatus): boolean => {
@@ -103,10 +99,6 @@ export const isMultiSendTxInfo = (value: TransactionInfo): value is MultiSend =>
 
 export const isCancellationTxInfo = (value: TransactionInfo): value is Cancellation => {
   return isCustomTxInfo(value) && value.isCancellation
-}
-
-export const hasSafeAppInfo = <T extends TransactionSummary>(value: T): value is T & { safeAppInfo: SafeAppInfo } => {
-  return !!value.safeAppInfo
 }
 
 export const isCreationTxInfo = (value: TransactionInfo): value is Creation => {

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -25,7 +25,11 @@ import {
 import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
 import { sameAddress } from '@/utils/addresses'
 import { getMultiSendCallOnlyContractAddress, getMultiSendContractAddress } from '@/services/contracts/safeContracts'
-import { NativeCoinTransfer, TransferInfo } from '@gnosis.pm/safe-react-gateway-sdk/dist/types/transactions'
+import {
+  NativeCoinTransfer,
+  SafeAppInfo,
+  TransferInfo,
+} from '@gnosis.pm/safe-react-gateway-sdk/dist/types/transactions'
 import { NamedAddress } from '@/components/create-safe/types'
 
 export const isTxQueued = (value: TransactionStatus): boolean => {
@@ -66,7 +70,7 @@ enum EXECUTION_INFO_TYPES {
 
 // TransactionInfo type guards
 // TODO: could be passed to Client GW SDK
-enum TransactionInfoType {
+export enum TransactionInfoType {
   TRANSFER = 'Transfer',
   SETTINGS_CHANGE = 'SettingsChange',
   CUSTOM = 'Custom',
@@ -99,6 +103,10 @@ export const isMultiSendTxInfo = (value: TransactionInfo): value is MultiSend =>
 
 export const isCancellationTxInfo = (value: TransactionInfo): value is Cancellation => {
   return isCustomTxInfo(value) && value.isCancellation
+}
+
+export const hasSafeAppInfo = <T extends TransactionSummary>(value: T): value is T & { safeAppInfo: SafeAppInfo } => {
+  return !!value.safeAppInfo
 }
 
 export const isCreationTxInfo = (value: TransactionInfo): value is Creation => {


### PR DESCRIPTION
## What it solves

Unnecessary side effect and inconsistent default module names

## How this PR fixes it

Unknown modules are now shown under the same name ("Unknown module") in the settings and transaction list.

`useTransactionType` has also been simplified to not rely on state/effects, abstracting the transaction `type` parsing into `getTxType`.

## How to test it

The transaction list `type`s (in the summary headers) should appear the same as before.
