### PR TITLE
fix: Add manual refresh to mobile pairing qr code

### DIFF
--- a/src/components/common/PairingDetails/index.tsx
+++ b/src/components/common/PairingDetails/index.tsx
@@ -1,18 +1,61 @@
-import { Typography } from '@mui/material'
+import { IconButton, Typography } from '@mui/material'
 import type { ReactElement } from 'react'
 
 import usePairingUri from '@/services/pairing/hooks'
 import QRCode from '@/components/common/QRCode'
 import PairingDescription from './PairingDescription'
+import { getPairingConnector, usePairingConnector, WalletConnectEvents } from '@/services/pairing/connector'
+import useChainId from '@/hooks/useChainId'
+import { useEffect, useState } from 'react'
+import Box from '@mui/material/Box'
+import RefreshIcon from '@mui/icons-material/Refresh'
 
 const QR_CODE_SIZE = 100
 
 const PairingDetails = ({ vertical = false }: { vertical?: boolean }): ReactElement => {
+  const [displayRefresh, setDisplayRefresh] = useState<boolean>(false)
+  const chainId = useChainId()
   const uri = usePairingUri()
+  const connector = usePairingConnector()
+
+  /**
+   * TODO: Fix connector to pick up changes when creating/killing a session
+   *
+   * Workaround because the disconnect listener
+   * in useInitPairing is not picking up the event
+   */
+  useEffect(() => {
+    connector?.on(WalletConnectEvents.DISCONNECT, () => {
+      setDisplayRefresh(true)
+    })
+  }, [connector])
+
+  const handleRefresh = () => {
+    setDisplayRefresh(false)
+    getPairingConnector()?.createSession({ chainId: +chainId })
+  }
 
   const title = <Typography variant="h5">Connect to mobile</Typography>
 
-  const qr = <QRCode value={uri} size={QR_CODE_SIZE} />
+  const qr =
+    displayRefresh || (connector && !connector.handshakeTopic) ? (
+      <Box
+        sx={{
+          width: 100,
+          height: 100,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: (theme) => theme.palette.background.main,
+        }}
+      >
+        <IconButton onClick={handleRefresh}>
+          <RefreshIcon fontSize="large" />
+        </IconButton>
+      </Box>
+    ) : (
+      <QRCode value={uri} size={QR_CODE_SIZE} />
+    )
 
   const description = <PairingDescription />
 

--- a/src/services/pairing/connector.ts
+++ b/src/services/pairing/connector.ts
@@ -2,12 +2,12 @@ import WalletConnect from '@walletconnect/client'
 import bowser from 'bowser'
 
 import packageJson from '../../../package.json'
-import { IS_PRODUCTION, SAFE_REACT_URL, WC_BRIDGE } from '@/config/constants'
-import local from '@/services/local-storage/local'
+import { IS_PRODUCTION, SAFE_REACT_URL } from '@/config/constants'
+import ExternalStore from '@/services/ExternalStore'
 
 export const PAIRING_MODULE_STORAGE_ID = 'pairingConnector'
 
-const getClientMeta = () => {
+export const getClientMeta = () => {
   const APP_META = {
     name: `Safe Web v${packageJson.version}`,
     url: SAFE_REACT_URL,
@@ -31,15 +31,11 @@ const getClientMeta = () => {
   }
 }
 
-const _pairingConnector = new WalletConnect({
-  bridge: WC_BRIDGE,
-  storageId: local.getPrefixedKey(PAIRING_MODULE_STORAGE_ID),
-  clientMeta: getClientMeta(),
-})
-
-export const getPairingConnector = () => {
-  return _pairingConnector
-}
+export const {
+  getStore: getPairingConnector,
+  setStore: setPairingConnector,
+  useStore: usePairingConnector,
+} = new ExternalStore<WalletConnect>()
 
 export enum WalletConnectEvents {
   CONNECT = 'connect',
@@ -54,6 +50,6 @@ export enum WalletConnectEvents {
 
 if (!IS_PRODUCTION) {
   Object.values(WalletConnectEvents).forEach((event) => {
-    _pairingConnector.on(event, (...args) => console.info('[Pairing]', event, ...args))
+    getPairingConnector()?.on(event, (...args) => console.info('[Pairing]', event, ...args))
   })
 }

--- a/src/services/pairing/module.ts
+++ b/src/services/pairing/module.ts
@@ -239,7 +239,7 @@ const pairingModule = (): WalletInit => {
         }
 
         return {
-          provider: new EthProvider({ chains, connector: getPairingConnector() }),
+          provider: new EthProvider({ chains, connector: getPairingConnector()! }),
         }
       },
     }


### PR DESCRIPTION
## What it solves

Resolves #488 

## How this PR fixes it

The changes to the `connector` from inside the pairing module are not being picked up by the `useInitPairing` hook. This results in event listeners not updating and thus not creating a new session / generating a new uri.

This PR adds the same workaround as we had in the old codebase to display a manual refresh button instead of the QR Code if the session was rejected or the uri is faulty (no `handshakeTopic` being present)

## How to test it

1. Open the Safe
2. Scan the Mobile Pairing QR code
3. Confirm on phone
4. Observe being connected
5. Disconnect via Desktop
6. Observe seeing a QR Code or the manual refresh button
7. Scan the QR Code
8. Reject on phone
9. Observe seein the manual refresh button

## Screenshots
<img width="352" alt="Screenshot 2022-09-06 at 17 03 45" src="https://user-images.githubusercontent.com/5880855/188669761-35deaee9-773a-4c56-9e52-e24847f4ba92.png">

