### PR TITLE
fix: copy prefix when showing it is disabled

### DIFF
--- a/src/components/common/CopyAddressButton/index.tsx
+++ b/src/components/common/CopyAddressButton/index.tsx
@@ -1,11 +1,17 @@
 import { type ReactElement } from 'react'
-import { useAppSelector } from '@/store'
-import { selectSettings } from '@/store/settingsSlice'
+
 import CopyButton from '../CopyButton'
 
-const CopyAddressButton = ({ prefix, address }: { prefix?: string; address: string }): ReactElement => {
-  const settings = useAppSelector(selectSettings)
-  const addressText = settings.shortName.copy && prefix ? `${prefix}:${address}` : address
+const CopyAddressButton = ({
+  prefix,
+  address,
+  copyPrefix,
+}: {
+  prefix?: string
+  address: string
+  copyPrefix?: boolean
+}): ReactElement => {
+  const addressText = copyPrefix && prefix ? `${prefix}:${address}` : address
 
   return <CopyButton text={addressText} />
 }

--- a/src/components/common/EthHashInfo/index.test.tsx
+++ b/src/components/common/EthHashInfo/index.test.tsx
@@ -232,6 +232,39 @@ describe('EthHashInfo', () => {
       expect(container.querySelector('button')).toBeInTheDocument()
     })
 
+    it("doesn't copy the prefix with non-addresses", async () => {
+      jest.spyOn(useChainId, 'default').mockReturnValue('4')
+
+      jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
+        selector({
+          session: {},
+          settings: {
+            shortName: {
+              show: true,
+              copy: true,
+            },
+          },
+          chains: {
+            data: [{ chainId: '4', shortName: 'rin' }],
+          },
+        } as store.RootState),
+      )
+
+      const { container } = render(
+        <EthHashInfo address={'0xe26920604f9a02c5a877d449faa71b7504f0c2508dcc7c0384078a024b8e592f'} showCopyButton />,
+      )
+
+      const button = container.querySelector('button')
+
+      await act(() => {
+        fireEvent.click(button!)
+      })
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        '0xe26920604f9a02c5a877d449faa71b7504f0c2508dcc7c0384078a024b8e592f',
+      )
+    })
+
     it('copies the default prefixed address', async () => {
       jest.spyOn(useChainId, 'default').mockReturnValue('4')
 
@@ -251,6 +284,39 @@ describe('EthHashInfo', () => {
       )
 
       const { container } = render(<EthHashInfo address={MOCK_SAFE_ADDRESS} showCopyButton />)
+
+      const button = container.querySelector('button')
+
+      await act(() => {
+        fireEvent.click(button!)
+      })
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(`rin:${MOCK_SAFE_ADDRESS}`)
+    })
+
+    it('copies the prefix even if it is hidden', async () => {
+      jest.spyOn(useChainId, 'default').mockReturnValue('4')
+
+      jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
+        selector({
+          session: {},
+          settings: {
+            shortName: {
+              show: true,
+              copy: true,
+            },
+          },
+          chains: {
+            data: [{ chainId: '4', shortName: 'rin' }],
+          },
+        } as store.RootState),
+      )
+
+      const { container, queryByText } = render(
+        <EthHashInfo address={MOCK_SAFE_ADDRESS} showCopyButton showPrefix={false} />,
+      )
+
+      expect(queryByText('rin:')).not.toBeInTheDocument()
 
       const button = container.querySelector('button')
 

--- a/src/components/common/EthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/index.tsx
@@ -11,6 +11,7 @@ import { useAppSelector } from '@/store'
 import { selectSettings } from '@/store/settingsSlice'
 import { selectChainById } from '@/store/chainsSlice'
 import useChainId from '@/hooks/useChainId'
+import { ethers } from 'ethers'
 
 type EthHashInfoProps = {
   address: string
@@ -41,7 +42,7 @@ const EthHashInfo = ({
   hasExplorer,
 }: EthHashInfoProps): ReactElement => {
   const [fallbackToIdenticon, setFallbackToIdenticon] = useState(false)
-  const isAddress = address.length === 42
+  const shouldPrefix = ethers.utils.isAddress(address)
 
   return (
     <div className={css.container}>
@@ -70,12 +71,12 @@ const EthHashInfo = ({
 
         <Box className={css.addressRow}>
           <Typography variant="body2" fontWeight="inherit" component="div" className={css.address}>
-            {isAddress && showPrefix && prefix && <b>{prefix}:</b>}
+            {showPrefix && shouldPrefix && prefix && <b>{prefix}:</b>}
             {shortAddress && shortAddress ? shortenAddress(address) : address}
           </Typography>
 
           {showCopyButton && (
-            <CopyAddressButton prefix={prefix} address={address} copyPrefix={isAddress && copyPrefix} />
+            <CopyAddressButton prefix={prefix} address={address} copyPrefix={shouldPrefix && copyPrefix} />
           )}
 
           {hasExplorer && <ExplorerLink address={address} />}

--- a/src/components/common/EthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/index.tsx
@@ -41,6 +41,7 @@ const EthHashInfo = ({
   hasExplorer,
 }: EthHashInfoProps): ReactElement => {
   const [fallbackToIdenticon, setFallbackToIdenticon] = useState(false)
+  const isAddress = address.length === 42
 
   return (
     <div className={css.container}>
@@ -69,11 +70,13 @@ const EthHashInfo = ({
 
         <Box className={css.addressRow}>
           <Typography variant="body2" fontWeight="inherit" component="div" className={css.address}>
-            {showPrefix && prefix && <b>{prefix}:</b>}
+            {isAddress && showPrefix && prefix && <b>{prefix}:</b>}
             {shortAddress && shortAddress ? shortenAddress(address) : address}
           </Typography>
 
-          {showCopyButton && <CopyAddressButton prefix={prefix} address={address} copyPrefix={copyPrefix} />}
+          {showCopyButton && (
+            <CopyAddressButton prefix={prefix} address={address} copyPrefix={isAddress && copyPrefix} />
+          )}
 
           {hasExplorer && <ExplorerLink address={address} />}
         </Box>
@@ -91,14 +94,13 @@ const PrefixedEthHashInfo = ({
   const chain = useAppSelector((state) => selectChainById(state, props.chainId || currentChainId))
   const addressBook = useAddressBook()
 
-  const isAddress = props.address.length === 42
   const name = showName ? props.name || addressBook[props.address] : undefined
 
   return (
     <EthHashInfo
       prefix={chain?.shortName}
-      showPrefix={isAddress && settings.shortName.show}
-      copyPrefix={isAddress && settings.shortName.copy}
+      showPrefix={settings.shortName.show}
+      copyPrefix={settings.shortName.copy}
       {...props}
       name={name}
     />

--- a/src/components/common/EthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/index.tsx
@@ -19,6 +19,8 @@ type EthHashInfoProps = {
   showAvatar?: boolean
   showCopyButton?: boolean
   prefix?: string
+  showPrefix?: boolean
+  copyPrefix?: boolean
   shortAddress?: boolean
   customAvatar?: string
   hasExplorer?: boolean
@@ -29,6 +31,8 @@ const EthHashInfo = ({
   address,
   customAvatar,
   prefix = '',
+  copyPrefix,
+  showPrefix,
   shortAddress = true,
   showAvatar = true,
   avatarSize,
@@ -65,11 +69,11 @@ const EthHashInfo = ({
 
         <Box className={css.addressRow}>
           <Typography variant="body2" fontWeight="inherit" component="div" className={css.address}>
-            {prefix && <b>{prefix}:</b>}
-            {shortAddress ? shortenAddress(address) : address}
+            {showPrefix && prefix && <b>{prefix}:</b>}
+            {shortAddress && shortAddress ? shortenAddress(address) : address}
           </Typography>
 
-          {showCopyButton && <CopyAddressButton prefix={prefix} address={address} />}
+          {showCopyButton && <CopyAddressButton prefix={prefix} address={address} copyPrefix={copyPrefix} />}
 
           {hasExplorer && <ExplorerLink address={address} />}
         </Box>
@@ -87,10 +91,18 @@ const PrefixedEthHashInfo = ({
   const chain = useAppSelector((state) => selectChainById(state, props.chainId || currentChainId))
   const addressBook = useAddressBook()
 
+  const isAddress = props.address.length === 42
   const name = showName ? props.name || addressBook[props.address] : undefined
-  const prefix = props.address.length === 42 && settings.shortName.show ? chain?.shortName : undefined
 
-  return <EthHashInfo prefix={prefix} {...props} name={name} />
+  return (
+    <EthHashInfo
+      prefix={chain?.shortName}
+      showPrefix={isAddress && settings.shortName.show}
+      copyPrefix={isAddress && settings.shortName.copy}
+      {...props}
+      name={name}
+    />
+  )
 }
 
 export default PrefixedEthHashInfo

--- a/src/components/common/EthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/index.tsx
@@ -72,7 +72,7 @@ const EthHashInfo = ({
         <Box className={css.addressRow}>
           <Typography variant="body2" fontWeight="inherit" component="div" className={css.address}>
             {showPrefix && shouldPrefix && prefix && <b>{prefix}:</b>}
-            {shortAddress && shortAddress ? shortenAddress(address) : address}
+            {shortAddress ? shortenAddress(address) : address}
           </Typography>
 
           {showCopyButton && (


### PR DESCRIPTION
## What it solves

Resolves address prefixes not copying

## How this PR fixes it

`showPrefix`/`copyPrefix` props have been added as per `safe-react` and the `<PrefixedEthHashInfo>` references settings to enable these accordingly.

## How to test it

Disable rendering of prefixes. Observe that the prefix is, however, copied.