### PR TITLE
fix: only prefix addresses

### DIFF
--- a/src/components/common/EthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/index.tsx
@@ -85,7 +85,7 @@ const PrefixedEthHashInfo = ({
   const addressBook = useAddressBook()
 
   const name = showName ? props.name || addressBook[props.address] : undefined
-  const prefix = settings.shortName.show ? chain?.shortName : undefined
+  const prefix = props.address.length === 42 && settings.shortName.show ? chain?.shortName : undefined
 
   return <EthHashInfo prefix={prefix} {...props} name={name} />
 }


### PR DESCRIPTION
## What it solves

Hashes being prefixed

## How this PR fixes it

`EthHashInfo` only adds prefixes to `props.address` lengths of `42`. Hashes are therefore no longer prefixed.

## How to test it

Open transaction details and observe the "Transaction hash" and "safeTxHash" having no prefix.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/188486114-0e79cac7-3c0f-4bae-b8dc-c7caa6c032d4.png)
