### PR TITLE
fix: add App Store button to footer

### DIFF
--- a/src/components/common/AppStoreButton/index.tsx
+++ b/src/components/common/AppStoreButton/index.tsx
@@ -8,7 +8,6 @@ import css from '@/components/common/AppStoreButton/styles.module.css'
 // App Store campaigns track the user interaction
 enum LINKS {
   pairing = 'https://apps.apple.com/app/apple-store/id1515759131?pt=119497694&ct=Web%20App%20Connect&mt=8',
-  // TODO: Add to footer
   footer = 'https://apps.apple.com/app/apple-store/id1515759131?pt=119497694&ct=Web%20App%20Footer&mt=8',
 }
 

--- a/src/components/common/Footer/index.tsx
+++ b/src/components/common/Footer/index.tsx
@@ -6,6 +6,7 @@ import { useAppDispatch } from '@/store'
 import { openCookieBanner } from '@/store/popupSlice'
 import { AppRoutes } from '@/config/routes'
 import packageJson from '../../../../package.json'
+import AppstoreButton from '../AppStoreButton'
 
 const footerPages = [AppRoutes.welcome, AppRoutes.safe.settings.index]
 
@@ -65,6 +66,9 @@ const Footer = (): ReactElement | null => {
           >
             v{packageJson.version}
           </Link>
+        </li>
+        <li>
+          <AppstoreButton placement="footer" />
         </li>
       </ul>
     </footer>

--- a/src/components/common/Footer/styles.module.css
+++ b/src/components/common/Footer/styles.module.css
@@ -12,6 +12,7 @@
   justify-content: center;
   row-gap: 0.2em;
   column-gap: var(--space-2);
+  align-items: center;
 }
 
 .container li {


### PR DESCRIPTION
## What it solves

Resolves no App Store button in footer

## How this PR fixes it

The App Store button has been added to the footer, responding to light/dark mode

## How to test it

Open the settings and observe the App Store button present in the footer, opening the App Store correctly when clicking. Changing the theme should also change the colour of the button

## Analytics changes

Clicking the button should dispatch the "appstore-button-click" action with a `label` of "footer".

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/190611747-c28c73f4-b622-4661-9b32-f03a8b0996bc.png)

![image](https://user-images.githubusercontent.com/20442784/190611776-32a25c67-893a-4659-97e8-87602cae0696.png)