### PR TITLE
refactor: instantiate contracts via Core SDK

### DIFF
--- a/src/components/create-safe/sender.ts
+++ b/src/components/create-safe/sender.ts
@@ -38,7 +38,7 @@ export const getSafeCreationTx = ({
   const proxyContract = getProxyFactoryContractInstance(chain.chainId)
   const fallbackHandlerContract = getFallbackHandlerContractInstance(chain.chainId)
 
-  const setupData = safeContract.interface.encodeFunctionData('setup', [
+  const setupData = safeContract.encode('setup', [
     owners,
     threshold,
     ZERO_ADDRESS,
@@ -49,9 +49,5 @@ export const getSafeCreationTx = ({
     ZERO_ADDRESS,
   ])
 
-  return proxyContract.interface.encodeFunctionData('createProxyWithNonce', [
-    safeContract.address,
-    setupData,
-    saltNonce,
-  ])
+  return proxyContract.encode('createProxyWithNonce', [safeContract.getAddress(), setupData, saltNonce])
 }

--- a/src/components/create-safe/status/usePendingSafeCreation.ts
+++ b/src/components/create-safe/status/usePendingSafeCreation.ts
@@ -29,7 +29,7 @@ export const checkSafeCreationTx = async (provider: JsonRpcProvider, txHash: str
 
   try {
     const txResponse = await provider.getTransaction(txHash)
-    const proxyContractAddress = getProxyFactoryContractInstance(chainId).address
+    const proxyContractAddress = getProxyFactoryContractInstance(chainId).getAddress()
 
     const replacement = {
       data: txResponse.data,

--- a/src/components/create-safe/status/useSafeCreation.test.ts
+++ b/src/components/create-safe/status/useSafeCreation.test.ts
@@ -122,19 +122,11 @@ const provider = new JsonRpcProvider(undefined, { name: 'rinkeby', chainId: 4 })
 
 describe('monitorSafeCreationTx', () => {
   let waitForTxSpy = jest.spyOn(provider, '_waitForTransaction')
-  jest.spyOn(provider, 'getBlockNumber').mockReturnValue(Promise.resolve(4))
-  jest.spyOn(provider, 'getTransaction').mockReturnValue(
-    Promise.resolve({
-      data: '0x',
-      nonce: 1,
-      from: '0x10',
-      to: '0x11',
-      value: BigNumber.from(0),
-    } as TransactionResponse),
-  )
 
   beforeEach(() => {
     jest.resetAllMocks()
+
+    jest.spyOn(web3, 'getWeb3').mockImplementation(() => new Web3Provider(jest.fn()))
 
     waitForTxSpy = jest.spyOn(provider, '_waitForTransaction')
     jest.spyOn(provider, 'getBlockNumber').mockReturnValue(Promise.resolve(4))

--- a/src/components/create-safe/useEstimateSafeCreationGas.test.ts
+++ b/src/components/create-safe/useEstimateSafeCreationGas.test.ts
@@ -12,7 +12,7 @@ import { waitFor } from '@testing-library/react'
 import { type EIP1193Provider } from '@web3-onboard/core'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { BigNumber } from 'ethers'
-import { Proxy_factory } from '@/types/contracts/Proxy_factory'
+import GnosisSafeProxyFactoryEthersContract from '@gnosis.pm/safe-ethers-lib/dist/src/contracts/GnosisSafeProxyFactory/GnosisSafeProxyFactoryEthersContract'
 
 const mockProps = {
   owners: [],
@@ -28,7 +28,7 @@ describe('useEstimateSafeCreationGas', () => {
     jest.spyOn(chainIdModule, 'useChainId').mockReturnValue('4')
     jest
       .spyOn(safeContracts, 'getProxyFactoryContractInstance')
-      .mockReturnValue({ address: ZERO_ADDRESS } as unknown as Proxy_factory)
+      .mockReturnValue({ getAddress: () => ZERO_ADDRESS } as GnosisSafeProxyFactoryEthersContract)
     jest.spyOn(sender, 'getSafeCreationTx').mockReturnValue(EMPTY_DATA)
     jest.spyOn(wallet, 'default').mockReturnValue({} as ConnectedWallet)
   })

--- a/src/components/create-safe/useEstimateSafeCreationGas.ts
+++ b/src/components/create-safe/useEstimateSafeCreationGas.ts
@@ -29,17 +29,19 @@ export const useEstimateSafeCreationGas = ({
   const wallet = useWallet()
 
   const proxyContract = getProxyFactoryContractInstance(chainId)
+  const proxyContractAddress = proxyContract.getAddress()
+
   const encodedSafeCreationTx = getSafeCreationTx({ owners, threshold, saltNonce, chain: currentChain })
 
   const [gasLimit, gasLimitError, gasLimitLoading] = useAsync<BigNumber>(() => {
     if (!wallet?.address || !encodedSafeCreationTx || !web3ReadOnly) return
 
     return web3ReadOnly.estimateGas({
-      to: proxyContract.address,
+      to: proxyContractAddress,
       from: wallet.address,
       data: encodedSafeCreationTx,
     })
-  }, [proxyContract.address, wallet, encodedSafeCreationTx, web3ReadOnly])
+  }, [proxyContractAddress, wallet, encodedSafeCreationTx, web3ReadOnly])
 
   return { gasLimit, gasLimitError, gasLimitLoading }
 }

--- a/src/components/tx/modals/BatchExecuteModal/ReviewBatchExecute.tsx
+++ b/src/components/tx/modals/BatchExecuteModal/ReviewBatchExecute.tsx
@@ -32,7 +32,7 @@ const ReviewBatchExecute = ({ data, onSubmit }: { data: BatchExecuteData; onSubm
 
   const multiSendContract = useMemo(() => {
     if (!chain?.chainId) return
-    return getMultiSendCallOnlyContractInstance(chain.chainId)
+    return getMultiSendCallOnlyContractInstance(chain.chainId, safe.version)
   }, [chain?.chainId])
 
   const multiSendTxs = useMemo(() => {
@@ -65,61 +65,59 @@ const ReviewBatchExecute = ({ data, onSubmit }: { data: BatchExecuteData; onSubm
   const submitDisabled = loading || !isSubmittable
 
   return (
-    <div>
-      <DialogContent>
-        <Typography variant="body2" mb={2}>
-          This transaction batches a total of {data.txs.length} transactions from your queue into a single Ethereum
-          transaction. Please check every included transaction carefully, especially if you have rejection transactions,
-          and make sure you want to execute all of them. Included transactions are highlighted in green when you hover
-          over the execute button.
-        </Typography>
+    <DialogContent>
+      <Typography variant="body2" mb={2}>
+        This transaction batches a total of {data.txs.length} transactions from your queue into a single Ethereum
+        transaction. Please check every included transaction carefully, especially if you have rejection transactions,
+        and make sure you want to execute all of them. Included transactions are highlighted in green when you hover
+        over the execute button.
+      </Typography>
 
-        <Typography color="secondary.light">Interact with:</Typography>
-        {multiSendContract && (
-          <EthHashInfo address={multiSendContract.address} shortAddress={false} hasExplorer showCopyButton />
-        )}
+      <Typography color="secondary.light">Interact with:</Typography>
+      {multiSendContract && (
+        <EthHashInfo address={multiSendContract.getAddress()} shortAddress={false} hasExplorer showCopyButton />
+      )}
 
-        {multiSendTxData && (
-          <>
-            <Typography mt={2} color="secondary.light">
-              Data (hex encoded)
-            </Typography>
-            {generateDataRowValue(multiSendTxData, 'rawData')}
-          </>
-        )}
+      {multiSendTxData && (
+        <>
+          <Typography mt={2} color="secondary.light">
+            Data (hex encoded)
+          </Typography>
+          {generateDataRowValue(multiSendTxData, 'rawData')}
+        </>
+      )}
 
-        <Typography mt={2} color="secondary.light">
-          Batched transactions:
-        </Typography>
-        <DecodedTxs txs={txsWithDetails} numberOfTxs={data.txs.length} />
+      <Typography mt={2} color="secondary.light">
+        Batched transactions:
+      </Typography>
+      <DecodedTxs txs={txsWithDetails} numberOfTxs={data.txs.length} />
 
-        {multiSendTxs && <TxSimulation canExecute transactions={multiSendTxs} disabled={submitDisabled} />}
+      {multiSendTxs && <TxSimulation canExecute transactions={multiSendTxs} disabled={submitDisabled} />}
 
-        <Typography variant="body2" mt={2} textAlign="center">
-          Be aware that if any of the included transactions revert, none of them will be executed. This will result in
-          the loss of the allocated transaction fees.
-        </Typography>
+      <Typography variant="body2" mt={2} textAlign="center">
+        Be aware that if any of the included transactions revert, none of them will be executed. This will result in the
+        loss of the allocated transaction fees.
+      </Typography>
 
-        {error && (
-          <ErrorMessage error={error}>
-            This transaction will most likely fail. To save gas costs, avoid creating the transaction.
-          </ErrorMessage>
-        )}
+      {error && (
+        <ErrorMessage error={error}>
+          This transaction will most likely fail. To save gas costs, avoid creating the transaction.
+        </ErrorMessage>
+      )}
 
-        {submitError && (
-          <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
-        )}
+      {submitError && (
+        <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
+      )}
 
-        <Button
-          onClick={onExecute}
-          disabled={submitDisabled}
-          variant="contained"
-          sx={{ position: 'absolute', bottom: '24px', right: '24px', zIndex: 1 }}
-        >
-          Send
-        </Button>
-      </DialogContent>
-    </div>
+      <Button
+        onClick={onExecute}
+        disabled={submitDisabled}
+        variant="contained"
+        sx={{ position: 'absolute', bottom: '24px', right: '24px', zIndex: 1 }}
+      >
+        Send
+      </Button>
+    </DialogContent>
   )
 }
 

--- a/src/components/tx/modals/BatchExecuteModal/ReviewBatchExecute.tsx
+++ b/src/components/tx/modals/BatchExecuteModal/ReviewBatchExecute.tsx
@@ -33,7 +33,7 @@ const ReviewBatchExecute = ({ data, onSubmit }: { data: BatchExecuteData; onSubm
   const multiSendContract = useMemo(() => {
     if (!chain?.chainId) return
     return getMultiSendCallOnlyContractInstance(chain.chainId, safe.version)
-  }, [chain?.chainId])
+  }, [chain?.chainId, safe.version])
 
   const multiSendTxs = useMemo(() => {
     if (!txsWithDetails || !chain) return
@@ -65,59 +65,61 @@ const ReviewBatchExecute = ({ data, onSubmit }: { data: BatchExecuteData; onSubm
   const submitDisabled = loading || !isSubmittable
 
   return (
-    <DialogContent>
-      <Typography variant="body2" mb={2}>
-        This transaction batches a total of {data.txs.length} transactions from your queue into a single Ethereum
-        transaction. Please check every included transaction carefully, especially if you have rejection transactions,
-        and make sure you want to execute all of them. Included transactions are highlighted in green when you hover
-        over the execute button.
-      </Typography>
+    <div>
+      <DialogContent>
+        <Typography variant="body2" mb={2}>
+          This transaction batches a total of {data.txs.length} transactions from your queue into a single Ethereum
+          transaction. Please check every included transaction carefully, especially if you have rejection transactions,
+          and make sure you want to execute all of them. Included transactions are highlighted in green when you hover
+          over the execute button.
+        </Typography>
 
-      <Typography color="secondary.light">Interact with:</Typography>
-      {multiSendContract && (
-        <EthHashInfo address={multiSendContract.getAddress()} shortAddress={false} hasExplorer showCopyButton />
-      )}
+        <Typography color="secondary.light">Interact with:</Typography>
+        {multiSendContract && (
+          <EthHashInfo address={multiSendContract.getAddress()} shortAddress={false} hasExplorer showCopyButton />
+        )}
 
-      {multiSendTxData && (
-        <>
-          <Typography mt={2} color="secondary.light">
-            Data (hex encoded)
-          </Typography>
-          {generateDataRowValue(multiSendTxData, 'rawData')}
-        </>
-      )}
+        {multiSendTxData && (
+          <>
+            <Typography mt={2} color="secondary.light">
+              Data (hex encoded)
+            </Typography>
+            {generateDataRowValue(multiSendTxData, 'rawData')}
+          </>
+        )}
 
-      <Typography mt={2} color="secondary.light">
-        Batched transactions:
-      </Typography>
-      <DecodedTxs txs={txsWithDetails} numberOfTxs={data.txs.length} />
+        <Typography mt={2} color="secondary.light">
+          Batched transactions:
+        </Typography>
+        <DecodedTxs txs={txsWithDetails} numberOfTxs={data.txs.length} />
 
-      {multiSendTxs && <TxSimulation canExecute transactions={multiSendTxs} disabled={submitDisabled} />}
+        {multiSendTxs && <TxSimulation canExecute transactions={multiSendTxs} disabled={submitDisabled} />}
 
-      <Typography variant="body2" mt={2} textAlign="center">
-        Be aware that if any of the included transactions revert, none of them will be executed. This will result in the
-        loss of the allocated transaction fees.
-      </Typography>
+        <Typography variant="body2" mt={2} textAlign="center">
+          Be aware that if any of the included transactions revert, none of them will be executed. This will result in
+          the loss of the allocated transaction fees.
+        </Typography>
 
-      {error && (
-        <ErrorMessage error={error}>
-          This transaction will most likely fail. To save gas costs, avoid creating the transaction.
-        </ErrorMessage>
-      )}
+        {error && (
+          <ErrorMessage error={error}>
+            This transaction will most likely fail. To save gas costs, avoid creating the transaction.
+          </ErrorMessage>
+        )}
 
-      {submitError && (
-        <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
-      )}
+        {submitError && (
+          <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
+        )}
 
-      <Button
-        onClick={onExecute}
-        disabled={submitDisabled}
-        variant="contained"
-        sx={{ position: 'absolute', bottom: '24px', right: '24px', zIndex: 1 }}
-      >
-        Send
-      </Button>
-    </DialogContent>
+        <Button
+          onClick={onExecute}
+          disabled={submitDisabled}
+          variant="contained"
+          sx={{ position: 'absolute', bottom: '24px', right: '24px', zIndex: 1 }}
+        >
+          Send
+        </Button>
+      </DialogContent>
+    </div>
   )
 }
 

--- a/src/hooks/coreSDK/safeCoreSDK.ts
+++ b/src/hooks/coreSDK/safeCoreSDK.ts
@@ -4,7 +4,7 @@ import { ethers } from 'ethers'
 import EthersAdapter from '@gnosis.pm/safe-ethers-lib'
 import semverSatisfies from 'semver/functions/satisfies'
 import chains from '@/config/chains'
-import { Web3Provider } from '@ethersproject/providers'
+import { getWeb3 } from '@/hooks/wallets/web3'
 import ExternalStore from '@/services/ExternalStore'
 import type { SafeVersion } from '@gnosis.pm/safe-core-sdk-types'
 
@@ -13,12 +13,16 @@ const isLegacyVersion = (safeVersion: string): boolean => {
   return semverSatisfies(safeVersion, LEGACY_VERSION)
 }
 
-export const isSafeVersion = (safeVersion?: string): safeVersion is SafeVersion => {
+export const isValidSafeVersion = (safeVersion?: string): safeVersion is SafeVersion => {
   const SAFE_VERSIONS: SafeVersion[] = ['1.3.0', '1.2.0', '1.1.1']
   return !!safeVersion && SAFE_VERSIONS.some((version) => semverSatisfies(safeVersion, version))
 }
 
-export const createEthersAdapter = (provider: Web3Provider) => {
+export const createEthersAdapter = (provider = getWeb3()) => {
+  if (!provider) {
+    throw new Error('Unable to create `EthersAdapter` without a provider')
+  }
+
   const signer = provider.getSigner(0)
   return new EthersAdapter({
     ethers,

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -11,16 +11,37 @@ import { LATEST_SAFE_VERSION } from '@/config/constants'
 import { Contract } from 'ethers'
 import { Interface } from '@ethersproject/abi'
 import semverSatisfies from 'semver/functions/satisfies'
-import { type ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
-import { type Gnosis_safe } from '@/types/contracts/Gnosis_safe'
+import { SafeInfo, type ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
+import type { GetContractProps } from '@gnosis.pm/safe-core-sdk-types'
 import { type Compatibility_fallback_handler } from '@/types/contracts/Compatibility_fallback_handler'
-import { type Multi_send } from '@/types/contracts/Multi_send'
-import { type Proxy_factory } from '@/types/contracts/Proxy_factory'
-import { type Multi_send_call_only } from '@/types/contracts/Multi_send_call_only'
+import { createEthersAdapter, isValidSafeVersion } from '@/hooks/coreSDK/safeCoreSDK'
 
-// TODO: Retrieve contracts via Core SDK
+const getValidatedGetContractProps = (
+  chainId: string,
+  safeVersion: string,
+): Pick<GetContractProps, 'chainId' | 'safeVersion'> => {
+  if (!isValidSafeVersion(safeVersion)) {
+    throw new Error(`${safeVersion} is not a valid Safe version`)
+  }
 
-const getSafeContractDeployment = (chain: ChainInfo, safeVersion: string): SingletonDeployment | undefined => {
+  return {
+    chainId: +chainId,
+    safeVersion,
+  }
+}
+
+// GnosisSafe
+
+export const getSpecificGnosisSafeContractInstance = (safe: SafeInfo) => {
+  const ethAdapter = createEthersAdapter()
+
+  return ethAdapter.getSafeContract({
+    customContractAddress: safe.address.value,
+    ...getValidatedGetContractProps(safe.chainId, safe.version),
+  })
+}
+
+export const _getSafeContractDeployment = (chain: ChainInfo, safeVersion: string): SingletonDeployment | undefined => {
   // We check if version is prior to v1.0.0 as they are not supported but still we want to keep a minimum compatibility
   const useOldestContractVersion = semverSatisfies(safeVersion, '<1.0.0')
 
@@ -45,19 +66,84 @@ const getSafeContractDeployment = (chain: ChainInfo, safeVersion: string): Singl
   )
 }
 
-export const getGnosisSafeContractInstance = (chain: ChainInfo, safeVersion: string): Gnosis_safe => {
-  const safeSingletonDeployment = getSafeContractDeployment(chain, safeVersion)
+export const getGnosisSafeContractInstance = (chain: ChainInfo, safeVersion: string = LATEST_SAFE_VERSION) => {
+  const ethAdapter = createEthersAdapter()
 
-  if (!safeSingletonDeployment) {
-    throw new Error(`GnosisSafe contract not found for chainId: ${chain.chainId}`)
-  }
-  const contractAddress = safeSingletonDeployment.networkAddresses[chain.chainId]
-
-  return new Contract(contractAddress, safeSingletonDeployment.abi) as Gnosis_safe
+  return ethAdapter.getSafeContract({
+    singletonDeployment: _getSafeContractDeployment(chain, safeVersion),
+    ...getValidatedGetContractProps(chain.chainId, safeVersion),
+  })
 }
 
-export const getFallbackHandlerContractInstance = (chainId: string): Compatibility_fallback_handler => {
-  const fallbackHandlerDeployment =
+// MultiSend
+
+const getMultiSendContractDeployment = (chainId: string) => {
+  return getMultiSendDeployment({ network: chainId }) || getMultiSendDeployment()
+}
+
+export const getMultiSendContractAddress = (chainId: string): string | undefined => {
+  const deployment = getMultiSendContractDeployment(chainId)
+
+  return deployment?.networkAddresses[chainId]
+}
+
+export const getMultiSendContractInstance = (chainId: string, safeVersion: string = LATEST_SAFE_VERSION) => {
+  const ethAdapter = createEthersAdapter()
+
+  return ethAdapter.getMultiSendContract({
+    singletonDeployment: getMultiSendContractDeployment(chainId),
+    ...getValidatedGetContractProps(chainId, safeVersion),
+  })
+}
+
+// MultiSendCallOnly
+
+const getMultiSendCallOnlyContractDeployment = (chainId: string) => {
+  return getMultiSendCallOnlyDeployment({ network: chainId }) || getMultiSendCallOnlyDeployment()
+}
+
+export const getMultiSendCallOnlyContractAddress = (chainId: string): string | undefined => {
+  const deployment = getMultiSendCallOnlyContractDeployment(chainId)
+
+  return deployment?.networkAddresses[chainId]
+}
+
+export const getMultiSendCallOnlyContractInstance = (chainId: string, safeVersion: string = LATEST_SAFE_VERSION) => {
+  const ethAdapter = createEthersAdapter()
+
+  return ethAdapter.getMultiSendCallOnlyContract({
+    singletonDeployment: getMultiSendCallOnlyContractDeployment(chainId),
+    ...getValidatedGetContractProps(chainId, safeVersion),
+  })
+}
+
+// GnosisSafeProxyFactory
+
+const getProxyFactoryContractDeployment = (chainId: string) => {
+  return (
+    getProxyFactoryDeployment({
+      version: LATEST_SAFE_VERSION,
+      network: chainId,
+    }) ||
+    getProxyFactoryDeployment({
+      version: LATEST_SAFE_VERSION,
+    })
+  )
+}
+
+export const getProxyFactoryContractInstance = (chainId: string, safeVersion: string = LATEST_SAFE_VERSION) => {
+  const ethAdapter = createEthersAdapter()
+
+  return ethAdapter.getSafeProxyFactoryContract({
+    singletonDeployment: getProxyFactoryContractDeployment(chainId),
+    ...getValidatedGetContractProps(chainId, safeVersion),
+  })
+}
+
+// Fallback handler
+
+const getFallbackHandlerContractDeployment = (chainId: string) => {
+  return (
     getFallbackHandlerDeployment({
       version: LATEST_SAFE_VERSION,
       network: chainId,
@@ -65,6 +151,12 @@ export const getFallbackHandlerContractInstance = (chainId: string): Compatibili
     getFallbackHandlerDeployment({
       version: LATEST_SAFE_VERSION,
     })
+  )
+}
+
+// TODO: Yet to be implemented in Core SDK
+export const getFallbackHandlerContractInstance = (chainId: string): Compatibility_fallback_handler => {
+  const fallbackHandlerDeployment = getFallbackHandlerContractDeployment(chainId)
 
   if (!fallbackHandlerDeployment) {
     throw new Error(`FallbackHandler contract not found for chainId: ${chainId}`)
@@ -73,58 +165,4 @@ export const getFallbackHandlerContractInstance = (chainId: string): Compatibili
   const contractAddress = fallbackHandlerDeployment.networkAddresses[chainId]
 
   return new Contract(contractAddress, new Interface(fallbackHandlerDeployment.abi)) as Compatibility_fallback_handler
-}
-
-export const getMultiSendCallOnlyContractAddress = (chainId: string): string | undefined => {
-  const deployment = getMultiSendCallOnlyDeployment({ network: chainId }) || getMultiSendCallOnlyDeployment()
-
-  return deployment?.networkAddresses[chainId]
-}
-
-export const getMultiSendCallOnlyContractInstance = (chainId: string): Multi_send_call_only => {
-  const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId }) || getMultiSendCallOnlyDeployment()
-
-  if (!multiSendDeployment) {
-    throw new Error(`MultiSendCallOnly contract not found for chainId: ${chainId}`)
-  }
-
-  const contractAddress = multiSendDeployment.networkAddresses[chainId]
-
-  return new Contract(contractAddress, new Interface(multiSendDeployment.abi)) as Multi_send_call_only
-}
-
-export const getMultiSendContractAddress = (chainId: string): string | undefined => {
-  const deployment = getMultiSendDeployment({ network: chainId }) || getMultiSendDeployment()
-
-  return deployment?.networkAddresses[chainId]
-}
-
-const getMultiSendContractInstance = (chainId: string): Multi_send => {
-  const multiSendDeployment = getMultiSendDeployment({ network: chainId }) || getMultiSendDeployment()
-
-  if (!multiSendDeployment) {
-    throw new Error(`MultiSend contract not found for chainId: ${chainId}`)
-  }
-
-  const contractAddress = multiSendDeployment.networkAddresses[chainId]
-
-  return new Contract(contractAddress, new Interface(multiSendDeployment.abi)) as Multi_send
-}
-
-export const getProxyFactoryContractInstance = (chainId: string): Proxy_factory => {
-  const proxyFactoryDeployment =
-    getProxyFactoryDeployment({
-      version: LATEST_SAFE_VERSION,
-      network: chainId.toString(),
-    }) ||
-    getProxyFactoryDeployment({
-      version: LATEST_SAFE_VERSION,
-    })
-
-  if (!proxyFactoryDeployment) {
-    throw new Error(`GnosisSafeProxyFactory contract not found for chainId: ${chainId}`)
-  }
-  const contractAddress = proxyFactoryDeployment.networkAddresses[chainId]
-
-  return new Contract(contractAddress, proxyFactoryDeployment.abi) as Proxy_factory
 }

--- a/src/services/contracts/spendingLimitContracts.ts
+++ b/src/services/contracts/spendingLimitContracts.ts
@@ -3,6 +3,7 @@ import { getAllowanceModuleDeployment } from '@gnosis.pm/safe-modules-deployment
 import { AllowanceModule, AllowanceModule__factory } from '@/types/contracts'
 import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers'
 
+// TODO: Yet to be implemented in Core SDK
 export const getSpendingLimitModuleAddress = (chainId: string): string | undefined => {
   const deployment = getAllowanceModuleDeployment({ network: chainId })
 

--- a/src/services/tx/__tests__/safeUpdateParams.test.ts
+++ b/src/services/tx/__tests__/safeUpdateParams.test.ts
@@ -8,10 +8,14 @@ import { ChainInfo, SafeInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { ethers } from 'ethers'
 import { CHANGE_FALLBACK_HANDLER_ABI, CHANGE_MASTER_COPY_ABI, createUpdateSafeTxs } from '../safeUpdateParams'
 import { LATEST_SAFE_VERSION } from '@/config/constants'
+import { Web3Provider } from '@ethersproject/providers'
+import * as web3 from '@/hooks/wallets/web3'
 
 const MOCK_SAFE_ADDRESS = '0x0000000000000000000000000000000000005AFE'
 
 describe('safeUpgradeParams', () => {
+  jest.spyOn(web3, 'getWeb3').mockImplementation(() => new Web3Provider(jest.fn()))
+
   it('Should upgrade L1 safe to L1 1.3.0', () => {
     const mockSafe = {
       address: {

--- a/src/services/tx/safeUpdateParams.ts
+++ b/src/services/tx/safeUpdateParams.ts
@@ -15,16 +15,12 @@ export const CHANGE_FALLBACK_HANDLER_ABI = 'function setFallbackHandler(address 
 export const createUpdateSafeTxs = (safe: SafeInfo, chain: ChainInfo): MetaTransactionData[] => {
   const latestMasterCopy = getGnosisSafeContractInstance(chain, LATEST_SAFE_VERSION)
   const safeContractInstance = getGnosisSafeContractInstance(chain, safe.version)
-  const safeContractInterface = safeContractInstance.interface
+
   // @ts-expect-error this was removed in 1.3.0 but we need to support it for older safe versions
-  const changeMasterCopyCallData = safeContractInterface.encodeFunctionData('changeMasterCopy', [
-    latestMasterCopy.address,
-  ])
+  const changeMasterCopyCallData = safeContractInstance.encode('changeMasterCopy', [latestMasterCopy.getAddress()])
 
   const fallbackHandlerAddress = getFallbackHandlerContractInstance(chain.chainId).address
-  const changeFallbackHandlerCallData = safeContractInterface.encodeFunctionData('setFallbackHandler', [
-    fallbackHandlerAddress,
-  ])
+  const changeFallbackHandlerCallData = safeContractInstance.encode('setFallbackHandler', [fallbackHandlerAddress])
 
   const txs: MetaTransactionData[] = [
     {

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -99,7 +99,7 @@ export const getMultiSendTxs = (
       const args = extractTxInfo(tx, safeAddress)
       const sigs = getSignatures(args.signatures)
 
-      const data = safeContractInstance.interface.encodeFunctionData('execTransaction', [
+      const data = safeContractInstance.encode('execTransaction', [
         args.txParams.to,
         args.txParams.value,
         args.txParams.data,


### PR DESCRIPTION
## What it solves

Using the Core SDK to get contract instances.

## How this PR fixes it

All (possible) contract instance retrievals are now done via the Core SDK so that we rely less on TypeChain.

## How to test it

- Safe creation and associated gas estimation works as expected.
- Interrupted Safe creation transactions succeed.
- Batch execution works as expected.
- Safe updating works as expected.