### PR TITLE
fix: remove filter date labels + timezone offset

### DIFF
--- a/src/components/common/PaginatedTxns/index.tsx
+++ b/src/components/common/PaginatedTxns/index.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useEffect, useState, useMemo } from 'react'
+import { type ReactElement, useEffect, useState } from 'react'
 import { Box, Typography } from '@mui/material'
 import TxList from '@/components/transactions/TxList'
 import ErrorMessage from '@/components/tx/ErrorMessage'
@@ -13,7 +13,6 @@ import { TxFilter, useTxFilter } from '@/utils/tx-history-filter'
 import { isTransactionListItem } from '@/utils/transaction-guards'
 import type { TransactionListPage } from '@gnosis.pm/safe-react-gateway-sdk'
 import { BatchExecuteHoverProvider } from '@/components/transactions/BatchExecuteButton/BatchExecuteHoverProvider'
-import { adjustDateLabelsTimezone } from '@/utils/transactions'
 
 const NoQueuedTxns = () => (
   <Box mt="5vh">
@@ -43,27 +42,18 @@ const TxPage = ({
 
   const isQueue = useTxns === useTxQueue
 
-  const txListPageItems = useMemo(() => {
-    if (!page?.results) {
-      return
-    }
-
-    // Date labels are returned at start of UTC day. Users in UTC-n timezones would see "yesterday" for txs today
-    return isQueue ? page.results : adjustDateLabelsTimezone(page.results)
-  }, [isQueue, page?.results])
-
-  if (page && txListPageItems) {
+  if (page?.results) {
     return (
       <>
         {/* FIXME: batching will only work for the first page results */}
         {isFirstPage && (
           <Box display="flex" flexDirection="column" alignItems="flex-end" mt={['-94px', '-44px']} mb={['60px', 0]}>
-            {isQueue ? <BatchExecuteButton items={txListPageItems} /> : <TxFilterButton />}
+            {isQueue ? <BatchExecuteButton items={page.results} /> : <TxFilterButton />}
             {filter && <Typography mt={2}>{getResultCount(filter, page)}</Typography>}
           </Box>
         )}
 
-        {page.results.length ? <TxList items={txListPageItems} /> : isQueue && <NoQueuedTxns />}
+        {page.results.length ? <TxList items={page.results} /> : isQueue && <NoQueuedTxns />}
 
         {onNextPage && page.next && (
           <Box my={4} textAlign="center">

--- a/src/utils/__tests__/tx-history-filter.test.ts
+++ b/src/utils/__tests__/tx-history-filter.test.ts
@@ -1,9 +1,4 @@
-import {
-  getIncomingTransfers,
-  getMultisigTransactions,
-  getModuleTransactions,
-  type TransactionListItem,
-} from '@gnosis.pm/safe-react-gateway-sdk'
+import { getIncomingTransfers, getMultisigTransactions, getModuleTransactions } from '@gnosis.pm/safe-react-gateway-sdk'
 import * as router from 'next/router'
 
 import {
@@ -19,7 +14,6 @@ import {
 import { renderHook } from '@/tests/test-utils'
 import type { NextRouter } from 'next/router'
 import { type TxFilterFormState } from '@/components/transactions/TxFilterForm'
-import { adjustDateLabelsTimezone } from '../transactions'
 
 jest.mock('@gnosis.pm/safe-react-gateway-sdk', () => ({
   getIncomingTransfers: jest.fn(() => Promise.resolve({ results: [] })),
@@ -373,80 +367,6 @@ describe('tx-history-filter', () => {
           safe: '0x123',
         },
       })
-    })
-  })
-  describe('adjustDateLabelsTimezone', () => {
-    it('should return items as is if it is an empty array', () => {
-      const result = adjustDateLabelsTimezone([])
-      expect(result).toEqual([])
-    })
-
-    it('should return items as is if it contains no transactions', () => {
-      const items = [
-        { type: 'LABEL', label: 'Next' },
-        { type: 'CONFLICT_HEADER', nonce: 1571 },
-      ] as TransactionListItem[]
-
-      const result = adjustDateLabelsTimezone(items)
-      expect(result).toEqual(items)
-    })
-
-    // TODO: Add conflict header test
-    it('should prepend and nest date labels between transactions on different days', () => {
-      const items = [
-        {
-          type: 'TRANSACTION',
-          transaction: {
-            timestamp: 1661305372000,
-          },
-        },
-        {
-          type: 'TRANSACTION',
-          transaction: {
-            timestamp: 1638530807000,
-          },
-        },
-        {
-          type: 'TRANSACTION',
-          transaction: {
-            timestamp: 1637069854000,
-          },
-        },
-      ] as TransactionListItem[]
-
-      const result = adjustDateLabelsTimezone(items)
-      expect(result).toEqual([
-        {
-          type: 'DATE_LABEL',
-          timestamp: 1661292000000,
-        },
-        {
-          type: 'TRANSACTION',
-          transaction: {
-            timestamp: 1661305372000,
-          },
-        },
-        {
-          type: 'DATE_LABEL',
-          timestamp: 1638486000000,
-        },
-        {
-          type: 'TRANSACTION',
-          transaction: {
-            timestamp: 1638530807000,
-          },
-        },
-        {
-          type: 'DATE_LABEL',
-          timestamp: 1637017200000,
-        },
-        {
-          type: 'TRANSACTION',
-          transaction: {
-            timestamp: 1637069854000,
-          },
-        },
-      ])
     })
   })
 

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -8,13 +8,10 @@ import {
   MultisigExecutionInfo,
   Transaction,
   TransactionDetails,
-  TransactionListItem,
 } from '@gnosis.pm/safe-react-gateway-sdk'
 import {
-  isDateLabel,
   isModuleExecutionInfo,
   isMultisigExecutionDetails,
-  isTransactionListItem,
   isTxQueued,
   TransactionListItemType,
 } from './transaction-guards'
@@ -25,7 +22,7 @@ import { createExistingTx } from '@/services/tx/txSender'
 import { AdvancedParameters } from '@/components/tx/AdvancedParams'
 import { TransactionOptions } from '@gnosis.pm/safe-core-sdk-types'
 import { hasFeature } from '@/utils/chains'
-import { startOfDay, isSameDay } from 'date-fns'
+import { startOfDay } from 'date-fns'
 
 export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction => {
   const getMissingSigners = ({
@@ -83,41 +80,6 @@ export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction =>
 export const makeDateLabelFromTx = (tx: Transaction): DateLabel => {
   const startOfDayTimestamp = startOfDay(tx.transaction.timestamp).getTime()
   return { timestamp: startOfDayTimestamp, type: TransactionListItemType.DATE_LABEL }
-}
-
-/**
- * Add date labels between transactions made on the same day by local timezone
- */
-// TODO: Needs to know if previous page has same day to prevent duplicate date labels
-export const adjustDateLabelsTimezone = (items: TransactionListItem[]): TransactionListItem[] => {
-  const firstTx = items.find(isTransactionListItem)
-
-  if (!firstTx) {
-    return items
-  }
-
-  // Insert date labels between transactions on different days
-  return items
-    .filter((item) => !isDateLabel(item))
-    .reduce<TransactionListItem[]>((resultItems, item, index, allItems) => {
-      const prevItem = allItems[index - 1]
-
-      // Add date label before the first transaction of the first page
-      if (!prevItem) {
-        return ([makeDateLabelFromTx(firstTx)] as TransactionListItem[]).concat(item)
-      }
-
-      // Transaction is on different day as previous transaction
-      if (
-        isTransactionListItem(prevItem) &&
-        isTransactionListItem(item) &&
-        !isSameDay(prevItem.transaction.timestamp, item.transaction.timestamp)
-      ) {
-        return resultItems.concat(makeDateLabelFromTx(item), item)
-      }
-
-      return resultItems.concat(item)
-    }, [])
 }
 
 const getSignatures = (confirmations: Record<string, string>) => {


### PR DESCRIPTION
## What it solves

Removes unnecessary logic from client-side.

## How this PR fixes it

Manual additon of date labels to filter results/adjustment for timezones has been removed.

## How to test it

Open transaction history, ensure timezone is set to non-UTC, observe that date labels span transactions of different days.
Filter transactions. Observe that there are no date labels.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/189364070-917cf19f-ab1f-47ee-bd21-fe9c1cc022d7.png)

![image](https://user-images.githubusercontent.com/20442784/189364173-4c64a5d3-a949-4637-834a-4ab88ea7a315.png)