### PR TITLE
WIP: fix: reinitialise pairing connector after disconnection

### DIFF
--- a/src/components/common/ConnectWallet/ConnectionCenter.tsx
+++ b/src/components/common/ConnectWallet/ConnectionCenter.tsx
@@ -9,7 +9,7 @@ import PairingDetails from '@/components/common/PairingDetails'
 
 import css from '@/components/common/ConnectWallet/styles.module.css'
 import { useCurrentChain } from '@/hooks/useChains'
-import { isPairingSupported } from '@/services/pairing/utils'
+import { isPairingSupported } from '@/hooks/wallets/wallets'
 
 const ConnectionCenter = (): ReactElement => {
   const chain = useCurrentChain()

--- a/src/components/create-safe/steps/ConnectWalletStep.tsx
+++ b/src/components/create-safe/steps/ConnectWalletStep.tsx
@@ -8,7 +8,7 @@ import { type ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import NetworkSelector from '@/components/common/NetworkSelector'
 import useIsWrongChain from '@/hooks/useIsWrongChain'
 import { useCurrentChain } from '@/hooks/useChains'
-import { isPairingSupported } from '@/services/pairing/utils'
+import { isPairingSupported } from '@/hooks/wallets/wallets'
 
 import css from '@/components/create-safe/steps/styles.module.css'
 

--- a/src/hooks/wallets/wallets.ts
+++ b/src/hooks/wallets/wallets.ts
@@ -13,6 +13,7 @@ import walletConnect from '@web3-onboard/walletconnect'
 
 import pairingModule from '@/services/pairing/module'
 import { type ConnectedWallet } from '@/hooks/wallets/useOnboard'
+import { getPairingConnector } from '@/services/pairing/connector'
 
 export const enum WALLET_KEYS {
   COINBASE = 'COINBASE',
@@ -42,7 +43,7 @@ export const CGW_NAMES: { [key in WALLET_KEYS]: string | undefined } = {
 
 const WALLET_MODULES: { [key in WALLET_KEYS]: () => WalletInit } = {
   [WALLET_KEYS.INJECTED]: injectedWalletModule,
-  [WALLET_KEYS.PAIRING]: pairingModule,
+  [WALLET_KEYS.PAIRING]: () => pairingModule({ connector: getPairingConnector()! }),
   [WALLET_KEYS.WALLETCONNECT]: () => walletConnect({ bridge: WC_BRIDGE }),
   [WALLET_KEYS.LEDGER]: ledgerModule,
   [WALLET_KEYS.TREZOR]: () => trezorModule({ appUrl: TREZOR_APP_URL, email: TREZOR_EMAIL }),
@@ -65,6 +66,10 @@ export const getRecommendedInjectedWallets = (): RecommendedInjectedWallets[] =>
 export const isWalletSupported = (disabledWallets: string[], walletLabel: string): boolean => {
   const legacyWalletName = CGW_NAMES?.[walletLabel.toUpperCase() as WALLET_KEYS]
   return !disabledWallets.includes(legacyWalletName || walletLabel)
+}
+
+export const isPairingSupported = (disabledWallets?: string[]) => {
+  return !!disabledWallets && isWalletSupported(disabledWallets, CGW_NAMES[WALLET_KEYS.PAIRING] as string)
 }
 
 export const getSupportedWallets = (disabledWallets: string[]): WalletInit[] => {

--- a/src/services/pairing/hooks.ts
+++ b/src/services/pairing/hooks.ts
@@ -23,12 +23,11 @@ let hasInitialized = false
 // WC has no flag to determine if a session is currently being created
 let isConnecting = false
 
-const canConnect = !connector.connected && !isConnecting
-
 export const useInitPairing = () => {
   const onboard = useOnboard()
   const chain = useCurrentChain()
 
+  const canConnect = !connector.connected && !isConnecting
   const isSupported = isPairingSupported(chain?.disabledWallets)
 
   const createSession = useCallback(() => {
@@ -43,7 +42,7 @@ export const useInitPairing = () => {
         isConnecting = false
       })
       .catch((e) => logError(Errors._303, (e as Error).message))
-  }, [chain, isSupported])
+  }, [chain, isSupported, canConnect])
 
   useEffect(() => {
     if (!onboard || !isSupported) {

--- a/src/services/pairing/hooks.ts
+++ b/src/services/pairing/hooks.ts
@@ -97,7 +97,7 @@ export const useInitPairing = () => {
     }
 
     killPairingSession(connector)
-  }, [chain, isSupported])
+  }, [chain, isSupported, canConnect])
 }
 
 /**

--- a/src/services/pairing/utils.ts
+++ b/src/services/pairing/utils.ts
@@ -1,8 +1,4 @@
-import WalletConnect from '@walletconnect/client'
-
-import { CGW_NAMES, WALLET_KEYS } from '@/hooks/wallets/wallets'
-
-export const formatPairingUri = (wcUri: string) => {
+export const formatPairingUri = (wcUri?: string) => {
   const PAIRING_MODULE_URI_PREFIX = 'safe-'
 
   // A disconnected session returns URI with an empty `key`
@@ -11,20 +7,4 @@ export const formatPairingUri = (wcUri: string) => {
   }
 
   return `${PAIRING_MODULE_URI_PREFIX}${wcUri}`
-}
-
-export const killPairingSession = (connector: InstanceType<typeof WalletConnect>) => {
-  const TEMP_PEER_ID = '_tempPeerId'
-
-  // WalletConnect throws if no `peerId` is set when attempting to `killSession`
-  // We therefore manually set it in order to `killSession` without throwing
-  if (!connector.peerId) {
-    connector.peerId = TEMP_PEER_ID
-  }
-
-  return connector.killSession()
-}
-
-export const isPairingSupported = (disabledWallets?: string[]) => {
-  return !!disabledWallets?.length && !disabledWallets.includes(CGW_NAMES[WALLET_KEYS.PAIRING] as string)
 }

--- a/src/services/pairing/utils/utils.test.ts
+++ b/src/services/pairing/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { formatPairingUri, isPairingSupported } from '../utils'
+import { formatPairingUri } from '../utils'
 
 describe('Pairing utils', () => {
   describe('formatPairingUri', () => {
@@ -19,21 +19,6 @@ describe('Pairing utils', () => {
 
       const result = formatPairingUri(uri)
       expect(result).toBeUndefined()
-    })
-  })
-
-  describe('isPairingSupported', () => {
-    it('should return true if the wallet is enabled', () => {
-      const result = isPairingSupported(['walletConnect'])
-      expect(result).toBe(true)
-    })
-
-    it('should return false if the wallet is disabled', () => {
-      const result1 = isPairingSupported([])
-      expect(result1).toBe(false)
-
-      const result2 = isPairingSupported(['safeMobile'])
-      expect(result2).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## What it solves

Resolves #488

## How this PR fixes it

Pairing session creation now depends on whether the pairing `connector `canConnect` `(!connector.connected` and `!isConnecting`).

## How to test it

1. Open the Safe on Rinkeby and pair via the mobile app.
2. Refresh the page and disconnect.
3. Pairing again should pair with Rinkeby.
