### PR TITLE
fix: remove unnecessary/categorise stepper events

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -11,8 +11,6 @@ import NotificationCenter from '@/components/notification-center/NotificationCen
 import { AppRoutes } from '@/config/routes'
 import useChainId from '@/hooks/useChainId'
 import SafeLogo from '@/public/logo.svg'
-import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
-import Track from '../Track'
 import Link from 'next/link'
 
 type HeaderProps = {
@@ -32,13 +30,11 @@ const Header = ({ onMenuToggle }: HeaderProps): ReactElement => {
       </div>
 
       <div className={classnames(css.element, css.hideMobile, css.logo)}>
-        <Track {...OVERVIEW_EVENTS.HOME}>
-          <Link href={AppRoutes.index} passHref>
-            <a>
-              <SafeLogo alt="Safe logo" />
-            </a>
-          </Link>
-        </Track>
+        <Link href={AppRoutes.index} passHref>
+          <a>
+            <SafeLogo alt="Safe logo" />
+          </a>
+        </Link>
       </div>
 
       <div className={classnames(css.element, css.hideMobile)}>

--- a/src/components/create-safe/index.tsx
+++ b/src/components/create-safe/index.tsx
@@ -12,6 +12,7 @@ import { CreationStatus } from '@/components/create-safe/status/CreationStatus'
 import { usePendingSafe } from '@/components/create-safe/usePendingSafe'
 import useChainId from '@/hooks/useChainId'
 import { SafeFormData } from '@/components/create-safe/types.d'
+import { CREATE_SAFE_CATEGORY } from '@/services/analytics'
 
 export type PendingSafeData = SafeFormData & { txHash?: string; saltNonce: number }
 export type PendingSafeByChain = Record<string, PendingSafeData | undefined>
@@ -64,7 +65,12 @@ const CreateSafe = () => {
   return safeCreationPending ? (
     <CreationStatus onClose={onClose} />
   ) : (
-    <VerticalTxStepper steps={CreateSafeSteps} onClose={onClose} onFinish={onFinish} />
+    <VerticalTxStepper
+      steps={CreateSafeSteps}
+      onClose={onClose}
+      onFinish={onFinish}
+      eventCategory={CREATE_SAFE_CATEGORY}
+    />
   )
 }
 

--- a/src/components/load-safe/index.tsx
+++ b/src/components/load-safe/index.tsx
@@ -9,6 +9,7 @@ import SetAddressStep from '@/components/load-safe/steps/SetAddressStep'
 import SafeReviewStep from '@/components/load-safe/steps/SafeReviewStep'
 import SelectNetworkStep from '@/components/load-safe/steps/SelectNetworkStep'
 import { SafeFormData } from '@/components/create-safe/types'
+import { LOAD_SAFE_CATEGORY } from '@/services/analytics'
 
 export const LoadSafeSteps: TxStepperProps['steps'] = [
   {
@@ -48,6 +49,7 @@ const LoadSafe = ({
       initialStep={initialStep}
       initialData={initialData}
       onClose={() => router.push(AppRoutes.welcome)}
+      eventCategory={LOAD_SAFE_CATEGORY}
     />
   )
 }

--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -3,7 +3,6 @@ import { Accordion, AccordionDetails, AccordionSummary, Skeleton, Typography, Li
 import { useCurrentChain } from '@/hooks/useChains'
 import { formatVisualAmount } from '@/utils/formatters'
 import { type AdvancedParameters } from '../AdvancedParams/types'
-import Track from '@/components/common/Track'
 import { trackEvent, MODALS_EVENTS } from '@/services/analytics'
 
 const GasDetail = ({ name, value, isLoading }: { name: string; value: string; isLoading: boolean }): ReactElement => {
@@ -90,11 +89,9 @@ const GasParams = ({ params, isExecution, onEdit }: GasParamsProps): ReactElemen
         )}
 
         {!isExecution || (isExecution && !isLoading) ? (
-          <Track {...MODALS_EVENTS.EDIT_ESTIMATION}>
-            <Link component="button" onClick={onEditClick} sx={{ mt: 2 }} fontSize="medium">
-              Edit
-            </Link>
-          </Track>
+          <Link component="button" onClick={onEditClick} sx={{ mt: 2 }} fontSize="medium">
+            Edit
+          </Link>
         ) : (
           <Skeleton variant="text" sx={{ display: 'inline-block', minWidth: '2em', mt: 2 }} />
         )}

--- a/src/components/tx/TxStepper/useTxStepper.ts
+++ b/src/components/tx/TxStepper/useTxStepper.ts
@@ -22,22 +22,30 @@ export type TxStepperProps = {
   steps: Array<Step>
   initialData?: unknown[]
   initialStep?: number
+  eventCategory?: string
   onClose: () => void
   onFinish?: () => void
 }
 
-export const useTxStepper = ({ steps, initialData, initialStep, onClose, onFinish }: TxStepperProps) => {
+export const useTxStepper = ({
+  steps,
+  initialData,
+  initialStep,
+  eventCategory = MODALS_CATEGORY,
+  onClose,
+  onFinish,
+}: TxStepperProps) => {
   const [activeStep, setActiveStep] = useState<number>(initialStep || 0)
   const [stepData, setStepData] = useState<Array<unknown>>(initialData || [])
 
   const handleNext = () => {
     setActiveStep((prevActiveStep) => prevActiveStep + 1)
-    trackEvent({ category: MODALS_CATEGORY, action: lastStep ? 'Submit' : 'Next' })
+    trackEvent({ category: eventCategory, action: lastStep ? 'Submit' : 'Next' })
   }
 
   const handleBack = () => {
     setActiveStep((prevActiveStep) => prevActiveStep - 1)
-    trackEvent({ category: MODALS_CATEGORY, action: firstStep ? 'Cancel' : 'Back' })
+    trackEvent({ category: eventCategory, action: firstStep ? 'Cancel' : 'Back' })
   }
 
   const setStep = (step: number) => {

--- a/src/services/analytics/events/createLoadSafe.ts
+++ b/src/services/analytics/events/createLoadSafe.ts
@@ -1,6 +1,6 @@
 import { EventType } from '@/services/analytics/types'
 
-const CREATE_SAFE_CATEGORY = 'create-safe'
+export const CREATE_SAFE_CATEGORY = 'create-safe'
 
 export const CREATE_SAFE_EVENTS = {
   CREATE_BUTTON: {
@@ -57,7 +57,7 @@ export const CREATE_SAFE_EVENTS = {
   },
 }
 
-const LOAD_SAFE_CATEGORY = 'load-safe'
+export const LOAD_SAFE_CATEGORY = 'load-safe'
 
 export const LOAD_SAFE_EVENTS = {
   LOAD_BUTTON: {

--- a/src/services/analytics/events/modals.ts
+++ b/src/services/analytics/events/modals.ts
@@ -30,10 +30,6 @@ export const MODALS_EVENTS = {
     action: 'Estimation',
     category: MODALS_CATEGORY,
   },
-  EDIT_ESTIMATION: {
-    action: 'Edit estimation',
-    category: MODALS_CATEGORY,
-  },
   EXECUTE_TX: {
     action: 'Execute transaction',
     category: MODALS_CATEGORY,

--- a/src/services/analytics/events/overview.ts
+++ b/src/services/analytics/events/overview.ts
@@ -3,10 +3,6 @@ import { EventType } from '@/services/analytics/types'
 const OVERVIEW_CATEGORY = 'overview'
 
 export const OVERVIEW_EVENTS = {
-  HOME: {
-    action: 'Go to Welcome page',
-    category: OVERVIEW_CATEGORY,
-  },
   // TODO: Not yet in web-core
   IPHONE_APP_BUTTON: {
     action: 'Download App',


### PR DESCRIPTION
## What it solves

Resolves #471 

## Analytics changes

1. Clicking the logo no longer dispatches the "Go to Welcome page" event.
2. Editing the advanced parameters of a transaction only dispatches "Edit advanced params". ("Edit estimation" has been removed).
3. Navigating forward/backwards in the Safe load/creation flow dispatches the following: (Before it dispatched under the `'modals'` category).
```ts
  { eventCategory: 'load-safe'/'create-safe', eventAction: 'Next'/'Submit'/'Cancel'/'Back' }
```

## How to test it

1. Clicking the logo should dispatch no event.
2. Opening the advanced parameters modal should only dispatch one event.
3. Going forward/backward in Safe load/creation flows should be categorised correctly. Forward/backward navigation in modals should be categorised under `'modals'`.