### PR TITLE
fix: load/interface with GTM directly

### DIFF
--- a/src/services/analytics/TagManager.ts
+++ b/src/services/analytics/TagManager.ts
@@ -8,10 +8,6 @@ export type TagManagerArgs = {
    */
   gtmId: string
   /**
-   * Additional events such as 'gtm.start': new Date().getTime(),event:'gtm.js'.
-   */
-  events?: Record<string, unknown> | undefined
-  /**
    * Used to set environments.
    */
   auth?: string | undefined
@@ -27,16 +23,9 @@ export type TagManagerArgs = {
 
 export const DATA_LAYER_NAME = 'dataLayer'
 
-export const _getRequiredGtmArgs = ({
-  gtmId,
-  events = {},
-  dataLayer = undefined,
-  auth = '',
-  preview = '',
-}: TagManagerArgs) => {
+export const _getRequiredGtmArgs = ({ gtmId, dataLayer = undefined, auth = '', preview = '' }: TagManagerArgs) => {
   return {
     gtmId,
-    events,
     dataLayer,
     auth: auth ? `&gtm_auth=${auth}` : '',
     preview: preview ? `&gtm_preview=${preview}` : '',
@@ -46,17 +35,21 @@ export const _getRequiredGtmArgs = ({
 // Initialization scripts
 
 export const _getGtmScript = (args: TagManagerArgs) => {
-  const { gtmId, events, auth, preview } = _getRequiredGtmArgs(args)
+  const { gtmId, auth, preview } = _getRequiredGtmArgs(args)
 
   const script = document.createElement('script')
 
   const gtmScript = `
-      (function(w,d,s,l,i){w[l]=w[l]||[];
-        w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js', ${JSON.stringify(events).slice(1, -1)}});
-        var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
-        j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+'${auth}${preview}&gtm_cookies_win=x';
-        f.parentNode.insertBefore(j,f);
-      })(window,document,'script','${DATA_LAYER_NAME}','${gtmId}');`
+    (function (w, d, s, l, i) {
+      w[l] = w[l] || [];
+      w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+      var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s),
+        dl = l != 'dataLayer' ? '&l=' + l : '';
+      j.async = true;
+      j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl + '${auth}${preview}&gtm_cookies_win=x';
+      f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', '${DATA_LAYER_NAME}', '${gtmId}');`
 
   script.innerHTML = gtmScript
 
@@ -96,7 +89,8 @@ const TagManager = {
     const { dataLayer } = _getRequiredGtmArgs(args)
 
     if (dataLayer) {
-      document.createElement('script').innerHTML = JSON.stringify(dataLayer)
+      const gtmDataLayerScript = _getGtmDataLayerScript(dataLayer)
+      document.head.appendChild(gtmDataLayerScript)
     }
 
     const gtmScript = _getGtmScript(args)

--- a/src/services/analytics/TagManager.ts
+++ b/src/services/analytics/TagManager.ts
@@ -1,0 +1,118 @@
+// Based on https://github.com/alinemorelli/react-gtm
+
+type DataLayer = Record<string, unknown>
+
+export type TagManagerArgs = {
+  /**
+   * GTM id, must be something like GTM-000000.
+   */
+  gtmId: string
+  /**
+   * Additional events such as 'gtm.start': new Date().getTime(),event:'gtm.js'.
+   */
+  events?: Record<string, unknown> | undefined
+  /**
+   * Used to set environments.
+   */
+  auth?: string | undefined
+  /**
+   * Used to set environments, something like env-00.
+   */
+  preview?: string | undefined
+  /**
+   * Object that contains all of the information that you want to pass to Google Tag Manager.
+   */
+  dataLayer?: DataLayer | undefined
+}
+
+export const DATA_LAYER_NAME = 'dataLayer'
+
+export const _getRequiredGtmArgs = ({
+  gtmId,
+  events = {},
+  dataLayer = undefined,
+  auth = '',
+  preview = '',
+}: TagManagerArgs) => {
+  return {
+    gtmId,
+    events,
+    dataLayer,
+    auth: auth ? `&gtm_auth=${auth}` : '',
+    preview: preview ? `&gtm_preview=${preview}` : '',
+  }
+}
+
+// Initialization scripts
+
+export const _getGtmScript = (args: TagManagerArgs) => {
+  const { gtmId, events, auth, preview } = _getRequiredGtmArgs(args)
+
+  const script = document.createElement('script')
+
+  const gtmScript = `
+      (function(w,d,s,l,i){w[l]=w[l]||[];
+        w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js', ${JSON.stringify(events).slice(1, -1)}});
+        var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+        j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+'${auth}${preview}&gtm_cookies_win=x';
+        f.parentNode.insertBefore(j,f);
+      })(window,document,'script','${DATA_LAYER_NAME}','${gtmId}');`
+
+  script.innerHTML = gtmScript
+
+  return script
+}
+
+export const _getGtmNoScript = (args: TagManagerArgs) => {
+  const { gtmId, auth, preview } = _getRequiredGtmArgs(args)
+
+  const noscript = document.createElement('noscript')
+
+  const gtmIframe = `
+      <iframe src="https://www.googletagmanager.com/ns.html?id=${gtmId}${auth}${preview}&gtm_cookies_win=x"
+        height="0" width="0" style="display:none;visibility:hidden" id="tag-manager"></iframe>`
+
+  noscript.innerHTML = gtmIframe
+
+  return noscript
+}
+
+// Data layer scripts
+
+export const _getGtmDataLayerScript = (dataLayer: DataLayer) => {
+  const script = document.createElement('script')
+
+  const gtmDataLayerScript = `
+      window.${DATA_LAYER_NAME} = window.${DATA_LAYER_NAME} || [];
+      window.${DATA_LAYER_NAME}.push(${JSON.stringify(dataLayer)})`
+
+  script.innerHTML = gtmDataLayerScript
+
+  return script
+}
+
+const TagManager = {
+  initialize: (args: TagManagerArgs) => {
+    const { dataLayer } = _getRequiredGtmArgs(args)
+
+    if (dataLayer) {
+      document.createElement('script').innerHTML = JSON.stringify(dataLayer)
+    }
+
+    const gtmScript = _getGtmScript(args)
+    document.head.insertBefore(gtmScript, document.head.childNodes[0])
+
+    const gtmNoScript = _getGtmNoScript(args)
+    document.body.insertBefore(gtmNoScript, document.body.childNodes[0])
+  },
+  dataLayer: (dataLayer: DataLayer) => {
+    if (window[DATA_LAYER_NAME]) {
+      return window[DATA_LAYER_NAME].push(dataLayer)
+    }
+
+    const gtmDataLayerScript = _getGtmDataLayerScript(dataLayer)
+    document.head.insertBefore(gtmDataLayerScript, document.head.childNodes[0])
+  },
+}
+
+export default TagManager

--- a/src/services/analytics/__tests__/TagManager.test.ts
+++ b/src/services/analytics/__tests__/TagManager.test.ts
@@ -13,7 +13,6 @@ describe('TagManager', () => {
 
       expect(result1).toStrictEqual({
         gtmId: MOCK_ID,
-        events: {},
         dataLayer: undefined,
         auth: '',
         preview: '',
@@ -23,7 +22,6 @@ describe('TagManager', () => {
 
       expect(result2).toStrictEqual({
         gtmId: MOCK_ID,
-        events: {},
         dataLayer: undefined,
         auth: '&gtm_auth=abcdefg',
         preview: '&gtm_preview=env-1',

--- a/src/services/analytics/__tests__/TagManager.test.ts
+++ b/src/services/analytics/__tests__/TagManager.test.ts
@@ -1,0 +1,117 @@
+import TagManager, { _getGtmDataLayerScript, _getGtmNoScript, _getGtmScript, _getRequiredGtmArgs } from '../TagManager'
+
+const MOCK_ID = 'GTM-123456'
+
+describe('TagManager', () => {
+  beforeEach(() => {
+    delete window.dataLayer
+  })
+
+  describe('getRequiredGtmArgs', () => {
+    it('should assign default arguments', () => {
+      const result1 = _getRequiredGtmArgs({ gtmId: MOCK_ID })
+
+      expect(result1).toStrictEqual({
+        gtmId: MOCK_ID,
+        events: {},
+        dataLayer: undefined,
+        auth: '',
+        preview: '',
+      })
+
+      const result2 = _getRequiredGtmArgs({ gtmId: MOCK_ID, auth: 'abcdefg', preview: 'env-1' })
+
+      expect(result2).toStrictEqual({
+        gtmId: MOCK_ID,
+        events: {},
+        dataLayer: undefined,
+        auth: '&gtm_auth=abcdefg',
+        preview: '&gtm_preview=env-1',
+      })
+    })
+  })
+
+  describe('getGtmScript', () => {
+    it('should use the id', () => {
+      const script1 = _getGtmScript({ gtmId: MOCK_ID })
+
+      expect(script1.innerHTML).toContain(MOCK_ID)
+      expect(script1.innerHTML).toContain('dataLayer')
+    })
+
+    it('should use the auth and preview if present', () => {
+      const script1 = _getGtmScript({
+        gtmId: MOCK_ID,
+      })
+
+      expect(script1.innerHTML).not.toContain('&gtm_auth')
+      expect(script1.innerHTML).not.toContain('&gtm_preview')
+
+      const script2 = _getGtmScript({
+        gtmId: MOCK_ID,
+        auth: 'abcdefg',
+        preview: 'env-1',
+      })
+
+      expect(script2.innerHTML).toContain('&gtm_auth=abcdefg&gtm_preview=env-1')
+    })
+  })
+
+  describe('getGtmNoScript', () => {
+    it('should use the id for the iframe', () => {
+      const noscript = _getGtmNoScript({ gtmId: MOCK_ID })
+
+      expect(noscript.innerHTML).toContain(`id=GTM-123456`)
+    })
+
+    it('should use the gtm_auth and gtm_preview for the iframe if present', () => {
+      const noscript1 = _getGtmNoScript({
+        gtmId: MOCK_ID,
+      })
+
+      expect(noscript1.innerHTML).not.toContain('&gtm_auth')
+      expect(noscript1.innerHTML).not.toContain('&gtm_preview')
+
+      const noscript2 = _getGtmNoScript({
+        gtmId: MOCK_ID,
+        auth: 'abcdefg',
+        preview: 'env-1',
+      })
+
+      expect(noscript2.innerHTML).toContain('&gtm_auth=abcdefg&gtm_preview=env-1')
+    })
+  })
+
+  describe('getGtmDataLayerScript', () => {
+    it('should use the `dataLayer` for the script', () => {
+      const dataLayerScript = _getGtmDataLayerScript({
+        gtmId: MOCK_ID,
+        dataLayer: { foo: 'bar' },
+      })
+
+      expect(dataLayerScript.innerHTML).toContain('{"foo":"bar"}')
+    })
+  })
+
+  describe('TagManager.initialize', () => {
+    it('should initialize TagManager', () => {
+      TagManager.initialize({ gtmId: MOCK_ID })
+
+      expect(window.dataLayer).toHaveLength(1)
+      expect(window.dataLayer[0]).toStrictEqual({ event: 'gtm.js', 'gtm.start': expect.any(Number) })
+    })
+  })
+
+  describe('TagManager.dataLayer', () => {
+    it('should push data to the dataLayer', () => {
+      TagManager.dataLayer({
+        test: '123',
+      })
+
+      expect(window.dataLayer).toHaveLength(1)
+      expect(window.dataLayer[0]).toStrictEqual({
+        test: '123',
+      })
+    })
+  })
+})

--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -7,7 +7,7 @@
  * This service should NOT be used directly by components. Use the `analytics` service instead.
  */
 
-import TagManager, { TagManagerArgs } from 'react-gtm-module'
+import TagManager, { TagManagerArgs, DATA_LAYER_NAME } from './TagManager'
 import Cookies from 'js-cookie'
 import {
   IS_PRODUCTION,
@@ -64,7 +64,7 @@ export const gtmInit = (): void => {
 }
 
 const isGtmLoaded = (): boolean => {
-  return typeof window !== 'undefined' && !!window.dataLayer
+  return typeof window !== 'undefined' && !!window[DATA_LAYER_NAME]
 }
 
 export const gtmClear = (): void => {
@@ -99,9 +99,7 @@ const gtmSend = (event: GtmEvent): void => {
 
   if (!isGtmLoaded()) return
 
-  TagManager.dataLayer({
-    dataLayer: event,
-  })
+  TagManager.dataLayer(event)
 }
 
 export const gtmTrack = (eventData: AnalyticsEvent): void => {


### PR DESCRIPTION
## What it solves

Resolves #502

## How this PR fixes it

We no longer load GTM via a package. The syntax remains the same for initialization, wheras `TagManager.dataLayer` no longer requires nesting the event inside a `dataLayer` property.

## How to test it

- Open the Safe with Analytics cookies enabled. Observe that GTM loads as normal and events are tracked correctly.

## Analytics changes

GTM is loaded directly.