### PR TITLE
fix: do not pass version metadata to Core SDK

### DIFF
--- a/src/hooks/coreSDK/__tests__/safeCoreSDK.test.ts
+++ b/src/hooks/coreSDK/__tests__/safeCoreSDK.test.ts
@@ -1,0 +1,26 @@
+import { isValidSafeVersion } from '../safeCoreSDK'
+
+describe('safeCoreSDK', () => {
+  describe('isValidSafeVersion', () => {
+    it('should return true for valid versions', () => {
+      expect(isValidSafeVersion('1.3.0')).toBe(true)
+
+      expect(isValidSafeVersion('1.2.0')).toBe(true)
+
+      expect(isValidSafeVersion('1.1.1')).toBe(true)
+
+      expect(isValidSafeVersion('1.3.0+L2')).toBe(true)
+    })
+    it('should return false for invalid versions', () => {
+      expect(isValidSafeVersion('1.3.1')).toBe(false)
+
+      expect(isValidSafeVersion('1.4.0')).toBe(false)
+
+      expect(isValidSafeVersion('1.0.0')).toBe(false)
+
+      expect(isValidSafeVersion('')).toBe(false)
+
+      expect(isValidSafeVersion()).toBe(false)
+    })
+  })
+})

--- a/src/services/__tests__/safeContracts.test.ts
+++ b/src/services/__tests__/safeContracts.test.ts
@@ -1,0 +1,36 @@
+import { _getValidatedGetContractProps } from '../contracts/safeContracts'
+
+describe('safeContracts', () => {
+  describe('getValidatedGetContractProps', () => {
+    it('should return the correct props', () => {
+      expect(_getValidatedGetContractProps('1', '1.1.1')).toEqual({
+        chainId: 1,
+        safeVersion: '1.1.1',
+      })
+
+      expect(_getValidatedGetContractProps('1', '1.2.0')).toEqual({
+        chainId: 1,
+        safeVersion: '1.2.0',
+      })
+
+      expect(_getValidatedGetContractProps('1', '1.3.0')).toEqual({
+        chainId: 1,
+        safeVersion: '1.3.0',
+      })
+
+      expect(_getValidatedGetContractProps('1', '1.3.0+L2')).toEqual({
+        chainId: 1,
+        safeVersion: '1.3.0',
+      })
+    })
+    it('should throw if the Safe version is invalid', () => {
+      expect(() => _getValidatedGetContractProps('1', '1.3.1')).toThrow('1.3.1 is not a valid Safe version')
+
+      expect(() => _getValidatedGetContractProps('1', '1.4.0')).toThrow('1.4.0 is not a valid Safe version')
+
+      expect(() => _getValidatedGetContractProps('1', '1.0.0')).toThrow('1.0.0 is not a valid Safe version')
+
+      expect(() => _getValidatedGetContractProps('1', '')).toThrow(' is not a valid Safe version')
+    })
+  })
+})

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -12,11 +12,11 @@ import { Contract } from 'ethers'
 import { Interface } from '@ethersproject/abi'
 import semverSatisfies from 'semver/functions/satisfies'
 import { SafeInfo, type ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
-import type { GetContractProps } from '@gnosis.pm/safe-core-sdk-types'
+import type { GetContractProps, SafeVersion } from '@gnosis.pm/safe-core-sdk-types'
 import { type Compatibility_fallback_handler } from '@/types/contracts/Compatibility_fallback_handler'
 import { createEthersAdapter, isValidSafeVersion } from '@/hooks/coreSDK/safeCoreSDK'
 
-const getValidatedGetContractProps = (
+export const _getValidatedGetContractProps = (
   chainId: string,
   safeVersion: string,
 ): Pick<GetContractProps, 'chainId' | 'safeVersion'> => {
@@ -24,9 +24,13 @@ const getValidatedGetContractProps = (
     throw new Error(`${safeVersion} is not a valid Safe version`)
   }
 
+  // TODO: Implement in Core SDK
+  // Remove '+L2' metadata from version
+  const [noMetadataVersion] = safeVersion.split('+')
+
   return {
     chainId: +chainId,
-    safeVersion,
+    safeVersion: noMetadataVersion as SafeVersion,
   }
 }
 
@@ -37,7 +41,7 @@ export const getSpecificGnosisSafeContractInstance = (safe: SafeInfo) => {
 
   return ethAdapter.getSafeContract({
     customContractAddress: safe.address.value,
-    ...getValidatedGetContractProps(safe.chainId, safe.version),
+    ..._getValidatedGetContractProps(safe.chainId, safe.version),
   })
 }
 
@@ -71,7 +75,7 @@ export const getGnosisSafeContractInstance = (chain: ChainInfo, safeVersion: str
 
   return ethAdapter.getSafeContract({
     singletonDeployment: _getSafeContractDeployment(chain, safeVersion),
-    ...getValidatedGetContractProps(chain.chainId, safeVersion),
+    ..._getValidatedGetContractProps(chain.chainId, safeVersion),
   })
 }
 
@@ -92,7 +96,7 @@ export const getMultiSendContractInstance = (chainId: string, safeVersion: strin
 
   return ethAdapter.getMultiSendContract({
     singletonDeployment: getMultiSendContractDeployment(chainId),
-    ...getValidatedGetContractProps(chainId, safeVersion),
+    ..._getValidatedGetContractProps(chainId, safeVersion),
   })
 }
 
@@ -113,7 +117,7 @@ export const getMultiSendCallOnlyContractInstance = (chainId: string, safeVersio
 
   return ethAdapter.getMultiSendCallOnlyContract({
     singletonDeployment: getMultiSendCallOnlyContractDeployment(chainId),
-    ...getValidatedGetContractProps(chainId, safeVersion),
+    ..._getValidatedGetContractProps(chainId, safeVersion),
   })
 }
 
@@ -136,7 +140,7 @@ export const getProxyFactoryContractInstance = (chainId: string, safeVersion: st
 
   return ethAdapter.getSafeProxyFactoryContract({
     singletonDeployment: getProxyFactoryContractDeployment(chainId),
-    ...getValidatedGetContractProps(chainId, safeVersion),
+    ..._getValidatedGetContractProps(chainId, safeVersion),
   })
 }
 

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -25,7 +25,7 @@ export const _getValidatedGetContractProps = (
   }
 
   // TODO: Implement in Core SDK
-  // Remove '+L2' metadata from version
+  // Remove '+L2'/'+Circles' metadata from version
   const [noMetadataVersion] = safeVersion.split('+')
 
   return {


### PR DESCRIPTION
## What it solves

Resolves #508

## How this PR fixes it

Metadata is stripped from version number.

## How to test it

When getting contract instances via the Core SDK, it only accepts versions `1.1.1`, `1.2.0` or `1.3.0`. The `version` of L2 Safes includes `+L2` metadata. This is now stripped before getting contract instances from the Core SDK.