### PR TITLE
fix: Update claming app url

### DIFF
--- a/src/components/common/SafeTokenWidget/__tests__/SafeTokenWidget.test.tsx
+++ b/src/components/common/SafeTokenWidget/__tests__/SafeTokenWidget.test.tsx
@@ -5,7 +5,7 @@ import * as useChainId from '@/hooks/useChainId'
 import { render, waitFor } from '@/tests/test-utils'
 import { TokenType } from '@gnosis.pm/safe-react-gateway-sdk'
 import { ethers } from 'ethers'
-import SafeTokenWidget from '..'
+import SafeTokenWidget, { CLAIMING_APP_URL } from '..'
 import { NextRouter } from 'next/router'
 import { hexZeroPad } from 'ethers/lib/utils'
 import { AppRoutes } from '@/config/routes'
@@ -126,7 +126,7 @@ describe('SafeTokenWidget', () => {
     const result = render(<SafeTokenWidget />)
     await waitFor(() => {
       expect(result.baseElement).toContainHTML(
-        `href="${AppRoutes.safe.apps}?safe=${fakeSafeAddress}&appUrl=https://safe-claiming-app.pages.dev/"`,
+        `href="${AppRoutes.safe.apps}?safe=${fakeSafeAddress}&appUrl=${CLAIMING_APP_URL}"`,
       )
     })
   })

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -15,7 +15,7 @@ import SafeTokenIcon from './safe_token.svg'
 import css from './styles.module.css'
 
 // TODO: once listed on safe apps list, get the url from there?
-const CLAIMING_APP_URL = 'https://safe-claiming-app.pages.dev/'
+export const CLAIMING_APP_URL = 'https://safe-apps.dev.gnosisdev.com/safe-claiming-app/'
 
 export const getSafeTokenAddress = (chainId: string): string => {
   return SAFE_TOKEN_ADDRESSES[chainId]


### PR DESCRIPTION
## What it solves

Updates the url to the deployed claiming app for the token widget
