### PR TITLE
fix: show connected wallet chain info

### DIFF
--- a/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -6,7 +6,6 @@ import EthHashInfo from '@/components/common/EthHashInfo'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import useOnboard, { lastWalletStorage } from '@/hooks/wallets/useOnboard'
-import useChainId from '@/hooks/useChainId'
 import { useAppSelector } from '@/store'
 import { selectChainById } from '@/store/chainsSlice'
 import Identicon from '@/components/common/Identicon'
@@ -19,8 +18,7 @@ const WalletIcon = dynamic(() => import('@/components/common/WalletIcon'))
 const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
   const onboard = useOnboard()
-  const chainId = useChainId()
-  const chainInfo = useAppSelector((state) => selectChainById(state, chainId))
+  const chainInfo = useAppSelector((state) => selectChainById(state, wallet.chainId))
   const addressBook = useAddressBook()
 
   const handleDisconnect = () => {
@@ -60,7 +58,15 @@ const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
             </Typography>
 
             <Typography variant="caption" fontWeight="bold" className={css.address}>
-              {wallet.ens || <EthHashInfo address={wallet.address} showName={false} showAvatar avatarSize={12} />}
+              {wallet.ens || (
+                <EthHashInfo
+                  prefix={chainInfo?.shortName}
+                  address={wallet.address}
+                  showName={false}
+                  showAvatar
+                  avatarSize={12}
+                />
+              )}
             </Typography>
           </Box>
 


### PR DESCRIPTION
## What it solves
The `<AccountCenter />` displays the selected network instead of the connected wallet network.

## How this PR fixes it
 `<AccountCenter />` component now displays the connected wallet chain information. This change aligns the UI with showing the `<ChainSwitcher />` component.

## How to test it
1. Connect to the app with a wallet that doesn't disconnect on switching chains (p.ex. MetaMask)
2. In the Network Selector change network.
3. The connected wallet should remain aligned with MM

## Screenshots
_before_
![Screenshot 2022-09-01 at 21 45 07](https://user-images.githubusercontent.com/32431609/188012249-4c445c94-a115-4ec5-a928-0f151aa0b4b6.png)

_after_
![Screenshot 2022-09-01 at 22 57 04](https://user-images.githubusercontent.com/32431609/188012261-36725fc7-2470-4eb1-8198-4c2bdf3c9e9d.png)
