### PR TITLE
fix: remove redundant TODO

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,6 +1,3 @@
-// TODO: Remove date-fns and convert to use the native JS formatter
-// @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat
-
 import { format, formatDistanceToNow, formatRelative } from 'date-fns'
 
 export const currentMinutes = (): number => Math.floor(Date.now() / (1000 * 60))


### PR DESCRIPTION
## What it solves

Removes redudant TODO

## How this PR fixes it

Comment has been removed:

- `@date-io/date-fns` is needed for the MUI date picker. It doesn't expose `date-fns`.
- `date-fns` is used extensively, not just for relevant times.
- Our `formatTimeInWords` uses hours, days, weeks, months, years, whereas `Intl.RelativeTimeFormat` is restricted to just one.