### PR TITLE
style: adjust Sidebar media query

### DIFF
--- a/src/components/sidebar/Sidebar/styles.module.css
+++ b/src/components/sidebar/Sidebar/styles.module.css
@@ -64,7 +64,7 @@
   transform: translateX(-25%);
 }
 
-@media (max-width: 600px) {
+@media (max-width: 900px) {
   .container {
     padding-top: var(--header-height);
   }


### PR DESCRIPTION
## What it solves
The Mobile `Sidebar` is covered by the `Header` for some viewport widths

## How this PR fixes it
The Sidebar media query is adjusted to apply `padding-top` to the Mobile Sidebar

## How to test it
1. Adjust the viewport width to 700px
2. Click the Menu button
3. The Sidebar is no longer under the Header bar

## Screenshots
_before_
<img width="724" alt="Screenshot 2022-09-05 at 00 22 25" src="https://user-images.githubusercontent.com/32431609/188335705-3b910fc9-d112-46f0-94e5-8081954b3634.png">

_after_
<img width="722" alt="Screenshot 2022-09-05 at 00 22 02" src="https://user-images.githubusercontent.com/32431609/188335716-c76a762c-fb66-4970-8222-8e1786ec3a2e.png">
