### PR TITLE
fix: cleanup analytics events

### DIFF
--- a/src/services/analytics/events/assets.ts
+++ b/src/services/analytics/events/assets.ts
@@ -27,9 +27,4 @@ export const ASSETS_EVENTS = {
     action: 'Send',
     category: ASSETS_CATEGORY,
   },
-  // TODO: Does not yet exist in web-core
-  RECEIVE: {
-    action: 'Receive',
-    category: ASSETS_CATEGORY,
-  },
 }

--- a/src/services/analytics/events/mobileAppPromotion.ts
+++ b/src/services/analytics/events/mobileAppPromotion.ts
@@ -1,26 +1,6 @@
 const MOBILE_APP_CATEGORY = 'mobile-app-promotion'
-const SURVEY_ACTION = 'dashboard-banner-survey'
 
-// TODO: Does not yet exist in web-core
 export const MOBILE_APP_EVENTS = {
-  DASHBOARD_BANNER_CLICK: {
-    action: 'dashboard-banner-click',
-    category: MOBILE_APP_CATEGORY,
-  },
-  ALREADY_USE: {
-    label: 'already-use',
-    action: SURVEY_ACTION,
-    category: MOBILE_APP_CATEGORY,
-  },
-  NOT_INTERESTED: {
-    label: 'not-interested',
-    action: SURVEY_ACTION,
-    category: MOBILE_APP_CATEGORY,
-  },
-  DASHBOARD_BANNER_CLOSE: {
-    action: 'dashboard-banner-close',
-    category: MOBILE_APP_CATEGORY,
-  },
   APPSTORE_BUTTON_CLICK: {
     action: 'appstore-button-click',
     category: MOBILE_APP_CATEGORY,

--- a/src/services/analytics/events/modals.ts
+++ b/src/services/analytics/events/modals.ts
@@ -4,18 +4,11 @@ export const MODALS_CATEGORY = 'modals'
 
 export const MODALS_EVENTS = {
   SEND_FUNDS: {
-    // TODO: Should we rename this to 'Send tokens' as in UI?
-    action: 'Send funds',
+    action: 'Send tokens',
     category: MODALS_CATEGORY,
   },
-  // TODO: Should we rename this to 'Send NFTs' as in UI?
   SEND_COLLECTIBLE: {
-    action: 'Send collectible',
-    category: MODALS_CATEGORY,
-  },
-  // TODO: Does not yet exist in web-core
-  CONTRACT_INTERACTION: {
-    action: 'Contract interaction',
+    action: 'Send NFTs',
     category: MODALS_CATEGORY,
   },
   TX_DETAILS: {
@@ -39,7 +32,6 @@ export const MODALS_EVENTS = {
     action: 'Use spending limit',
     category: MODALS_CATEGORY,
   },
-  // TODO: Does not yet exist in web-core
   SIMULATE_TX: {
     action: 'Simulate transaction',
     category: MODALS_CATEGORY,

--- a/src/services/analytics/events/overview.ts
+++ b/src/services/analytics/events/overview.ts
@@ -3,11 +3,6 @@ import { EventType } from '@/services/analytics/types'
 const OVERVIEW_CATEGORY = 'overview'
 
 export const OVERVIEW_EVENTS = {
-  // TODO: Not yet in web-core
-  IPHONE_APP_BUTTON: {
-    action: 'Download App',
-    category: OVERVIEW_CATEGORY,
-  },
   OPEN_ONBOARD: {
     action: 'Open wallet modal',
     category: OVERVIEW_CATEGORY,

--- a/src/services/analytics/events/txList.ts
+++ b/src/services/analytics/events/txList.ts
@@ -8,7 +8,7 @@ export const TX_LIST_EVENTS = {
     action: 'Queued transactions',
     category: TX_LIST_CATEGORY,
   },
-  // TODO: label: 'Edit' does not exist in web-core
+  // 'Edit' label does not exist in web-core
   ADDRESS_BOOK: {
     action: 'Update address book',
     category: TX_LIST_CATEGORY,


### PR DESCRIPTION
## What it solves

Resolves TODOs from analytic events

## How this PR fixes it

TODOs in analytics events have been cleaned up:
- Events not present in `web-core` have been removed
- Sending funds/collectibles now match the naming of the buttons: "Send tokens"/"Send NFTs"

## Open questions
- How do we track NFT amounts? We are now paginating NFTs. Should we even track this anymore?

## How to test it

Send tokens/NFTs and observe the new event `action`

## Analytics changes
- Non-dispatched events have been removed
- "Send funds"/"Send collectibles" => "Send tokens"/"Send NFTs"