### PR TITLE
fix: cleanup `EthHashInfo` + add tests

### DIFF
--- a/src/components/common/CopyAddressButton/index.tsx
+++ b/src/components/common/CopyAddressButton/index.tsx
@@ -1,13 +1,11 @@
 import { type ReactElement } from 'react'
-import { useCurrentChain } from '@/hooks/useChains'
 import { useAppSelector } from '@/store'
 import { selectSettings } from '@/store/settingsSlice'
 import CopyButton from '../CopyButton'
 
-const CopyAddressButton = ({ address }: { address: string }): ReactElement => {
+const CopyAddressButton = ({ prefix, address }: { prefix?: string; address: string }): ReactElement => {
   const settings = useAppSelector(selectSettings)
-  const chain = useCurrentChain()
-  const addressText = settings.shortName.copy && chain ? `${chain.shortName}:${address}` : address
+  const addressText = settings.shortName.copy && prefix ? `${prefix}:${address}` : address
 
   return <CopyButton text={addressText} />
 }

--- a/src/components/common/EthHashInfo/index.test.tsx
+++ b/src/components/common/EthHashInfo/index.test.tsx
@@ -1,0 +1,352 @@
+import makeBlockie from 'ethereum-blockies-base64'
+import type { ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
+
+import { act, fireEvent, render, waitFor } from '@/tests/test-utils'
+import * as useAddressBook from '@/hooks/useAddressBook'
+import * as useChainId from '@/hooks/useChainId'
+import * as store from '@/store'
+import EthHashInfo from '.'
+
+const originalClipboard = { ...global.navigator.clipboard }
+
+const MOCK_SAFE_ADDRESS = '0x0000000000000000000000000000000000005AFE'
+
+jest.mock('@/hooks/useAddressBook')
+jest.mock('@/hooks/useChainId')
+
+describe('EthHashInfo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    jest.spyOn(useAddressBook, 'default').mockImplementation(() => ({
+      [MOCK_SAFE_ADDRESS]: 'Address book name',
+    }))
+
+    //@ts-ignore
+    global.navigator.clipboard = {
+      writeText: jest.fn(() => Promise.resolve()),
+    }
+  })
+
+  afterEach(() => {
+    //@ts-ignore
+    global.navigator.clipboard = originalClipboard
+  })
+
+  describe('address', () => {
+    it('renders a shortened address by default', () => {
+      const { queryByText } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} />)
+
+      expect(queryByText('0x0000...5AFE')).toBeInTheDocument()
+    })
+
+    it('renders a full address', () => {
+      const { queryByText } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} shortAddress={false} />)
+
+      expect(queryByText(MOCK_SAFE_ADDRESS)).toBeInTheDocument()
+    })
+  })
+
+  describe('prefix', () => {
+    it('renders the current chain prefix by default', () => {
+      jest.spyOn(useChainId, 'default').mockReturnValue('4')
+
+      jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
+        selector({
+          session: {},
+          settings: {
+            shortName: {
+              show: true,
+            },
+          },
+          chains: {
+            data: [{ chainId: '4', shortName: 'rin' }],
+          },
+        } as store.RootState),
+      )
+
+      const { queryByText } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} />)
+
+      expect(queryByText('rin:')).toBeInTheDocument()
+    })
+
+    it('renders the chain prefix associated with the given chainId', () => {
+      jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
+        selector({
+          session: {},
+          settings: {
+            shortName: {
+              show: true,
+            },
+          },
+          chains: {
+            data: [
+              { chainId: '4', shortName: 'rin' },
+              { chainId: '100', shortName: 'gno' },
+            ],
+          },
+        } as store.RootState),
+      )
+
+      const { queryByText } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} chainId="100" />)
+
+      expect(queryByText('gno:')).toBeInTheDocument()
+    })
+
+    it('renders a custom prefix', () => {
+      jest.spyOn(store, 'useAppSelector').mockReturnValue({
+        shortName: {
+          show: true,
+        },
+      })
+
+      const { queryByText } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} prefix="test" />)
+
+      expect(queryByText('test:')).toBeInTheDocument()
+    })
+
+    it("doesn't prefix non-addresses", () => {
+      jest.spyOn(useChainId, 'default').mockReturnValue('4')
+
+      jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
+        selector({
+          session: {},
+          settings: {
+            shortName: {
+              show: true,
+            },
+          },
+          chains: {
+            data: [{ chainId: '4', shortName: 'rin' }],
+          },
+        } as store.RootState),
+      )
+
+      const result1 = render(
+        <EthHashInfo address="0xe26920604f9a02c5a877d449faa71b7504f0c2508dcc7c0384078a024b8e592f" />,
+      )
+
+      expect(result1.queryByText('rin:')).not.toBeInTheDocument()
+
+      const result2 = render(<EthHashInfo address="0x123" />)
+
+      expect(result2.queryByText('rin:')).not.toBeInTheDocument()
+    })
+
+    it("doesn't render the prefix when disabled in the settings", () => {
+      jest.spyOn(store, 'useAppSelector').mockReturnValue({
+        shortName: {
+          show: false,
+        },
+      })
+
+      const { queryByText } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} />)
+
+      expect(queryByText('rin:')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('name', () => {
+    it('renders a name by default', () => {
+      const { queryByText } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} name="Test" />)
+
+      expect(queryByText('Test')).toBeInTheDocument()
+    })
+
+    it('renders a name from the address book', () => {
+      const { queryByText } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} />)
+
+      expect(queryByText('Address book name')).toBeInTheDocument()
+    })
+
+    it('hides a name', () => {
+      const { queryByText } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} name="Test" showName={false} />)
+
+      expect(queryByText('Test')).not.toBeInTheDocument()
+      expect(queryByText('Address book name')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('avatar', () => {
+    it('renders an avatar by default', () => {
+      const { container } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} />)
+
+      expect(container.querySelector('.icon')).toHaveAttribute(
+        'style',
+        `background-image: url(${makeBlockie(MOCK_SAFE_ADDRESS)}); width: 40px; height: 40px;`,
+      )
+    })
+
+    it('allows for sizing of avatars', () => {
+      const { container } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} avatarSize={100} />)
+
+      expect(container.querySelector('.icon')).toHaveAttribute(
+        'style',
+        `background-image: url(${makeBlockie(MOCK_SAFE_ADDRESS)}); width: 100px; height: 100px;`,
+      )
+    })
+
+    it('renders a custom avatar', () => {
+      const { container } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} customAvatar="./test.jpg" />)
+
+      expect(container.querySelector('img')).toHaveAttribute('src', './test.jpg')
+    })
+
+    it('allows for sizing of custom avatars', () => {
+      const { container } = render(
+        <EthHashInfo address={MOCK_SAFE_ADDRESS} customAvatar="./test.jpg" avatarSize={100} />,
+      )
+
+      const avatar = container.querySelector('img')
+
+      expect(avatar).toHaveAttribute('src', './test.jpg')
+      expect(avatar).toHaveAttribute('width', '100')
+      expect(avatar).toHaveAttribute('height', '100')
+    })
+
+    it('falls back to an identicon', async () => {
+      const { container } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} customAvatar="" />)
+
+      await waitFor(() => {
+        expect(container.querySelector('.icon')).toBeInTheDocument()
+      })
+    })
+
+    it('hides the avatar', () => {
+      const { container } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} showAvatar={false} />)
+
+      expect(container.querySelector('.icon')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('copy button', () => {
+    it("doesn't show the copy button by default", () => {
+      const { container } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} />)
+
+      expect(container.querySelector('button')).not.toBeInTheDocument()
+    })
+
+    it('shows the copy button', () => {
+      const { container } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} showCopyButton />)
+
+      expect(container.querySelector('button')).toBeInTheDocument()
+    })
+
+    it('copies the default prefixed address', async () => {
+      jest.spyOn(useChainId, 'default').mockReturnValue('4')
+
+      jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
+        selector({
+          session: {},
+          settings: {
+            shortName: {
+              show: true,
+              copy: true,
+            },
+          },
+          chains: {
+            data: [{ chainId: '4', shortName: 'rin' }],
+          },
+        } as store.RootState),
+      )
+
+      const { container } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} showCopyButton />)
+
+      const button = container.querySelector('button')
+
+      await act(() => {
+        fireEvent.click(button!)
+      })
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(`rin:${MOCK_SAFE_ADDRESS}`)
+    })
+
+    it('copies the selected chainId prefix', async () => {
+      jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
+        selector({
+          session: {},
+          settings: {
+            shortName: {
+              show: true,
+              copy: true,
+            },
+          },
+          chains: {
+            data: [
+              { chainId: '4', shortName: 'rin' },
+              { chainId: '100', shortName: 'gno' },
+            ],
+          },
+        } as store.RootState),
+      )
+
+      const { container } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} showCopyButton chainId="100" />)
+
+      const button = container.querySelector('button')
+
+      await act(() => {
+        fireEvent.click(button!)
+      })
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(`gno:${MOCK_SAFE_ADDRESS}`)
+    })
+
+    it('copies the raw address', async () => {
+      jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
+        selector({
+          session: {},
+          settings: {
+            shortName: {
+              show: true,
+              copy: false,
+            },
+          },
+          chains: {
+            data: [] as ChainInfo[],
+          },
+        } as store.RootState),
+      )
+
+      const { container } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} showCopyButton />)
+
+      const button = container.querySelector('button')
+
+      await act(() => {
+        fireEvent.click(button!)
+      })
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(MOCK_SAFE_ADDRESS)
+    })
+  })
+
+  describe('block explorer', () => {
+    it("doesn't render the block explorer link by default", () => {
+      const { container } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} />)
+
+      expect(container.querySelector('a')).not.toBeInTheDocument()
+    })
+    it('renders the block explorer link', () => {
+      jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
+        selector({
+          session: {},
+          settings: { shortName: {} },
+          chains: {
+            data: [
+              {
+                chainId: '4',
+                blockExplorerUriTemplate: { address: 'https://rinkeby.etherscan.io/address/{{address}}' },
+              },
+            ],
+          },
+        } as store.RootState),
+      )
+
+      const { container } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} hasExplorer />)
+
+      expect(container.querySelector('a')).toHaveAttribute(
+        'href',
+        'https://rinkeby.etherscan.io/address/0x0000000000000000000000000000000000005AFE',
+      )
+    })
+  })
+})

--- a/src/components/common/EthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/index.tsx
@@ -9,7 +9,8 @@ import ExplorerLink from '@/components/common/TokenExplorerLink'
 import CopyAddressButton from '@/components/common/CopyAddressButton'
 import { useAppSelector } from '@/store'
 import { selectSettings } from '@/store/settingsSlice'
-import { useCurrentChain } from '@/hooks/useChains'
+import { selectChainById } from '@/store/chainsSlice'
+import useChainId from '@/hooks/useChainId'
 
 type EthHashInfoProps = {
   address: string
@@ -18,7 +19,6 @@ type EthHashInfoProps = {
   showAvatar?: boolean
   showCopyButton?: boolean
   prefix?: string
-  copyPrefix?: boolean
   shortAddress?: boolean
   customAvatar?: string
   hasExplorer?: boolean
@@ -32,7 +32,9 @@ const EthHashInfo = ({
   shortAddress = true,
   showAvatar = true,
   avatarSize,
-  ...props
+  name,
+  showCopyButton,
+  hasExplorer,
 }: EthHashInfoProps): ReactElement => {
   const [fallbackToIdenticon, setFallbackToIdenticon] = useState(false)
 
@@ -55,9 +57,9 @@ const EthHashInfo = ({
       )}
 
       <div className={css.nameRow}>
-        {props.name && (
-          <Typography variant="body2" component="div" textOverflow="ellipsis" overflow="hidden" title={props.name}>
-            {props.name}
+        {name && (
+          <Typography variant="body2" component="div" textOverflow="ellipsis" overflow="hidden" title={name}>
+            {name}
           </Typography>
         )}
 
@@ -67,9 +69,9 @@ const EthHashInfo = ({
             {shortAddress ? shortenAddress(address) : address}
           </Typography>
 
-          {props.showCopyButton && <CopyAddressButton address={address} />}
+          {showCopyButton && <CopyAddressButton prefix={prefix} address={address} />}
 
-          {props.hasExplorer && <ExplorerLink address={address} />}
+          {hasExplorer && <ExplorerLink address={address} />}
         </Box>
       </div>
     </div>
@@ -81,7 +83,8 @@ const PrefixedEthHashInfo = ({
   ...props
 }: EthHashInfoProps & { showName?: boolean }): ReactElement => {
   const settings = useAppSelector(selectSettings)
-  const chain = useCurrentChain()
+  const currentChainId = useChainId()
+  const chain = useAppSelector((state) => selectChainById(state, props.chainId || currentChainId))
   const addressBook = useAddressBook()
 
   const name = showName ? props.name || addressBook[props.address] : undefined


### PR DESCRIPTION
## What it solves

Untested `EthHashInfo`

## How this PR fixes it

- `<EthHashInfo>` is now fully covered by unit tests.
- `props.copyPrefix` has been removed as `<CopyAddressButton>` determines this based on settings.
- The prefix is not retrieved from `useCurrentChain`. It is instead selected via props.chainId`/`useChainId`.
- In accordance with this, `<CopyAddressButton>` is passed a specific `prefix` to match the selected chain instead of using `useCurrentChain`.

## How to test it

- Addresses/hashes should appear the same in the UI depending on the prefix settings. Copying the address/prefix should also prepend the prefix according to the settings.
- `src/components/common/EthHashInfo/index.test.tsx` should pass.