### PR TITLE
refactor: use CGW SDK enums

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@gnosis.pm/safe-deployments": "^1.15.0",
     "@gnosis.pm/safe-ethers-lib": "^1.5.0",
     "@gnosis.pm/safe-modules-deployments": "^1.0.0",
-    "@gnosis.pm/safe-react-gateway-sdk": "^3.4.0",
+    "@gnosis.pm/safe-react-gateway-sdk": "^3.4.1",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.9.3",
     "@mui/x-date-pickers": "^5.0.0-beta.6",

--- a/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/src/components/transactions/TxDetails/Summary/index.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useState } from 'react'
 import { Link } from '@mui/material'
 import { generateDataRowValue, TxDataRow } from '@/components/transactions/TxDetails/Summary/TxDataRow'
-import { isMultisigExecutionDetails } from '@/utils/transaction-guards'
+import { isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
 import { Operation, TransactionDetails } from '@gnosis.pm/safe-react-gateway-sdk'
 import { dateString } from '@/utils/formatters'
 import css from './styles.module.css'
@@ -21,7 +21,7 @@ const Summary = ({ txDetails, defaultExpanded = false }: Props): ReactElement =>
   const { txHash, detailedExecutionInfo, executedAt, txData } = txDetails
 
   let submittedAt, confirmations, safeTxHash, baseGas, gasPrice, gasToken, refundReceiver, safeTxGas
-  if (isMultisigExecutionDetails(detailedExecutionInfo)) {
+  if (isMultisigDetailedExecutionInfo(detailedExecutionInfo)) {
     ;({ submittedAt, confirmations, safeTxHash, baseGas, gasPrice, gasToken, safeTxGas } = detailedExecutionInfo)
     refundReceiver = detailedExecutionInfo.refundReceiver?.value
   }

--- a/src/components/transactions/TxDetails/TxData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/index.tsx
@@ -3,7 +3,7 @@ import {
   isCancellationTxInfo,
   isCustomTxInfo,
   isMultiSendTxInfo,
-  isMultisigExecutionDetails,
+  isMultisigDetailedExecutionInfo,
   isSettingsChangeTxInfo,
   isSpendingLimitMethod,
   isSupportedMultiSendAddress,
@@ -32,7 +32,7 @@ const TxData = ({ txDetails }: { txDetails: TransactionDetails }): ReactElement 
     return <SettingsChangeTxInfo settingsInfo={txInfo.settingsInfo} />
   }
 
-  if (isCancellationTxInfo(txInfo) && isMultisigExecutionDetails(txDetails.detailedExecutionInfo)) {
+  if (isCancellationTxInfo(txInfo) && isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)) {
     return <RejectionTxInfo nonce={txDetails.detailedExecutionInfo?.nonce} isTxExecuted={!!txDetails.executedAt} />
   }
 

--- a/src/components/transactions/TxSigners/index.tsx
+++ b/src/components/transactions/TxSigners/index.tsx
@@ -14,7 +14,7 @@ import type {
 
 import useWallet from '@/hooks/wallets/useWallet'
 import useIsPending from '@/hooks/useIsPending'
-import { isCancellationTxInfo, isExecutable, isMultisigExecutionDetails } from '@/utils/transaction-guards'
+import { isCancellationTxInfo, isExecutable, isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
 import EthHashInfo from '@/components/common/EthHashInfo'
 
 import css from './styles.module.css'
@@ -69,7 +69,7 @@ const StyledStep = ({ $bold, $state, sx, ...rest }: StyledStepProps & StepProps)
 )
 
 const shouldHideConfirmations = (detailedExecutionInfo?: DetailedExecutionInfo): boolean => {
-  if (!detailedExecutionInfo || !isMultisigExecutionDetails(detailedExecutionInfo)) {
+  if (!detailedExecutionInfo || !isMultisigDetailedExecutionInfo(detailedExecutionInfo)) {
     return true
   }
 
@@ -104,7 +104,7 @@ export const TxSigners = ({
     setHideConfirmations((prev) => !prev)
   }
 
-  if (!detailedExecutionInfo || !isMultisigExecutionDetails(detailedExecutionInfo)) {
+  if (!detailedExecutionInfo || !isMultisigDetailedExecutionInfo(detailedExecutionInfo)) {
     return null
   }
 

--- a/src/hooks/__tests__/useBatchedTxs.test.ts
+++ b/src/hooks/__tests__/useBatchedTxs.test.ts
@@ -1,9 +1,13 @@
 import {
   AddressEx,
+  ConflictType,
+  DetailedExecutionInfoType,
   MultisigExecutionInfo,
   Transaction,
   TransactionInfo,
+  TransactionInfoType,
   TransactionListItem,
+  TransactionListItemType,
   TransactionStatus,
   TransactionSummary,
   TransactionTokenType,
@@ -23,7 +27,7 @@ const mockTransferInfo: TransferInfo = {
 }
 
 const mockTxInfo: TransactionInfo = {
-  type: 'Transfer',
+  type: TransactionInfoType.TRANSFER,
   sender: mockAddressEx,
   recipient: mockAddressEx,
   direction: TransferDirection.OUTGOING,
@@ -36,7 +40,7 @@ const defaultTx: TransactionSummary = {
   txInfo: mockTxInfo,
   txStatus: TransactionStatus.AWAITING_CONFIRMATIONS,
   executionInfo: {
-    type: 'MULTISIG',
+    type: DetailedExecutionInfoType.MULTISIG,
     nonce: 1,
     confirmationsRequired: 2,
     confirmationsSubmitted: 2,
@@ -52,8 +56,8 @@ const getMockTx = ({ nonce }: { nonce?: number }): Transaction => {
         nonce: nonce ?? (defaultTx.executionInfo as MultisigExecutionInfo).nonce,
       } as MultisigExecutionInfo,
     },
-    type: 'TRANSACTION',
-    conflictType: 'None',
+    type: TransactionListItemType.TRANSACTION,
+    conflictType: ConflictType.NONE,
   }
 }
 
@@ -75,8 +79,8 @@ describe('getBatchableTransactions', () => {
           confirmationsSubmitted: 2,
         } as MultisigExecutionInfo,
       },
-      type: 'TRANSACTION',
-      conflictType: 'None',
+      type: TransactionListItemType.TRANSACTION,
+      conflictType: ConflictType.NONE,
     }
     const result = getBatchableTransactions([mockTx], 0)
 
@@ -95,8 +99,8 @@ describe('getBatchableTransactions', () => {
           confirmationsSubmitted: 1,
         } as MultisigExecutionInfo,
       },
-      type: 'TRANSACTION',
-      conflictType: 'None',
+      type: TransactionListItemType.TRANSACTION,
+      conflictType: ConflictType.NONE,
     }
     const result = getBatchableTransactions([mockTx], 0)
 
@@ -115,12 +119,12 @@ describe('getBatchableTransactions', () => {
           confirmationsSubmitted: 2,
         } as MultisigExecutionInfo,
       },
-      type: 'TRANSACTION',
-      conflictType: 'None',
+      type: TransactionListItemType.TRANSACTION,
+      conflictType: ConflictType.NONE,
     }
 
     const mockConflict: TransactionListItem = {
-      type: 'CONFLICT_HEADER',
+      type: TransactionListItemType.CONFLICT_HEADER,
       nonce: 1,
     }
 
@@ -135,8 +139,8 @@ describe('getBatchableTransactions', () => {
         } as MultisigExecutionInfo,
         timestamp: 1,
       },
-      type: 'TRANSACTION',
-      conflictType: 'HasNext',
+      type: TransactionListItemType.TRANSACTION,
+      conflictType: ConflictType.HAS_NEXT,
     }
 
     const mockTx2: Transaction = {
@@ -150,8 +154,8 @@ describe('getBatchableTransactions', () => {
         } as MultisigExecutionInfo,
         timestamp: 2,
       },
-      type: 'TRANSACTION',
-      conflictType: 'End',
+      type: TransactionListItemType.TRANSACTION,
+      conflictType: ConflictType.END,
     }
 
     const result = getBatchableTransactions([mockTx, mockConflict, mockTx1, mockTx2], 0)
@@ -171,8 +175,8 @@ describe('getBatchableTransactions', () => {
           confirmationsSubmitted: 2,
         } as MultisigExecutionInfo,
       },
-      type: 'TRANSACTION',
-      conflictType: 'None',
+      type: TransactionListItemType.TRANSACTION,
+      conflictType: ConflictType.NONE,
     }
 
     const mockTx1: Transaction = {
@@ -185,8 +189,8 @@ describe('getBatchableTransactions', () => {
           confirmationsSubmitted: 2,
         } as MultisigExecutionInfo,
       },
-      type: 'TRANSACTION',
-      conflictType: 'None',
+      type: TransactionListItemType.TRANSACTION,
+      conflictType: ConflictType.NONE,
     }
 
     const result = getBatchableTransactions([mockTx, mockTx1], 0)

--- a/src/hooks/useTransactionType.ts
+++ b/src/hooks/useTransactionType.ts
@@ -1,17 +1,13 @@
 import { useMemo } from 'react'
 import {
   SettingsInfoType,
+  TransactionInfoType,
   TransferDirection,
   type AddressEx,
   type TransactionSummary,
 } from '@gnosis.pm/safe-react-gateway-sdk'
 
-import {
-  isCancellationTxInfo,
-  isModuleExecutionInfo,
-  isTxQueued,
-  TransactionInfoType,
-} from '@/utils/transaction-guards'
+import { isCancellationTxInfo, isModuleExecutionInfo, isTxQueued } from '@/utils/transaction-guards'
 import { DEFAULT_MODULE_NAME } from '@/components/settings/SafeModules'
 
 const getTxTo = ({ txInfo }: Pick<TransactionSummary, 'txInfo'>): AddressEx | undefined => {

--- a/src/services/tx/extractTxInfo.ts
+++ b/src/services/tx/extractTxInfo.ts
@@ -1,6 +1,6 @@
 import { OperationType, type SafeTransactionData } from '@gnosis.pm/safe-core-sdk-types'
 import { Operation, TransactionDetails } from '@gnosis.pm/safe-react-gateway-sdk'
-import { isMultisigExecutionDetails, isNativeTokenTransfer } from '@/utils/transaction-guards'
+import { isMultisigDetailedExecutionInfo, isNativeTokenTransfer } from '@/utils/transaction-guards'
 
 const ZERO_ADDRESS: string = '0x0000000000000000000000000000000000000000'
 const EMPTY_DATA: string = '0x'
@@ -14,7 +14,7 @@ const extractTxInfo = (
 ): { txParams: SafeTransactionData; signatures: Record<string, string> } => {
   // Format signatures into a map
   let signatures: Record<string, string> = {}
-  if (isMultisigExecutionDetails(txDetails.detailedExecutionInfo)) {
+  if (isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)) {
     signatures = txDetails.detailedExecutionInfo.confirmations.reduce((result, item) => {
       result[item.signer.value] = item.signature || ''
       return result
@@ -23,25 +23,27 @@ const extractTxInfo = (
 
   const data = txDetails.txData?.hexData ?? EMPTY_DATA
 
-  const baseGas = isMultisigExecutionDetails(txDetails.detailedExecutionInfo)
+  const baseGas = isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)
     ? Number(txDetails.detailedExecutionInfo.baseGas)
     : 0
 
-  const gasPrice = isMultisigExecutionDetails(txDetails.detailedExecutionInfo)
+  const gasPrice = isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)
     ? Number(txDetails.detailedExecutionInfo.gasPrice)
     : 0
 
-  const safeTxGas = isMultisigExecutionDetails(txDetails.detailedExecutionInfo)
+  const safeTxGas = isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)
     ? Number(txDetails.detailedExecutionInfo.safeTxGas)
     : 0
 
-  const gasToken = isMultisigExecutionDetails(txDetails.detailedExecutionInfo)
+  const gasToken = isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)
     ? txDetails.detailedExecutionInfo.gasToken
     : ZERO_ADDRESS
 
-  const nonce = isMultisigExecutionDetails(txDetails.detailedExecutionInfo) ? txDetails.detailedExecutionInfo.nonce : 0
+  const nonce = isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)
+    ? txDetails.detailedExecutionInfo.nonce
+    : 0
 
-  const refundReceiver = isMultisigExecutionDetails(txDetails.detailedExecutionInfo)
+  const refundReceiver = isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)
     ? txDetails.detailedExecutionInfo.refundReceiver.value
     : ZERO_ADDRESS
 

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -10,7 +10,9 @@ import {
   DetailedExecutionInfoType,
   Erc20Transfer,
   Erc721Transfer,
+  ExecutionInfo,
   Label,
+  ModuleExecutionDetails,
   ModuleExecutionInfo,
   MultiSend,
   MultisigExecutionDetails,
@@ -52,17 +54,13 @@ export const isOwner = (safeOwners: AddressEx[] | NamedAddress[] = [], walletAdd
   return safeOwners.some((owner) => sameAddress(owner.address, walletAddress))
 }
 
+// Narrows `TransactionDetails` -> when requesting a single transaction
 export const isMultisigExecutionDetails = (value?: DetailedExecutionInfo): value is MultisigExecutionDetails => {
   return value?.type === DetailedExecutionInfoType.MULTISIG
 }
 
-// TODO: replace this type guard for the one guard above
-export const isMultisigExecutionInfo = (value: TransactionSummary['executionInfo']): value is MultisigExecutionInfo =>
-  value?.type === DetailedExecutionInfoType.MULTISIG
-
-export const isModuleExecutionInfo = (
-  value: TransactionSummary['executionInfo'] | DetailedExecutionInfo,
-): value is ModuleExecutionInfo => value?.type === DetailedExecutionInfoType.MODULE
+export const isModuleExecutionDetails = (value?: DetailedExecutionInfo): value is ModuleExecutionDetails =>
+  value?.type === DetailedExecutionInfoType.MODULE
 
 // TransactionInfo type guards
 export const isTransferTxInfo = (value: TransactionInfo): value is Transfer => {
@@ -97,7 +95,7 @@ export const isCreationTxInfo = (value: TransactionInfo): value is Creation => {
   return value.type === TransactionInfoType.CREATION
 }
 
-// TxListItem type guards
+// TransactionListItem type guards
 export const isTransactionListItem = (value: TransactionListItem): value is Transaction => {
   return value.type === TransactionListItemType.TRANSACTION
 }
@@ -113,6 +111,13 @@ export const isConflictHeaderListItem = (value: TransactionListItem): value is C
 export const isDateLabel = (value: TransactionListItem): value is DateLabel => {
   return value.type === TransactionListItemType.DATE_LABEL
 }
+
+// Narrows `Transaction`s -> when request a page of `TransactionListItem`
+export const isMultisigExecutionInfo = (value?: ExecutionInfo): value is MultisigExecutionInfo =>
+  value?.type === DetailedExecutionInfoType.MULTISIG
+
+export const isModuleExecutionInfo = (value?: ExecutionInfo): value is ModuleExecutionInfo =>
+  value?.type === DetailedExecutionInfoType.MODULE
 
 export const isSignableBy = (txSummary: TransactionSummary, walletAddress: string): boolean => {
   const executionInfo = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo : undefined

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -55,11 +55,11 @@ export const isOwner = (safeOwners: AddressEx[] | NamedAddress[] = [], walletAdd
 }
 
 // Narrows `TransactionDetails` -> when requesting a single transaction
-export const isMultisigExecutionDetails = (value?: DetailedExecutionInfo): value is MultisigExecutionDetails => {
+export const isMultisigDetailedExecutionInfo = (value?: DetailedExecutionInfo): value is MultisigExecutionDetails => {
   return value?.type === DetailedExecutionInfoType.MULTISIG
 }
 
-export const isModuleExecutionDetails = (value?: DetailedExecutionInfo): value is ModuleExecutionDetails =>
+export const isModuleDetailedExecutionInfo = (value?: DetailedExecutionInfo): value is ModuleExecutionDetails =>
   value?.type === DetailedExecutionInfoType.MODULE
 
 // TransactionInfo type guards

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -2,10 +2,12 @@ import {
   AddressEx,
   Cancellation,
   ConflictHeader,
+  ConflictType,
   Creation,
   Custom,
   DateLabel,
   DetailedExecutionInfo,
+  DetailedExecutionInfoType,
   Erc20Transfer,
   Erc721Transfer,
   Label,
@@ -13,19 +15,22 @@ import {
   MultiSend,
   MultisigExecutionDetails,
   MultisigExecutionInfo,
+  NativeCoinTransfer,
   SettingsChange,
   Transaction,
   TransactionInfo,
+  TransactionInfoType,
   TransactionListItem,
+  TransactionListItemType,
   TransactionStatus,
   TransactionSummary,
   TransactionTokenType,
   Transfer,
+  TransferInfo,
 } from '@gnosis.pm/safe-react-gateway-sdk'
 import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
 import { sameAddress } from '@/utils/addresses'
 import { getMultiSendCallOnlyContractAddress, getMultiSendContractAddress } from '@/services/contracts/safeContracts'
-import { NativeCoinTransfer, TransferInfo } from '@gnosis.pm/safe-react-gateway-sdk/dist/types/transactions'
 import { NamedAddress } from '@/components/create-safe/types'
 
 export const isTxQueued = (value: TransactionStatus): boolean => {
@@ -48,31 +53,18 @@ export const isOwner = (safeOwners: AddressEx[] | NamedAddress[] = [], walletAdd
 }
 
 export const isMultisigExecutionDetails = (value?: DetailedExecutionInfo): value is MultisigExecutionDetails => {
-  return value?.type === 'MULTISIG'
+  return value?.type === DetailedExecutionInfoType.MULTISIG
 }
 
 // TODO: replace this type guard for the one guard above
 export const isMultisigExecutionInfo = (value: TransactionSummary['executionInfo']): value is MultisigExecutionInfo =>
-  value?.type === EXECUTION_INFO_TYPES.MULTISIG
+  value?.type === DetailedExecutionInfoType.MULTISIG
 
 export const isModuleExecutionInfo = (
   value: TransactionSummary['executionInfo'] | DetailedExecutionInfo,
-): value is ModuleExecutionInfo => value?.type === EXECUTION_INFO_TYPES.MODULE
-
-enum EXECUTION_INFO_TYPES {
-  MULTISIG = 'MULTISIG',
-  MODULE = 'MODULE',
-}
+): value is ModuleExecutionInfo => value?.type === DetailedExecutionInfoType.MODULE
 
 // TransactionInfo type guards
-// TODO: could be passed to Client GW SDK
-export enum TransactionInfoType {
-  TRANSFER = 'Transfer',
-  SETTINGS_CHANGE = 'SettingsChange',
-  CUSTOM = 'Custom',
-  CREATION = 'Creation',
-}
-
 export const isTransferTxInfo = (value: TransactionInfo): value is Transfer => {
   return value.type === TransactionInfoType.TRANSFER
 }
@@ -106,13 +98,6 @@ export const isCreationTxInfo = (value: TransactionInfo): value is Creation => {
 }
 
 // TxListItem type guards
-// TODO: could be passed to Client GW SDK
-export enum TransactionListItemType {
-  TRANSACTION = 'TRANSACTION',
-  LABEL = 'LABEL',
-  CONFLICT_HEADER = 'CONFLICT_HEADER',
-  DATE_LABEL = 'DATE_LABEL',
-}
 export const isTransactionListItem = (value: TransactionListItem): value is Transaction => {
   return value.type === TransactionListItemType.TRANSACTION
 }
@@ -179,22 +164,14 @@ export const isArrayParameter = (parameter: string): boolean => /(\[\d*])+$/.tes
 export const isAddress = (type: string): boolean => type.indexOf('address') === 0
 export const isByte = (type: string): boolean => type.indexOf('byte') === 0
 
-// Conflict types (https://safe.global/safe-client-gateway/docs/routes/transactions/models/summary/enum.ConflictType.html)
-// TODO: could be passed to Client GW SDK
-enum CONFLICT_TYPES {
-  NONE = 'None',
-  HAS_NEXT = 'HasNext',
-  END = 'End',
-}
-
 export const isNoneConflictType = (transaction: Transaction) => {
-  return transaction.conflictType === CONFLICT_TYPES.NONE
+  return transaction.conflictType === ConflictType.NONE
 }
 export const isHasNextConflictType = (transaction: Transaction) => {
-  return transaction.conflictType === CONFLICT_TYPES.HAS_NEXT
+  return transaction.conflictType === ConflictType.HAS_NEXT
 }
 export const isEndConflictType = (transaction: Transaction) => {
-  return transaction.conflictType === CONFLICT_TYPES.END
+  return transaction.conflictType === ConflictType.END
 }
 
 export const isNativeTokenTransfer = (value: TransferInfo): value is NativeCoinTransfer => {

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -54,13 +54,13 @@ export const isOwner = (safeOwners: AddressEx[] | NamedAddress[] = [], walletAdd
   return safeOwners.some((owner) => sameAddress(owner.address, walletAddress))
 }
 
-// Narrows `TransactionDetails` -> when requesting a single transaction
 export const isMultisigDetailedExecutionInfo = (value?: DetailedExecutionInfo): value is MultisigExecutionDetails => {
   return value?.type === DetailedExecutionInfoType.MULTISIG
 }
 
-export const isModuleDetailedExecutionInfo = (value?: DetailedExecutionInfo): value is ModuleExecutionDetails =>
-  value?.type === DetailedExecutionInfoType.MODULE
+export const isModuleDetailedExecutionInfo = (value?: DetailedExecutionInfo): value is ModuleExecutionDetails => {
+  return value?.type === DetailedExecutionInfoType.MODULE
+}
 
 // TransactionInfo type guards
 export const isTransferTxInfo = (value: TransactionInfo): value is Transfer => {
@@ -96,10 +96,6 @@ export const isCreationTxInfo = (value: TransactionInfo): value is Creation => {
 }
 
 // TransactionListItem type guards
-export const isTransactionListItem = (value: TransactionListItem): value is Transaction => {
-  return value.type === TransactionListItemType.TRANSACTION
-}
-
 export const isLabelListItem = (value: TransactionListItem): value is Label => {
   return value.type === TransactionListItemType.LABEL
 }
@@ -112,7 +108,11 @@ export const isDateLabel = (value: TransactionListItem): value is DateLabel => {
   return value.type === TransactionListItemType.DATE_LABEL
 }
 
-// Narrows `Transaction`s -> when request a page of `TransactionListItem`
+export const isTransactionListItem = (value: TransactionListItem): value is Transaction => {
+  return value.type === TransactionListItemType.TRANSACTION
+}
+
+// Narrows `Transaction`
 export const isMultisigExecutionInfo = (value?: ExecutionInfo): value is MultisigExecutionInfo =>
   value?.type === DetailedExecutionInfoType.MULTISIG
 

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -11,7 +11,7 @@ import {
   TransactionDetails,
   TransactionListItemType,
 } from '@gnosis.pm/safe-react-gateway-sdk'
-import { isModuleExecutionInfo, isMultisigExecutionDetails, isTxQueued } from './transaction-guards'
+import { isModuleExecutionDetails, isMultisigExecutionDetails, isTxQueued } from './transaction-guards'
 import { MetaTransactionData, OperationType } from '@gnosis.pm/safe-core-sdk-types/dist/src/types'
 import { getGnosisSafeContractInstance } from '@/services/contracts/safeContracts'
 import extractTxInfo from '@/services/tx/extractTxInfo'
@@ -48,7 +48,7 @@ export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction =>
     }
   }
 
-  const executionInfo: ExecutionInfo | undefined = isModuleExecutionInfo(txDetails.detailedExecutionInfo)
+  const executionInfo: ExecutionInfo | undefined = isModuleExecutionDetails(txDetails.detailedExecutionInfo)
     ? (txDetails.detailedExecutionInfo as ExecutionInfo)
     : getMultisigExecutionInfo(txDetails)
 

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -11,7 +11,7 @@ import {
   TransactionDetails,
   TransactionListItemType,
 } from '@gnosis.pm/safe-react-gateway-sdk'
-import { isModuleExecutionDetails, isMultisigExecutionDetails, isTxQueued } from './transaction-guards'
+import { isModuleDetailedExecutionInfo, isMultisigDetailedExecutionInfo, isTxQueued } from './transaction-guards'
 import { MetaTransactionData, OperationType } from '@gnosis.pm/safe-core-sdk-types/dist/src/types'
 import { getGnosisSafeContractInstance } from '@/services/contracts/safeContracts'
 import extractTxInfo from '@/services/tx/extractTxInfo'
@@ -37,7 +37,7 @@ export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction =>
   const getMultisigExecutionInfo = ({
     detailedExecutionInfo,
   }: TransactionDetails): MultisigExecutionInfo | undefined => {
-    if (!isMultisigExecutionDetails(detailedExecutionInfo)) return undefined
+    if (!isMultisigDetailedExecutionInfo(detailedExecutionInfo)) return undefined
 
     return {
       type: detailedExecutionInfo.type,
@@ -48,14 +48,14 @@ export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction =>
     }
   }
 
-  const executionInfo: ExecutionInfo | undefined = isModuleExecutionDetails(txDetails.detailedExecutionInfo)
+  const executionInfo: ExecutionInfo | undefined = isModuleDetailedExecutionInfo(txDetails.detailedExecutionInfo)
     ? (txDetails.detailedExecutionInfo as ExecutionInfo)
     : getMultisigExecutionInfo(txDetails)
 
   // Will only be used as a fallback whilst waiting on backend tx creation cache
   const now = Date.now()
   const timestamp = isTxQueued(txDetails.txStatus)
-    ? isMultisigExecutionDetails(txDetails.detailedExecutionInfo)
+    ? isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)
       ? txDetails.detailedExecutionInfo.submittedAt
       : now
     : txDetails.executedAt || now
@@ -98,7 +98,7 @@ export const getMultiSendTxs = (
 
   return txs
     .map((tx) => {
-      if (!isMultisigExecutionDetails(tx.detailedExecutionInfo)) return
+      if (!isMultisigDetailedExecutionInfo(tx.detailedExecutionInfo)) return
 
       const args = extractTxInfo(tx, safeAddress)
       const sigs = getSignatures(args.signatures)

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -1,5 +1,6 @@
 import {
   ChainInfo,
+  ConflictType,
   DateLabel,
   ExecutionInfo,
   FEATURES,
@@ -8,13 +9,9 @@ import {
   MultisigExecutionInfo,
   Transaction,
   TransactionDetails,
-} from '@gnosis.pm/safe-react-gateway-sdk'
-import {
-  isModuleExecutionInfo,
-  isMultisigExecutionDetails,
-  isTxQueued,
   TransactionListItemType,
-} from './transaction-guards'
+} from '@gnosis.pm/safe-react-gateway-sdk'
+import { isModuleExecutionInfo, isMultisigExecutionDetails, isTxQueued } from './transaction-guards'
 import { MetaTransactionData, OperationType } from '@gnosis.pm/safe-core-sdk-types/dist/src/types'
 import { getGnosisSafeContractInstance } from '@/services/contracts/safeContracts'
 import extractTxInfo from '@/services/tx/extractTxInfo'
@@ -64,7 +61,7 @@ export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction =>
     : txDetails.executedAt || now
 
   return {
-    type: 'TRANSACTION',
+    type: TransactionListItemType.TRANSACTION,
     transaction: {
       id: txDetails.txId,
       timestamp,
@@ -73,7 +70,7 @@ export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction =>
       executionInfo,
       safeAppInfo: txDetails?.safeAppInfo,
     },
-    conflictType: 'None',
+    conflictType: ConflictType.NONE,
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2653,10 +2653,10 @@
   dependencies:
     cross-fetch "^3.1.5"
 
-"@gnosis.pm/safe-react-gateway-sdk@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-3.4.0.tgz#65079897b5d1d0fcb600015449cb41cd07f95e0d"
-  integrity sha512-HtxcXA3KHc3Z/b7jFG7fp9sVTPYyzfV2/8EAZN94qlP7GL2SqU+TuzAR7ZdgBzLhQGWwwvS5b8Ahxraqr1Fz1Q==
+"@gnosis.pm/safe-react-gateway-sdk@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-3.4.1.tgz#6864abdb28ce0487d64929dee0205e03a49e864f"
+  integrity sha512-b8i0BLEP9CC7S2N7hYDX3OXRYIb9asOMVW0QWh4jzsgT5xitUOPy4jrZL9kAmx8QgcMPYbD+Jjsq/R9ltzSmew==
   dependencies:
     cross-fetch "^3.1.5"
 


### PR DESCRIPTION
## What it solves
Updates to CGW SDK latest version using the added types:

- ConflictType
- DetailedExecutionInfoType
- TransactionInfoType
- TransactionListItemType

## How to test it
History and Queue transaction lists should work as before
Expanding any transaction type details should work as before
