### PR TITLE
fix: remove date label timezone adjustment from queue

### DIFF
--- a/src/components/common/PaginatedTxns/index.tsx
+++ b/src/components/common/PaginatedTxns/index.tsx
@@ -43,7 +43,7 @@ const TxPage = ({
 
   const isQueue = useTxns === useTxQueue
 
-  const localizedItems = useMemo(() => {
+  const txListPageItems = useMemo(() => {
     if (!page?.results) {
       return
     }
@@ -52,18 +52,18 @@ const TxPage = ({
     return isQueue ? page.results : adjustDateLabelsTimezone(page.results)
   }, [isQueue, page?.results])
 
-  if (page && localizedItems) {
+  if (page && txListPageItems) {
     return (
       <>
         {/* FIXME: batching will only work for the first page results */}
         {isFirstPage && (
           <Box display="flex" flexDirection="column" alignItems="flex-end" mt={['-94px', '-44px']} mb={['60px', 0]}>
-            {isQueue ? <BatchExecuteButton items={localizedItems} /> : <TxFilterButton />}
+            {isQueue ? <BatchExecuteButton items={txListPageItems} /> : <TxFilterButton />}
             {filter && <Typography mt={2}>{getResultCount(filter, page)}</Typography>}
           </Box>
         )}
 
-        {page.results.length ? <TxList items={localizedItems} /> : isQueue && <NoQueuedTxns />}
+        {page.results.length ? <TxList items={txListPageItems} /> : isQueue && <NoQueuedTxns />}
 
         {onNextPage && page.next && (
           <Box my={4} textAlign="center">

--- a/src/components/common/PaginatedTxns/index.tsx
+++ b/src/components/common/PaginatedTxns/index.tsx
@@ -13,6 +13,7 @@ import { TxFilter, useTxFilter } from '@/utils/tx-history-filter'
 import { isTransactionListItem } from '@/utils/transaction-guards'
 import type { TransactionListPage } from '@gnosis.pm/safe-react-gateway-sdk'
 import { BatchExecuteHoverProvider } from '@/components/transactions/BatchExecuteButton/BatchExecuteHoverProvider'
+import { adjustDateLabelsTimezone } from '@/utils/transactions'
 
 const NoQueuedTxns = () => (
   <Box mt="5vh">
@@ -43,17 +44,20 @@ const TxPage = ({
   if (page?.results) {
     const isQueue = useTxns === useTxQueue
 
+    // Date labels are returned at start of UTC day. Users in UTC-n timezones would see "yesterday" for txs today
+    const localizedItems = isQueue ? page.results : adjustDateLabelsTimezone(page.results)
+
     return (
       <>
         {/* FIXME: batching will only work for the first page results */}
         {isFirstPage && (
           <Box display="flex" flexDirection="column" alignItems="flex-end" mt={['-94px', '-44px']} mb={['60px', 0]}>
-            {isQueue ? <BatchExecuteButton items={page.results} /> : <TxFilterButton />}
+            {isQueue ? <BatchExecuteButton items={localizedItems} /> : <TxFilterButton />}
             {filter && <Typography mt={2}>{getResultCount(filter, page)}</Typography>}
           </Box>
         )}
 
-        {page.results.length ? <TxList items={page.results} /> : isQueue && <NoQueuedTxns />}
+        {page.results.length ? <TxList items={localizedItems} /> : isQueue && <NoQueuedTxns />}
 
         {onNextPage && page.next && (
           <Box my={4} textAlign="center">

--- a/src/components/common/PaginatedTxns/index.tsx
+++ b/src/components/common/PaginatedTxns/index.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useEffect, useState } from 'react'
+import { type ReactElement, useEffect, useState, useMemo } from 'react'
 import { Box, Typography } from '@mui/material'
 import TxList from '@/components/transactions/TxList'
 import ErrorMessage from '@/components/tx/ErrorMessage'
@@ -41,12 +41,18 @@ const TxPage = ({
   const { page, error } = useTxns(pageUrl)
   const [filter] = useTxFilter()
 
-  if (page?.results) {
-    const isQueue = useTxns === useTxQueue
+  const isQueue = useTxns === useTxQueue
+
+  const localizedItems = useMemo(() => {
+    if (!page?.results) {
+      return
+    }
 
     // Date labels are returned at start of UTC day. Users in UTC-n timezones would see "yesterday" for txs today
-    const localizedItems = isQueue ? page.results : adjustDateLabelsTimezone(page.results)
+    return isQueue ? page.results : adjustDateLabelsTimezone(page.results)
+  }, [isQueue, page?.results])
 
+  if (page && localizedItems) {
     return (
       <>
         {/* FIXME: batching will only work for the first page results */}

--- a/src/hooks/useTxHistory.ts
+++ b/src/hooks/useTxHistory.ts
@@ -4,8 +4,6 @@ import useAsync from './useAsync'
 import { selectTxHistory } from '@/store/txHistorySlice'
 import useSafeInfo from './useSafeInfo'
 import { fetchFilteredTxHistory, useTxFilter } from '@/utils/tx-history-filter'
-import { localizeTxListDateLabelTimezone } from '@/utils/transactions'
-import { useMemo } from 'react'
 
 const useTxHistory = (
   pageUrl?: string,
@@ -36,25 +34,17 @@ const useTxHistory = (
   const historyState = useAppSelector(selectTxHistory)
 
   // Return the new page or the stored page
-  return useMemo(() => {
-    const txHistory =
-      filter || pageUrl
-        ? {
-            page,
-            error: error?.message,
-            loading: loading,
-          }
-        : {
-            page: historyState.data,
-            error: historyState.error,
-            loading: historyState.loading,
-          }
-
-    return {
-      ...txHistory,
-      page: localizeTxListDateLabelTimezone(txHistory.page),
-    }
-  }, [error?.message, filter, historyState.data, historyState.error, historyState.loading, loading, page, pageUrl])
+  return filter || pageUrl
+    ? {
+        page,
+        error: error?.message,
+        loading: loading,
+      }
+    : {
+        page: historyState.data,
+        error: historyState.error,
+        loading: historyState.loading,
+      }
 }
 
 export default useTxHistory

--- a/src/hooks/useTxQueue.ts
+++ b/src/hooks/useTxQueue.ts
@@ -3,8 +3,6 @@ import { useAppSelector } from '@/store'
 import useAsync from './useAsync'
 import { selectTxQueue, selectQueuedTransactionsByNonce } from '@/store/txQueueSlice'
 import useSafeInfo from './useSafeInfo'
-import { localizeTxListDateLabelTimezone } from '@/utils/transactions'
-import { useMemo } from 'react'
 
 const useTxQueue = (
   pageUrl?: string,
@@ -26,24 +24,17 @@ const useTxQueue = (
   const queueState = useAppSelector(selectTxQueue)
 
   // Return the new page or the stored page
-  return useMemo(() => {
-    const txQueue = pageUrl
-      ? {
-          page,
-          error: error?.message,
-          loading: loading,
-        }
-      : {
-          page: queueState.data,
-          error: queueState.error,
-          loading: queueState.loading,
-        }
-
-    return {
-      ...txQueue,
-      page: localizeTxListDateLabelTimezone(txQueue.page),
-    }
-  }, [error?.message, loading, page, pageUrl, queueState.data, queueState.error, queueState.loading])
+  return pageUrl
+    ? {
+        page,
+        error: error?.message,
+        loading: loading,
+      }
+    : {
+        page: queueState.data,
+        error: queueState.error,
+        loading: queueState.loading,
+      }
 }
 
 export const useQueuedTxByNonce = (nonce?: number) => {

--- a/src/utils/__tests__/tx-history-filter.test.ts
+++ b/src/utils/__tests__/tx-history-filter.test.ts
@@ -19,7 +19,7 @@ import {
 import { renderHook } from '@/tests/test-utils'
 import type { NextRouter } from 'next/router'
 import { type TxFilterFormState } from '@/components/transactions/TxFilterForm'
-import { _adjustDateLabelsTimezone } from '../transactions'
+import { adjustDateLabelsTimezone } from '../transactions'
 
 jest.mock('@gnosis.pm/safe-react-gateway-sdk', () => ({
   getIncomingTransfers: jest.fn(() => Promise.resolve({ results: [] })),
@@ -377,7 +377,7 @@ describe('tx-history-filter', () => {
   })
   describe('adjustDateLabelsTimezone', () => {
     it('should return items as is if it is an empty array', () => {
-      const result = _adjustDateLabelsTimezone([])
+      const result = adjustDateLabelsTimezone([])
       expect(result).toEqual([])
     })
 
@@ -387,7 +387,7 @@ describe('tx-history-filter', () => {
         { type: 'CONFLICT_HEADER', nonce: 1571 },
       ] as TransactionListItem[]
 
-      const result = _adjustDateLabelsTimezone(items)
+      const result = adjustDateLabelsTimezone(items)
       expect(result).toEqual(items)
     })
 
@@ -414,7 +414,7 @@ describe('tx-history-filter', () => {
         },
       ] as TransactionListItem[]
 
-      const result = _adjustDateLabelsTimezone(items)
+      const result = adjustDateLabelsTimezone(items)
       expect(result).toEqual([
         {
           type: 'DATE_LABEL',

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -9,7 +9,6 @@ import {
   Transaction,
   TransactionDetails,
   TransactionListItem,
-  TransactionListPage,
 } from '@gnosis.pm/safe-react-gateway-sdk'
 import {
   isDateLabel,
@@ -89,7 +88,8 @@ export const makeDateLabelFromTx = (tx: Transaction): DateLabel => {
 /**
  * Add date labels between transactions made on the same day by local timezone
  */
-export const _adjustDateLabelsTimezone = (items: TransactionListItem[]): TransactionListItem[] => {
+// TODO: Needs to know if previous page has same day to prevent duplicate date labels
+export const adjustDateLabelsTimezone = (items: TransactionListItem[]): TransactionListItem[] => {
   const firstTx = items.find(isTransactionListItem)
 
   if (!firstTx) {
@@ -118,19 +118,6 @@ export const _adjustDateLabelsTimezone = (items: TransactionListItem[]): Transac
 
       return resultItems.concat(item)
     }, [])
-}
-
-// TODO: Needs to know if previous page has same day to prevent duplicate date labels
-// Perhaps pass them to `useTxXYZ` hooks from `TxPage`
-export const localizeTxListDateLabelTimezone = (page?: TransactionListPage): TransactionListPage | undefined => {
-  if (!page) {
-    return page
-  }
-
-  return {
-    ...page,
-    results: _adjustDateLabelsTimezone(page.results),
-  }
 }
 
 const getSignatures = (confirmations: Record<string, string>) => {


### PR DESCRIPTION
## What it solves

Resolves broken transaction grouping

## How this PR fixes it

Date label timezone adjustment was inadventedly added to the transaction queue. The queue doesn't return date labels and it has therefore been removed.

![image](https://user-images.githubusercontent.com/20442784/189044425-a441bfb6-fb20-4005-9a7a-3ccb9e1e761c.png)

## How to test it

Open `rin:0xFfDC1BcdeC18b1196e7FA04246295DE3A17972Ac` and observe that no date labels are present and that nonce 395/396 transactions are correctly grouped with no date label separation.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/189044444-13cf5fad-77b3-4c57-83a5-45e34b837f0a.png)