### PR TITLE
Chore: add gitpoap badge to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/safe-global/web-core)](https://github.com/safe-global/web-core/blob/main/LICENSE.md)
 ![tests](https://img.shields.io/github/workflow/status/safe-global/web-core/Unit%20tests/main?label=tests)
 ![GitHub package.json version (branch)](https://img.shields.io/github/package-json/v/safe-global/web-core/main)
+[![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/safe-global/web-core/badge)](https://www.gitpoap.io/gh/gitpoap/gitpoap-docs)
 
 The default Safe web interface.
 


### PR DESCRIPTION
As per https://gitpoap.notion.site/Maximizing-your-GitPOAP-s-impact-fafb53a83c754c2588e90c57b18ee898