### PR TITLE
fix: pass txNonce 0 on RejectTx

### DIFF
--- a/src/components/tx/modals/RejectTxModal/RejectTx.tsx
+++ b/src/components/tx/modals/RejectTxModal/RejectTx.tsx
@@ -19,7 +19,7 @@ const RejectTx = ({ txSummary, onSubmit }: RejectTxProps): ReactElement => {
   const txNonce = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo.nonce : undefined
 
   const [rejectTx, rejectError] = useAsync<SafeTransaction>(() => {
-    if (txNonce) return createRejectTx(txNonce)
+    if (txNonce != undefined) return createRejectTx(txNonce)
   }, [txNonce])
 
   return (


### PR DESCRIPTION
## What it solves
Part of #532
https://github.com/safe-global/web-core/issues/532#issuecomment-1243090996
Submit button is disabled for Reject transactions with nonce 0

## How this PR fixes it
One can create a Reject transaction with `txNonce` 0

## How to test it
see https://github.com/safe-global/web-core/issues/532#issuecomment-1243090996

## Screenshots
![Screenshot 2022-09-15 at 11 49 12](https://user-images.githubusercontent.com/32431609/190375090-2ef9f829-4c24-4e42-8654-2300c27b37c0.png)
