### PR TITLE
fix: remove GTM `noscript`

### DIFF
--- a/src/services/analytics/TagManager.ts
+++ b/src/services/analytics/TagManager.ts
@@ -56,20 +56,6 @@ export const _getGtmScript = (args: TagManagerArgs) => {
   return script
 }
 
-export const _getGtmNoScript = (args: TagManagerArgs) => {
-  const { gtmId, auth, preview } = _getRequiredGtmArgs(args)
-
-  const noscript = document.createElement('noscript')
-
-  const gtmIframe = `
-      <iframe src="https://www.googletagmanager.com/ns.html?id=${gtmId}${auth}${preview}&gtm_cookies_win=x"
-        height="0" width="0" style="display:none;visibility:hidden" id="tag-manager"></iframe>`
-
-  noscript.innerHTML = gtmIframe
-
-  return noscript
-}
-
 // Data layer scripts
 
 export const _getGtmDataLayerScript = (dataLayer: DataLayer) => {
@@ -95,9 +81,6 @@ const TagManager = {
 
     const gtmScript = _getGtmScript(args)
     document.head.insertBefore(gtmScript, document.head.childNodes[0])
-
-    const gtmNoScript = _getGtmNoScript(args)
-    document.body.insertBefore(gtmNoScript, document.body.childNodes[0])
   },
   dataLayer: (dataLayer: DataLayer) => {
     if (window[DATA_LAYER_NAME]) {

--- a/src/services/analytics/__tests__/TagManager.test.ts
+++ b/src/services/analytics/__tests__/TagManager.test.ts
@@ -1,4 +1,4 @@
-import TagManager, { _getGtmDataLayerScript, _getGtmNoScript, _getGtmScript, _getRequiredGtmArgs } from '../TagManager'
+import TagManager, { _getGtmDataLayerScript, _getGtmScript, _getRequiredGtmArgs } from '../TagManager'
 
 const MOCK_ID = 'GTM-123456'
 
@@ -52,31 +52,6 @@ describe('TagManager', () => {
       })
 
       expect(script2.innerHTML).toContain('&gtm_auth=abcdefg&gtm_preview=env-1')
-    })
-  })
-
-  describe('getGtmNoScript', () => {
-    it('should use the id for the iframe', () => {
-      const noscript = _getGtmNoScript({ gtmId: MOCK_ID })
-
-      expect(noscript.innerHTML).toContain(`id=GTM-123456`)
-    })
-
-    it('should use the gtm_auth and gtm_preview for the iframe if present', () => {
-      const noscript1 = _getGtmNoScript({
-        gtmId: MOCK_ID,
-      })
-
-      expect(noscript1.innerHTML).not.toContain('&gtm_auth')
-      expect(noscript1.innerHTML).not.toContain('&gtm_preview')
-
-      const noscript2 = _getGtmNoScript({
-        gtmId: MOCK_ID,
-        auth: 'abcdefg',
-        preview: 'env-1',
-      })
-
-      expect(noscript2.innerHTML).toContain('&gtm_auth=abcdefg&gtm_preview=env-1')
     })
   })
 


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/web-core/pull/517#discussion_r967757713

## How this PR fixes it

GTM's `noscript` injection has been used as the Safe doesn't work without JS.

## How to test it

Observe no `<noscript>` injected in the DOM.
