### PR TITLE
fix: add missing wallet tracking

### DIFF
--- a/src/components/common/ConnectWallet/WalletDetails.tsx
+++ b/src/components/common/ConnectWallet/WalletDetails.tsx
@@ -1,8 +1,7 @@
 import { Button, Typography } from '@mui/material'
 import type { ReactElement } from 'react'
 
-import useOnboard from '@/hooks/wallets/useOnboard'
-import { logError, Errors } from '@/services/exceptions'
+import useOnboard, { connectWallet } from '@/hooks/wallets/useOnboard'
 import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
 import KeyholeIcon from '@/components/common/icons/KeyholeIcon'
 import { trackEvent } from '@/services/analytics'
@@ -17,7 +16,7 @@ const WalletDetails = ({ onConnect }: { onConnect?: () => void }): ReactElement 
     trackEvent(OVERVIEW_EVENTS.OPEN_ONBOARD)
 
     onConnect?.()
-    onboard.connectWallet().catch((e) => logError(Errors._302, (e as Error).message))
+    connectWallet(onboard)
   }
 
   return (

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -93,7 +93,7 @@ const trackWalletType = async (wallet: ConnectedWallet) => {
 }
 
 // Wrapper that tracks/sets the last used wallet
-export const connectWallet = (onboard: OnboardAPI, options: Parameters<OnboardAPI['connectWallet']>[0]) => {
+export const connectWallet = (onboard: OnboardAPI, options?: Parameters<OnboardAPI['connectWallet']>[0]) => {
   onboard
     .connectWallet(options)
     .then(async (wallets) => {


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/web-core/pull/543#issuecomment-1248684913

## How this PR fixes it

The connection call when manually connecting is now wrapped in the tracking function.

## How to test it

Connect to a wallet via the header and observe the tracking event.

## Analytics changes

Connecting to a wallet via the header tracks the "Connect wallet" event

## Screenshots

![connect](https://user-images.githubusercontent.com/20442784/190582618-189f6403-ab13-4639-b785-1d2adc2203f9.gif)