### PR TITLE
fix: Handle 0 nonce in GasParams

### DIFF
--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -66,7 +66,11 @@ const GasParams = ({ params, isExecution, onEdit }: GasParamsProps): ReactElemen
         ) : (
           <Typography>
             Signing the transaction with nonce&nbsp;
-            {nonce || <Skeleton variant="text" sx={{ display: 'inline-block', minWidth: '2em' }} />}
+            {nonce !== undefined ? (
+              nonce
+            ) : (
+              <Skeleton variant="text" sx={{ display: 'inline-block', minWidth: '2em' }} />
+            )}
           </Typography>
         )}
       </AccordionSummary>


### PR DESCRIPTION
## What it solves

Resolves #532 

## How this PR fixes it

Since 0 is a falsy value it will not render if evaluated with `&&` so we check if its `undefined` instead

## How to test

1. Open a newly created safe
2. Create a transaction
3. Observe the nonce is being displayed in the review screen

## Screenshot
<img width="643" alt="Screenshot 2022-09-09 at 09 33 36" src="https://user-images.githubusercontent.com/5880855/189296791-1992969b-1853-45e5-bc15-1c22a16c953a.png">
