### PR TITLE
add tracking and tooltip to token widget

### DIFF
--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -2,11 +2,13 @@ import { SAFE_TOKEN_ADDRESSES } from '@/config/constants'
 import { AppRoutes } from '@/config/routes'
 import useBalances from '@/hooks/useBalances'
 import useChainId from '@/hooks/useChainId'
+import { OVERVIEW_EVENTS } from '@/services/analytics'
 import { formatAmountWithPrecision } from '@/utils/formatNumber'
 import { safeFormatUnits } from '@/utils/formatters'
-import { Box, ButtonBase, Skeleton, Typography } from '@mui/material'
+import { Box, ButtonBase, Skeleton, Tooltip, Typography } from '@mui/material'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import Track from '../Track'
 
 import SafeTokenIcon from './safe_token.svg'
 
@@ -38,14 +40,24 @@ const SafeTokenWidget = () => {
 
   return (
     <Box className={css.buttonContainer}>
-      <Link href={url} passHref>
-        <ButtonBase aria-describedby={'safe-token-widget'} sx={{ alignSelf: 'stretch' }} className={css.tokenButton}>
-          <SafeTokenIcon />
-          <Typography lineHeight="16px" fontWeight={700}>
-            {balances.loading ? <Skeleton variant="text" width={16} /> : flooredSafeBalance}
-          </Typography>
-        </ButtonBase>
-      </Link>
+      <Tooltip title="Open $SAFE Claiming App">
+        <span>
+          <Track {...OVERVIEW_EVENTS.SAFE_TOKEN_WIDGET}>
+            <Link href={url} passHref>
+              <ButtonBase
+                aria-describedby={'safe-token-widget'}
+                sx={{ alignSelf: 'stretch' }}
+                className={css.tokenButton}
+              >
+                <SafeTokenIcon />
+                <Typography lineHeight="16px" fontWeight={700}>
+                  {balances.loading ? <Skeleton variant="text" width={16} /> : flooredSafeBalance}
+                </Typography>
+              </ButtonBase>
+            </Link>
+          </Track>
+        </span>
+      </Tooltip>
     </Box>
   )
 }

--- a/src/services/analytics/events/overview.ts
+++ b/src/services/analytics/events/overview.ts
@@ -73,4 +73,8 @@ export const OVERVIEW_EVENTS = {
     action: 'Remove Safe from sidebar',
     category: OVERVIEW_CATEGORY,
   },
+  SAFE_TOKEN_WIDGET: {
+    action: 'Open safe claiming app from widget',
+    category: OVERVIEW_CATEGORY,
+  },
 }

--- a/src/services/analytics/events/overview.ts
+++ b/src/services/analytics/events/overview.ts
@@ -74,7 +74,7 @@ export const OVERVIEW_EVENTS = {
     category: OVERVIEW_CATEGORY,
   },
   SAFE_TOKEN_WIDGET: {
-    action: 'Open safe claiming app from widget',
+    action: 'Open Safe Claiming App from widget',
     category: OVERVIEW_CATEGORY,
   },
 }


### PR DESCRIPTION
## What it solves
Adds tracking & tooltip to safe token widget.

## How to test it
Hover over widget.
Click on widget => new event gets tracked

## Analytics changes
New Event: Click on Safe Claiming App Widget

## Screenshots

![localhost_3000_rin_0x979774d85274A5F63C85786aC4Fa54B9A4f391c2_home (1)](https://user-images.githubusercontent.com/2670790/188591023-83a02535-8d5e-4edc-8b49-42b61dc50b3a.png)
