### PR TITLE
fix: queue/wallet events over tracking

### DIFF
--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -79,39 +79,33 @@ const getWalletConnectLabel = async ({ label, provider }: ConnectedWallet): Prom
   return peerWallet ?? UNKNOWN_PEER
 }
 
-const prevTrackedWallet = {
-  label: '',
-  wcLabel: '',
-}
-
-const trackWalletType = async (wallet: ReturnType<typeof getConnectedWallet>) => {
-  if (!wallet) {
-    prevTrackedWallet.label = ''
-    prevTrackedWallet.wcLabel = ''
-    return
-  }
-
-  if (wallet.label !== prevTrackedWallet.label) {
-    trackEvent({ ...WALLET_EVENTS.CONNECT, label: wallet.label })
-
-    prevTrackedWallet.label = wallet.label
-  }
+const trackWalletType = async (wallet: ConnectedWallet) => {
+  trackEvent({ ...WALLET_EVENTS.CONNECT, label: wallet.label })
 
   const wcLabel = await getWalletConnectLabel(wallet)
 
-  if (!wcLabel) {
-    prevTrackedWallet.wcLabel = ''
-    return
-  }
-
-  if (wcLabel !== prevTrackedWallet.wcLabel) {
+  if (wcLabel) {
     trackEvent({
       ...WALLET_EVENTS.WALLET_CONNECT,
       label: wcLabel,
     })
-
-    prevTrackedWallet.wcLabel = wcLabel
   }
+}
+
+// Wrapper that tracks/sets the last used wallet
+export const connectWallet = (onboard: OnboardAPI, options: Parameters<OnboardAPI['connectWallet']>[0]) => {
+  onboard
+    .connectWallet(options)
+    .then(async (wallets) => {
+      const newWallet = getConnectedWallet(wallets)
+
+      if (newWallet) {
+        lastWalletStorage.set(newWallet.label)
+
+        await trackWalletType(newWallet)
+      }
+    })
+    .catch((e) => logError(Errors._302, (e as Error).message))
 }
 
 // Disable/enable wallets according to chain and cache the last used wallet
@@ -141,36 +135,15 @@ export const useInitOnboard = () => {
     enableWallets()
   }, [chain?.disabledWallets, onboard])
 
-  // Remember the last used wallet
-  useEffect(() => {
-    if (!onboard) return
-
-    const walletSubscription = onboard.state.select('wallets').subscribe(async (wallets) => {
-      const newWallet = getConnectedWallet(wallets)
-
-      await trackWalletType(newWallet)
-
-      if (newWallet) {
-        lastWalletStorage.set(newWallet.label)
-      }
-    })
-
-    return () => {
-      walletSubscription.unsubscribe()
-    }
-  }, [onboard])
-
   // Connect to the last connected wallet
   useEffect(() => {
     if (onboard && onboard.state.get().wallets.length === 0) {
       const label = getLastUsedWallet()
 
       if (label) {
-        onboard
-          .connectWallet({
-            autoSelect: { label, disableModals: true },
-          })
-          .catch((e) => logError(Errors._302, (e as Error).message))
+        connectWallet(onboard, {
+          autoSelect: { label, disableModals: true },
+        })
       }
     }
   }, [onboard])

--- a/src/services/pairing/hooks.ts
+++ b/src/services/pairing/hooks.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 
 import { useCurrentChain } from '@/hooks/useChains'
-import useOnboard, { getConnectedWallet } from '@/hooks/wallets/useOnboard'
+import useOnboard, { connectWallet, getConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { logError, Errors } from '@/services/exceptions'
 import {
   getClientMeta,
@@ -69,20 +69,19 @@ export const useInitPairing = () => {
 
     // Upon successful WC connection, connect it to onboard
     connector?.on(WalletConnectEvents.CONNECT, () => {
-      onboard
-        .connectWallet({
-          autoSelect: {
-            label: PAIRING_MODULE_LABEL,
-            disableModals: true,
-          },
-        })
-        .catch((e) => logError(Errors._302, (e as Error).message))
+      connectWallet(onboard, {
+        autoSelect: {
+          label: PAIRING_MODULE_LABEL,
+          disableModals: true,
+        },
+      })
     })
 
     connector?.on(WalletConnectEvents.DISCONNECT, () => {
       createSession()
     })
 
+    // TODO: set `hasInitialized` after `onboard.connectWallet` is called
     // Create new session when no wallet is connected to onboard
     const subscription = onboard.state.select('wallets').subscribe((wallets) => {
       if (!getConnectedWallet(wallets) && !hasInitialized) {

--- a/src/store/txQueueSlice.ts
+++ b/src/store/txQueueSlice.ts
@@ -1,5 +1,6 @@
 import { createSelector, Middleware } from '@reduxjs/toolkit'
 import { TransactionListPage } from '@gnosis.pm/safe-react-gateway-sdk'
+import { isEqual } from 'lodash'
 import type { RootState } from '@/store'
 import { makeLoadableSlice } from './common'
 import { isMultisigExecutionInfo, isTransactionListItem } from '@/utils/transaction-guards'
@@ -24,18 +25,26 @@ export const selectQueuedTransactionsByNonce = createSelector(
   },
 )
 
-export const txQueueMiddleware: Middleware<{}, RootState> = () => (next) => (action) => {
+export const txQueueMiddleware: Middleware<{}, RootState> = (store) => (next) => (action) => {
+  const prevState = store.getState()
+
   const result = next(action)
 
   switch (action.type) {
     case txQueueSlice.actions.set.type: {
       const { payload } = action as ReturnType<typeof txQueueSlice.actions.set>
 
-      if (!payload.data) return
+      const txQueue = selectTxQueue(prevState)
+
+      if (isEqual(txQueue.data?.results, payload.data?.results)) {
+        return
+      }
+
+      const transactions = payload.data?.results.filter(isTransactionListItem) || []
 
       trackEvent({
         ...TX_LIST_EVENTS.QUEUED_TXS,
-        label: payload.data.results.length.toString(),
+        label: transactions.length.toString(),
       })
     }
   }


### PR DESCRIPTION
## What it solves

Resolves queue/wallet events over tracking.

## How this PR fixes it

1. Transaction queue is now compared for equality before being tracked. Only actual transactions are tracked, now not including `DATE_LABEL`s or `CONFLICT_HEADER`s.
2. Connected wallet/WalletConnect peer labels are cached/compared before tracking.

## How to test it

1. Open the dashboard/transaction queue. Observe that only one event is tracked for the queue length, unless a queued transaction is added or executed.
2. Connect a wallet/WalletConnect peer and observe that only one event is tracked.

## Analytics changes

1. Queue length is tracked once for current queue data.
2. Wallet connection events are tracked once upon connection.