### PR TITLE
fix: batch execution hover highlighting

### DIFF
--- a/src/components/common/PaginatedTxns/index.tsx
+++ b/src/components/common/PaginatedTxns/index.tsx
@@ -12,6 +12,7 @@ import TxFilterButton from '@/components/transactions/TxFilterButton'
 import { TxFilter, useTxFilter } from '@/utils/tx-history-filter'
 import { isTransactionListItem } from '@/utils/transaction-guards'
 import type { TransactionListPage } from '@gnosis.pm/safe-react-gateway-sdk'
+import { BatchExecuteHoverProvider } from '@/components/transactions/BatchExecuteButton/BatchExecuteHoverProvider'
 
 const NoQueuedTxns = () => (
   <Box mt="5vh">
@@ -84,15 +85,17 @@ const PaginatedTxns = ({ useTxns }: { useTxns: typeof useTxHistory | typeof useT
 
   return (
     <Box mb={4} position="relative">
-      {pages.map((pageUrl, index) => (
-        <TxPage
-          key={pageUrl}
-          pageUrl={pageUrl}
-          useTxns={useTxns}
-          isFirstPage={index === 0}
-          onNextPage={index === pages.length - 1 ? onNextPage : undefined}
-        />
-      ))}
+      <BatchExecuteHoverProvider>
+        {pages.map((pageUrl, index) => (
+          <TxPage
+            key={pageUrl}
+            pageUrl={pageUrl}
+            useTxns={useTxns}
+            isFirstPage={index === 0}
+            onNextPage={index === pages.length - 1 ? onNextPage : undefined}
+          />
+        ))}
+      </BatchExecuteHoverProvider>
     </Box>
   )
 }

--- a/src/components/transactions/TxList/index.tsx
+++ b/src/components/transactions/TxList/index.tsx
@@ -3,7 +3,6 @@ import { Box } from '@mui/material'
 import type { TransactionListPage } from '@gnosis.pm/safe-react-gateway-sdk'
 import TxListItem from '../TxListItem'
 import GroupedTxListItems from '@/components/transactions/GroupedTxListItems'
-import { BatchExecuteHoverProvider } from '@/components/transactions/BatchExecuteButton/BatchExecuteHoverProvider'
 import { groupConflictingTxs } from '@/utils/tx-list'
 
 type TxListProps = {
@@ -29,11 +28,7 @@ const TxList = ({ items }: TxListProps): ReactElement => {
     return <TxListItem key={index} item={item} />
   })
 
-  return (
-    <BatchExecuteHoverProvider>
-      <TxListGrid>{transactions}</TxListGrid>
-    </BatchExecuteHoverProvider>
-  )
+  return <TxListGrid>{transactions}</TxListGrid>
 }
 
 export default TxList


### PR DESCRIPTION
## What it solves

Resolves #514

## How this PR fixes it

The `<BatchExecuteHoverProvider>` has been hoisted to surround all pages.

## How to test it

Queue >1 transactions and hover over the "Execute batch" button. Observe that the transaction-to-batch are highlighted accordingly.

## Screenshots
![hover provider](https://user-images.githubusercontent.com/20442784/188900522-228f450d-8498-4b9c-b145-9989e4faa5bc.gif)