### PR TITLE
fix: load conflicted transactions across pages

### DIFF
--- a/src/components/common/PaginatedTxns/index.tsx
+++ b/src/components/common/PaginatedTxns/index.tsx
@@ -44,6 +44,10 @@ const TxPage = ({
   const isQueue = useTxns === useTxQueue
 
   useEffect(() => {
+    if (!isQueue) {
+      return
+    }
+
     // If conflict transactions split across pages, we must fetch the next page
     const lastItem = page?.results[page.results.length - 1]
     const hasSplitConflict = lastItem && isHasNextConflictTransactionListItem(lastItem)
@@ -51,7 +55,7 @@ const TxPage = ({
     if (hasSplitConflict) {
       onNextPage?.(page?.next)
     }
-  }, [onNextPage, page?.next, page?.results])
+  }, [isQueue, onNextPage, page?.next, page?.results])
 
   const txListPageItems = useMemo(() => {
     if (!page?.results) {

--- a/src/components/common/PaginatedTxns/index.tsx
+++ b/src/components/common/PaginatedTxns/index.tsx
@@ -10,7 +10,7 @@ import SkeletonTxList from './SkeletonTxList'
 import BatchExecuteButton from '@/components/transactions/BatchExecuteButton'
 import TxFilterButton from '@/components/transactions/TxFilterButton'
 import { TxFilter, useTxFilter } from '@/utils/tx-history-filter'
-import { isTransactionListItem } from '@/utils/transaction-guards'
+import { isHasNextConflictTransactionListItem, isTransactionListItem } from '@/utils/transaction-guards'
 import type { TransactionListPage } from '@gnosis.pm/safe-react-gateway-sdk'
 import { BatchExecuteHoverProvider } from '@/components/transactions/BatchExecuteButton/BatchExecuteHoverProvider'
 import { adjustDateLabelsTimezone } from '@/utils/transactions'
@@ -42,6 +42,16 @@ const TxPage = ({
   const [filter] = useTxFilter()
 
   const isQueue = useTxns === useTxQueue
+
+  useEffect(() => {
+    // If conflict transactions split across pages, we must fetch the next page
+    const lastItem = page?.results[page.results.length - 1]
+    const hasSplitConflict = lastItem && isHasNextConflictTransactionListItem(lastItem)
+
+    if (hasSplitConflict) {
+      onNextPage?.(page?.next)
+    }
+  }, [onNextPage, page?.next, page?.results])
 
   const txListPageItems = useMemo(() => {
     if (!page?.results) {

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -129,6 +129,12 @@ export const isDateLabel = (value: TransactionListItem): value is DateLabel => {
   return value.type === TransactionListItemType.DATE_LABEL
 }
 
+export const isHasNextConflictTransactionListItem = <T extends TransactionListItem>(
+  value: T,
+): value is T & { conflictType: CONFLICT_TYPES.HAS_NEXT } => {
+  return isTransactionListItem(value) && value.conflictType === CONFLICT_TYPES.HAS_NEXT
+}
+
 export const isSignableBy = (txSummary: TransactionSummary, walletAddress: string): boolean => {
   const executionInfo = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo : undefined
   return !!executionInfo?.missingSigners?.some((address) => address.value === walletAddress)


### PR DESCRIPTION
## What it solves

Resolves conflicts not rendering

## How this PR fixes it

If the final item in the transaction list has a "HasNext" conflict, the next page is automatically loaded.

## How to test it

Queue enough transactions to fill the page and then group the final trasaction so that it spreads onto the next page (example Safe: `rin:0xF5A2915982BC8b0dEDda9cEF79297A83081Fe88f`). Observe that there are two queue network requests when opening the queue.

## Screenshots
![conflicts](https://user-images.githubusercontent.com/20442784/189084250-b88fc99a-2cc0-4275-af58-e9c547273b68.gif)