### PR TITLE
fix: remove redundant TODO

### DIFF
--- a/src/services/pairing/QRModal.tsx
+++ b/src/services/pairing/QRModal.tsx
@@ -54,7 +54,6 @@ const Modal = ({ uri, cb }: { uri: string; cb: () => void }) => {
     close()
   }
 
-  // TODO: Can this be rendered inside the tree?
   return (
     <StoreHydrator>
       <AppProviders>


### PR DESCRIPTION
## What it solves

Removes TODO comment

## How this PR fixes it

The original idea was to render the pairing modal in the same tree as the app in order to have access to the same providers. After research, it seems as though a permanent container would be required within the tree to achieve this.

Whilst there are pros and cons for the current and above implementation, the current is a cleaner solution and the comment has therefore been remove.