### PR TITLE
test: unit test formatNumber

### DIFF
--- a/src/utils/__tests__/formatNumber.test.ts
+++ b/src/utils/__tests__/formatNumber.test.ts
@@ -138,11 +138,13 @@ describe('formatAmount', () => {
   })
 
   it('should use < -0.00001 or < +0.00001 when the Eucledian distance of the amount is smaller than 0.00001', () => {
-    // explicitly positive numbers: keep the sign
-    expect(formatAmount('+0.000001', true)).toEqual('< +0.00001')
-    expect(formatAmount('+0.000009', true)).toEqual('< +0.00001')
+    // to keep the '+' sign the amount shall be passed as a string
+    expect(formatAmount('+0.000001')).toEqual('< +0.00001')
+    expect(formatAmount('+0.000009')).toEqual('< +0.00001')
 
-    // negative numbers
+    // negative numbers will keep the sign either way
+    expect(formatAmount(-0.000001)).toEqual('< -0.00001')
+    expect(formatAmount(-0.000009)).toEqual('< -0.00001')
     expect(formatAmount('-0.000001')).toEqual('< -0.00001')
     expect(formatAmount('-0.000009')).toEqual('< -0.00001')
   })

--- a/src/utils/__tests__/formatNumber.test.ts
+++ b/src/utils/__tests__/formatNumber.test.ts
@@ -1,13 +1,149 @@
-describe('Appease Jest', () => {
-  it('adds at least one test to the test file', () => {
-    expect(true).toBe(true)
+import { formatAmount } from '@/utils/formatNumber'
+
+describe('formatAmount', () => {
+  it('should remove trailing zeroes', () => {
+    expect(formatAmount('0.10000')).toEqual('0.1')
+    expect(formatAmount('0.100000000000')).toEqual('0.1')
+  })
+
+  it('should use maximum of 5 decimals', () => {
+    expect(formatAmount('0.123456789')).toEqual('0.12346')
+  })
+
+  it('should use five decimals for numbers up until 999.99999', () => {
+    expect(formatAmount('345.123456789')).toEqual('345.12346') // 9 decimals
+    expect(formatAmount('999.99999')).toEqual('999.99999') // 5 decimals
+
+    // rounds above the specified limit
+    expect(formatAmount('999.999992')).toEqual('999.99999') // 6 decimals
+    expect(formatAmount('999.999996')).toEqual('1,000')
+  })
+
+  it('should use four decimals for numbers between 1,000.0001 until 9,999.9999', () => {
+    // rounds down past the specified precision
+    expect(formatAmount(1_000.00001)).toEqual('1,000')
+
+    expect(formatAmount(1_000.0001234)).toEqual('1,000.0001')
+    expect(formatAmount(1_234.123456789)).toEqual('1,234.1235')
+    expect(formatAmount(9_999.9999)).toEqual('9,999.9999')
+
+    // rounds above the specified limit
+    expect(formatAmount(9_999.99992)).toEqual('9,999.9999')
+    expect(formatAmount(9_999.99996)).toEqual('10,000')
+  })
+
+  it('should use three decimals for numbers between 10,000.001 until 99,999.999', () => {
+    // rounds down past the specified precision
+    expect(formatAmount(10_000.00001)).toEqual('10,000')
+
+    expect(formatAmount(10_000.001)).toEqual('10,000.001')
+    expect(formatAmount(12_345.123456789)).toEqual('12,345.123')
+    expect(formatAmount(99_999.999)).toEqual('99,999.999')
+
+    // rounds above the specified limit
+    expect(formatAmount(99_999.9992)).toEqual('99,999.999')
+    expect(formatAmount(99_999.9996)).toEqual('100,000')
+  })
+
+  it('should use two decimals for numbers between 100,000.01 until 999,999.99', () => {
+    // rounds down past the specified precision
+    expect(formatAmount(100_000.00001)).toEqual('100,000')
+
+    expect(formatAmount(100_000.01)).toEqual('100,000.01')
+    expect(formatAmount(123_456.123456789)).toEqual('123,456.12')
+    expect(formatAmount(999_999.99)).toEqual('999,999.99')
+
+    // rounds above the specified limit
+    expect(formatAmount(999_999.992)).toEqual('999,999.99')
+    expect(formatAmount(999_999.996)).toEqual('1,000,000')
+  })
+
+  it('should use one decimal for numbers between 1,000,000.1 until 9,999,999.9', () => {
+    // rounds down past the specified precision
+    expect(formatAmount(1_000_000.00001)).toEqual('1,000,000')
+
+    expect(formatAmount(1_000_000.1)).toEqual('1,000,000.1')
+    expect(formatAmount(1_234_567.123456789)).toEqual('1,234,567.1')
+    expect(formatAmount(9_999_999.9)).toEqual('9,999,999.9')
+
+    // rounds above the specified limit
+    expect(formatAmount(9_999_999.92)).toEqual('9,999,999.9')
+    expect(formatAmount(9_999_999.96)).toEqual('10,000,000')
+  })
+
+  it('should use no decimals for numbers between 10,000,000 and 99,999,999.5', () => {
+    // rounds down past the specified precision
+    expect(formatAmount(10_000_000.00001)).toEqual('10,000,000')
+
+    expect(formatAmount(10_000_000.1)).toEqual('10,000,000')
+    expect(formatAmount(12_345_678.123456789)).toEqual('12,345,678')
+    expect(formatAmount(99_999_999)).toEqual('99,999,999')
+
+    // rounds above the specified limit
+    expect(formatAmount(99_999_999.2)).toEqual('99,999,999')
+    expect(formatAmount(99_999_999.6)).toEqual('100M')
+  })
+
+  it('should use M symbol for numbers between 100,000,000 and 999,999,500', () => {
+    // rounds down past the specified precision
+    expect(formatAmount(100_000_000.00001)).toEqual('100M')
+    expect(formatAmount(100_000_100)).toEqual('100M')
+
+    expect(formatAmount(100_001_000)).toEqual('100.001M')
+    expect(formatAmount(123_456_789.123456789)).toEqual('123.457M')
+    expect(formatAmount(999_999_000)).toEqual('999.999M')
+
+    // rounds above the specified limit
+    expect(formatAmount(999_999_499)).toEqual('999.999M')
+    expect(formatAmount(999_999_500)).toEqual('1B')
+  })
+
+  it('should use B symbol for numbers between 999,999,500 and 999,999,500,000', () => {
+    // rounds down past the specified precision
+    expect(formatAmount(1_000_000_000.00001)).toEqual('1B')
+    expect(formatAmount(1_000_100_000)).toEqual('1B')
+
+    expect(formatAmount(1_100_000_000)).toEqual('1.1B')
+    expect(formatAmount(1_234_567_898.123456789)).toEqual('1.235B')
+    expect(formatAmount(100_001_000_500)).toEqual('100.001B')
+    expect(formatAmount(999_999_000_000)).toEqual('999.999B')
+
+    // rounds above the specified limit
+    expect(formatAmount(999_999_499_999)).toEqual('999.999B')
+    expect(formatAmount(999_999_500_000)).toEqual('1T')
+  })
+
+  it('should use T notation for numbers between 999,999,500,000 and 999,000,000,000', () => {
+    // rounds down past the specified precision
+    expect(formatAmount(1_000_000_000_000.00001)).toEqual('1T')
+    expect(formatAmount(1_000_100_000_000)).toEqual('1T')
+
+    expect(formatAmount(1_100_000_000_000)).toEqual('1.1T')
+    expect(formatAmount(1_234_567_898_765.123456789)).toEqual('1.235T')
+    expect(formatAmount(100_001_000_000_000)).toEqual('100.001T')
+    expect(formatAmount(999_999_000_000_000)).toEqual('> 999T')
+  })
+
+  it('should use > 999T for numbers above 999,000,000,000,000', () => {
+    expect(formatAmount(999_000_000_000_001)).toEqual('> 999T')
+    expect(formatAmount(999_000_000_000_000.001)).toEqual('> 999T')
+  })
+
+  it('should use < 0.00001 for amounts smaller then 0.00001', () => {
+    expect(formatAmount(0.00001)).toEqual('0.00001')
+    expect(formatAmount(0.000014)).toEqual('0.00001')
+    expect(formatAmount(0.000015)).toEqual('0.00002')
+    expect(formatAmount(0.000001)).toEqual('< 0.00001')
+    expect(formatAmount(0.000009)).toEqual('< 0.00001')
+  })
+
+  xit('should use < -0.00001 or < +0.00001 when the Eucledian distance of the amount is smaller than 0.00001', () => {
+    // explicitly positive numbers
+    expect(formatAmount('+0.000001')).toEqual('< +0.00001')
+    expect(formatAmount('+0.000009')).toEqual('< +0.00001')
+
+    // negative numbers
+    expect(formatAmount('-0.000001')).toEqual('< -0.00001')
+    expect(formatAmount('-0.000009')).toEqual('< -0.00001')
   })
 })
-
-// TODO: Instantiating Intl.NumberFormat programmatically does not pass in tests.
-describe.skip('formatAmount', () => {})
-
-describe.skip('formatCurrency', () => {})
-
-// Appease TypeScript
-export {}

--- a/src/utils/__tests__/formatNumber.test.ts
+++ b/src/utils/__tests__/formatNumber.test.ts
@@ -137,10 +137,10 @@ describe('formatAmount', () => {
     expect(formatAmount(0.000009)).toEqual('< 0.00001')
   })
 
-  xit('should use < -0.00001 or < +0.00001 when the Eucledian distance of the amount is smaller than 0.00001', () => {
-    // explicitly positive numbers
-    expect(formatAmount('+0.000001')).toEqual('< +0.00001')
-    expect(formatAmount('+0.000009')).toEqual('< +0.00001')
+  it('should use < -0.00001 or < +0.00001 when the Eucledian distance of the amount is smaller than 0.00001', () => {
+    // explicitly positive numbers: keep the sign
+    expect(formatAmount('+0.000001', true)).toEqual('< +0.00001')
+    expect(formatAmount('+0.000009', true)).toEqual('< +0.00001')
 
     // negative numbers
     expect(formatAmount('-0.000001')).toEqual('< -0.00001')

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -2,8 +2,8 @@
 // https://github.com/5afe/safe/wiki/How-to-format-amounts
 
 const LOWER_LIMIT = 0.00001
-const COMPACT_LIMIT = 100_000_000
-const UPPER_LIMIT = 10 ** 15
+const COMPACT_LIMIT = 99_999_999.5
+const UPPER_LIMIT = 999 * 10 ** 12
 
 const getNumberFormatMaxFractionDigits = (float: number): Intl.NumberFormatOptions['maximumFractionDigits'] => {
   if (float < 1_000) {
@@ -30,6 +30,7 @@ const getNumberFormatMaxFractionDigits = (float: number): Intl.NumberFormatOptio
     return 0
   }
 
+  // to represent numbers like 767.343M
   if (float < UPPER_LIMIT) {
     return 3
   }
@@ -38,10 +39,10 @@ const getNumberFormatMaxFractionDigits = (float: number): Intl.NumberFormatOptio
 }
 
 const getNumberFormatNotation = (float: number): Intl.NumberFormatOptions['notation'] => {
-  return float < COMPACT_LIMIT ? undefined : 'compact'
+  return float >= COMPACT_LIMIT ? 'compact' : undefined
 }
 
-const getNumberFormatterOptions = (float: number) => {
+const getNumberFormatterOptions = (float: number): Intl.NumberFormatOptions => {
   return {
     maximumFractionDigits: getNumberFormatMaxFractionDigits(float),
     notation: getNumberFormatNotation(float),
@@ -59,8 +60,6 @@ const getCurrencyFormatterOptions = (float: number, currency: string): Intl.Numb
 
 // TODO: Add signs in reference to final point of number formatting
 const formatNumber = (float: number, options: Intl.NumberFormatOptions): string => {
-  const VISIBLE_UPPER_LIMIT = 999 * 10 ** 12 // 999T
-
   const formatter = new Intl.NumberFormat(undefined, options)
 
   if (float === 0) {
@@ -75,7 +74,7 @@ const formatNumber = (float: number, options: Intl.NumberFormatOptions): string 
     return formatter.format(float)
   }
 
-  return `> ${formatter.format(VISIBLE_UPPER_LIMIT)}`
+  return `> ${formatter.format(UPPER_LIMIT)}`
 }
 
 export const formatAmount = (number: string | number): string => {

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -58,16 +58,16 @@ const getCurrencyFormatterOptions = (float: number, currency: string): Intl.Numb
   }
 }
 
-// TODO: Add signs in reference to final point of number formatting
-const formatNumber = (float: number, options: Intl.NumberFormatOptions): string => {
+const formatNumber = (float: number, options: Intl.NumberFormatOptions, keepSign?: boolean): string => {
   const formatter = new Intl.NumberFormat(undefined, options)
 
   if (float === 0) {
     return formatter.format(float)
   }
 
-  if (float < LOWER_LIMIT) {
-    return `< ${formatter.format(LOWER_LIMIT)}`
+  if (Math.abs(float) < LOWER_LIMIT) {
+    const sign = keepSign && Math.sign(float) > 0 ? '+' : Math.sign(float) < 0 ? '-' : ''
+    return `< ${sign}${formatter.format(LOWER_LIMIT)}`
   }
 
   if (float < UPPER_LIMIT) {
@@ -77,10 +77,10 @@ const formatNumber = (float: number, options: Intl.NumberFormatOptions): string 
   return `> ${formatter.format(UPPER_LIMIT)}`
 }
 
-export const formatAmount = (number: string | number): string => {
+export const formatAmount = (number: string | number, keepSign?: boolean): string => {
   const float = Number(number)
   const options = getNumberFormatterOptions(float)
-  return formatNumber(float, options)
+  return formatNumber(float, options, keepSign)
 }
 
 export const formatAmountWithPrecision = (number: string | number, fractionDigits: number): string => {

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -77,7 +77,9 @@ const formatNumber = (float: number, options: Intl.NumberFormatOptions, keepSign
   return `> ${formatter.format(UPPER_LIMIT)}`
 }
 
-export const formatAmount = (number: string | number, keepSign?: boolean): string => {
+export const formatAmount = (number: string | number): string => {
+  // to keep the '+' sign, pass the amount as a string
+  const keepSign = typeof number === 'string' && number.trim().startsWith('+')
   const float = Number(number)
   const options = getNumberFormatterOptions(float)
   return formatNumber(float, options, keepSign)

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -40,12 +40,8 @@ export const safeFormatUnits = (value: BigNumberish, decimals: number | string =
  * @param decimals decimals of the specified value or unit name
  * @returns value at specified decimals, formatted, i.e. -< 0.00001
  */
-export const formatVisualAmount = (
-  value: BigNumberish,
-  decimals: number | string = GWEI,
-  keepSign?: boolean,
-): string => {
-  return formatAmount(safeFormatUnits(value, decimals), keepSign)
+export const formatVisualAmount = (value: BigNumberish, decimals: number | string = GWEI): string => {
+  return formatAmount(safeFormatUnits(value, decimals))
 }
 
 export const safeParseUnits = (value: string, decimals: number | string = GWEI): BigNumber | undefined => {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -40,8 +40,12 @@ export const safeFormatUnits = (value: BigNumberish, decimals: number | string =
  * @param decimals decimals of the specified value or unit name
  * @returns value at specified decimals, formatted, i.e. -< 0.00001
  */
-export const formatVisualAmount = (value: BigNumberish, decimals: number | string = GWEI): string => {
-  return formatAmount(safeFormatUnits(value, decimals))
+export const formatVisualAmount = (
+  value: BigNumberish,
+  decimals: number | string = GWEI,
+  keepSign?: boolean,
+): string => {
+  return formatAmount(safeFormatUnits(value, decimals), keepSign)
 }
 
 export const safeParseUnits = (value: string, decimals: number | string = GWEI): BigNumber | undefined => {


### PR DESCRIPTION
## What it solves
Unit tests for number formatting -> https://github.com/5afe/safe/wiki/How-to-format-amounts

_Note:_ I've used underscore as numeric separator for readability.

## How to test it
Run `yarn test formatNumber`

