### PR TITLE
fix: use `eth_sign` + always send tx `value` when paired

### DIFF
--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -9,7 +9,7 @@ import useGasLimit from '@/hooks/useGasLimit'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import AdvancedParams, { type AdvancedParameters, useAdvancedParams } from '@/components/tx/AdvancedParams'
-import { isHardwareWallet } from '@/hooks/wallets/wallets'
+import { isHardwareWallet, isPaired } from '@/hooks/wallets/wallets'
 import DecodedTx from '../DecodedTx'
 import ExecuteCheckbox from '../ExecuteCheckbox'
 import { logError, Errors } from '@/services/exceptions'
@@ -88,8 +88,8 @@ const SignOrExecuteForm = ({
   const onSign = async (): Promise<string> => {
     const [connectedWallet, createdTx] = assertSubmittable()
 
-    const hardwareWallet = isHardwareWallet(connectedWallet)
-    const signedTx = await dispatchTxSigning(createdTx, hardwareWallet, txId)
+    const shouldSignTypedData = !isHardwareWallet(connectedWallet) || !isPaired(connectedWallet)
+    const signedTx = await dispatchTxSigning(createdTx, shouldSignTypedData, txId)
 
     const proposedTx = await dispatchTxProposal(safe.chainId, safeAddress, connectedWallet.address, signedTx, txId)
     return proposedTx.txId

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -88,8 +88,8 @@ const SignOrExecuteForm = ({
   const onSign = async (): Promise<string> => {
     const [connectedWallet, createdTx] = assertSubmittable()
 
-    const shouldSignTypedData = !isHardwareWallet(connectedWallet) || !isPaired(connectedWallet)
-    const signedTx = await dispatchTxSigning(createdTx, shouldSignTypedData, txId)
+    const shouldEthSign = isHardwareWallet(connectedWallet) || isPaired(connectedWallet)
+    const signedTx = await dispatchTxSigning(createdTx, shouldEthSign, txId)
 
     const proposedTx = await dispatchTxProposal(safe.chainId, safeAddress, connectedWallet.address, signedTx, txId)
     return proposedTx.txId

--- a/src/hooks/wallets/wallets.ts
+++ b/src/hooks/wallets/wallets.ts
@@ -11,7 +11,7 @@ import torusModule from '@web3-onboard/torus'
 import trezorModule from '@web3-onboard/trezor'
 import walletConnect from '@web3-onboard/walletconnect'
 
-import pairingModule from '@/services/pairing/module'
+import pairingModule, { PAIRING_MODULE_LABEL } from '@/services/pairing/module'
 import { type ConnectedWallet } from '@/hooks/wallets/useOnboard'
 
 export const enum WALLET_KEYS {
@@ -75,4 +75,8 @@ export const getSupportedWallets = (disabledWallets: string[]): WalletInit[] => 
 
 export const isHardwareWallet = (wallet: ConnectedWallet): boolean => {
   return [WALLET_KEYS.LEDGER, WALLET_KEYS.TREZOR].includes(wallet.label.toUpperCase() as WALLET_KEYS)
+}
+
+export const isPaired = (wallet: ConnectedWallet): boolean => {
+  return wallet.label === PAIRING_MODULE_LABEL
 }

--- a/src/services/pairing/module.ts
+++ b/src/services/pairing/module.ts
@@ -173,14 +173,20 @@ const pairingModule = (): WalletInit => {
                 }
 
                 case ProviderMethods.ETH_SEND_TRANSACTION: {
-                  return this.connector.sendTransaction(params![0] as ITxData)
+                  const txData = params![0] as ITxData
+
+                  return this.connector.sendTransaction({
+                    ...txData,
+                    // Mobile app expects `value`
+                    value: txData.value || '0x0',
+                  })
                 }
 
                 case ProviderMethods.ETH_SIGN_TRANSACTION: {
                   return this.connector.signTransaction(params![0] as ITxData)
                 }
 
-                // Pairing only supports `eth_sign` but the emitted event is `personal_sign`
+                // Mobile app only supports `eth_sign` but emits `personal_sign` event
                 case ProviderMethods.PERSONAL_SIGN: {
                   const [safeTxHash, sender] = params as [string, string]
                   return this.connector.signMessage([sender, safeTxHash]) // `eth_sign`
@@ -195,16 +201,17 @@ const pairingModule = (): WalletInit => {
                   })
                 }
 
-                case ProviderMethods.ETH_SIGN: // Not supported by pairing
-                case ProviderMethods.ETH_SIGN_TYPED_DATA: // Not supported by pairing
-                case ProviderMethods.ETH_SIGN_TYPED_DATA_V3: // Not supported by pairing
-                case ProviderMethods.ETH_SIGN_TYPED_DATA_V4: // Not supported by pairing
+                // Not supported by mobile app
+                case ProviderMethods.ETH_SIGN:
+                case ProviderMethods.ETH_SIGN_TYPED_DATA:
+                case ProviderMethods.ETH_SIGN_TYPED_DATA_V3:
+                case ProviderMethods.ETH_SIGN_TYPED_DATA_V4:
+                // Not supported by WC
                 case ProviderMethods.ETH_SELECT_ACCOUNTS:
                 case ProviderMethods.WALLET_SWITCH_ETHEREUM_CHAIN: {
-                  console.log('unsupported', method, params)
                   throw new ProviderRpcError({
                     code: ProviderRpcErrorCode.UNSUPPORTED_METHOD,
-                    message: `The Provider does not support the requested method: ${method}`,
+                    message: `The Mobile Safe does not support the requested method: ${method}`,
                   })
                 }
 

--- a/src/services/pairing/module.ts
+++ b/src/services/pairing/module.ts
@@ -22,6 +22,8 @@ enum ProviderMethods {
   ETH_SIGN_TRANSACTION = 'eth_signTransaction',
   ETH_SIGN = 'eth_sign',
   ETH_SIGN_TYPED_DATA = 'eth_signTypedData',
+  ETH_SIGN_TYPED_DATA_V3 = 'eth_signTypedData_v3',
+  ETH_SIGN_TYPED_DATA_V4 = 'eth_signTypedData_v4',
   ETH_ACCOUNTS = 'eth_accounts',
   WALLET_SWITCH_ETHEREUM_CHAIN = 'wallet_switchEthereumChain',
 }
@@ -178,16 +180,10 @@ const pairingModule = (): WalletInit => {
                   return this.connector.signTransaction(params![0] as ITxData)
                 }
 
+                // Pairing only supports `eth_sign` but the emitted event is `personal_sign`
                 case ProviderMethods.PERSONAL_SIGN: {
-                  return this.connector.signPersonalMessage(params!)
-                }
-
-                case ProviderMethods.ETH_SIGN: {
-                  return this.connector.signMessage(params!)
-                }
-
-                case ProviderMethods.ETH_SIGN_TYPED_DATA: {
-                  return this.connector.signTypedData(params!)
+                  const [safeTxHash, sender] = params as [string, string]
+                  return this.connector.signMessage([sender, safeTxHash]) // `eth_sign`
                 }
 
                 case ProviderMethods.ETH_ACCOUNTS: {
@@ -199,8 +195,13 @@ const pairingModule = (): WalletInit => {
                   })
                 }
 
+                case ProviderMethods.ETH_SIGN: // Not supported by pairing
+                case ProviderMethods.ETH_SIGN_TYPED_DATA: // Not supported by pairing
+                case ProviderMethods.ETH_SIGN_TYPED_DATA_V3: // Not supported by pairing
+                case ProviderMethods.ETH_SIGN_TYPED_DATA_V4: // Not supported by pairing
                 case ProviderMethods.ETH_SELECT_ACCOUNTS:
                 case ProviderMethods.WALLET_SWITCH_ETHEREUM_CHAIN: {
+                  console.log('unsupported', method, params)
                   throw new ProviderRpcError({
                     code: ProviderRpcErrorCode.UNSUPPORTED_METHOD,
                     message: `The Provider does not support the requested method: ${method}`,

--- a/src/services/tx/__tests__/txSender.test.ts
+++ b/src/services/tx/__tests__/txSender.test.ts
@@ -141,21 +141,21 @@ describe('txSender', () => {
         data: '0x0',
       })
 
-      const signedTx = await dispatchTxSigning(tx, false, '0x345')
+      const signedTx = await dispatchTxSigning(tx, true, '0x345')
 
       expect(mockSafeSDK.createTransaction).toHaveBeenCalled()
       expect(mockSafeSDK.signTransaction).toHaveBeenCalledWith(expect.anything(), 'eth_signTypedData')
       expect(signedTx).not.toBe(tx)
     })
 
-    it('should sign a tx with eth_sign if a hardware wallet is connected', async () => {
+    it('should sign a tx with eth_sign if a hardware wallet/pairing is connected', async () => {
       const tx = await createTx({
         to: '0x123',
         value: '1',
         data: '0x0',
       })
 
-      const signedTx = await dispatchTxSigning(tx, true, '0x345')
+      const signedTx = await dispatchTxSigning(tx, false, '0x345')
 
       expect(mockSafeSDK.createTransaction).toHaveBeenCalled()
       expect(mockSafeSDK.signTransaction).toHaveBeenCalledWith(expect.anything(), 'eth_sign')

--- a/src/services/tx/__tests__/txSender.test.ts
+++ b/src/services/tx/__tests__/txSender.test.ts
@@ -141,7 +141,7 @@ describe('txSender', () => {
         data: '0x0',
       })
 
-      const signedTx = await dispatchTxSigning(tx, true, '0x345')
+      const signedTx = await dispatchTxSigning(tx, false, '0x345')
 
       expect(mockSafeSDK.createTransaction).toHaveBeenCalled()
       expect(mockSafeSDK.signTransaction).toHaveBeenCalledWith(expect.anything(), 'eth_signTypedData')
@@ -155,7 +155,7 @@ describe('txSender', () => {
         data: '0x0',
       })
 
-      const signedTx = await dispatchTxSigning(tx, false, '0x345')
+      const signedTx = await dispatchTxSigning(tx, true, '0x345')
 
       expect(mockSafeSDK.createTransaction).toHaveBeenCalled()
       expect(mockSafeSDK.signTransaction).toHaveBeenCalledWith(expect.anything(), 'eth_sign')

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -170,11 +170,11 @@ export const dispatchTxProposal = async (
  */
 export const dispatchTxSigning = async (
   safeTx: SafeTransaction,
-  isHardwareWallet: boolean,
+  shouldSignTypedData: boolean,
   txId?: string,
 ): Promise<SafeTransaction> => {
   const sdk = getAndValidateSafeSDK()
-  const signingMethod = isHardwareWallet ? 'eth_sign' : 'eth_signTypedData'
+  const signingMethod = shouldSignTypedData ? 'eth_signTypedData' : 'eth_sign'
 
   let signedTx: SafeTransaction | undefined
   try {

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -170,11 +170,11 @@ export const dispatchTxProposal = async (
  */
 export const dispatchTxSigning = async (
   safeTx: SafeTransaction,
-  shouldSignTypedData: boolean,
+  shouldEthSign: boolean,
   txId?: string,
 ): Promise<SafeTransaction> => {
   const sdk = getAndValidateSafeSDK()
-  const signingMethod = shouldSignTypedData ? 'eth_signTypedData' : 'eth_sign'
+  const signingMethod = shouldEthSign ? 'eth_sign' : 'eth_signTypedData'
 
   let signedTx: SafeTransaction | undefined
   try {


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/web-core/issues/485

## How this PR fixes it

- Signing transactions now work: `personal_sign` event is emmitted by mobile app, signed with WC's `signMessage` (`eth_sign`).
- Sending transactions now work: an empty `value` is added to the `ITXData` payload of `sendTransaction` (`eth_sendTransaction`)

## How to test it

- Create and sign a transaction. Observe that it is added to the queue.
- Execute a transaction. Observe that it successfully executes.