### PR TITLE
Token widget url

### DIFF
--- a/src/components/common/SafeTokenWidget/__tests__/SafeTokenWidget.test.tsx
+++ b/src/components/common/SafeTokenWidget/__tests__/SafeTokenWidget.test.tsx
@@ -3,12 +3,14 @@ import * as useBalances from '@/hooks/useBalances'
 import * as nextRouter from 'next/router'
 import * as useChainId from '@/hooks/useChainId'
 import { render, waitFor } from '@/tests/test-utils'
-import { TokenType } from '@gnosis.pm/safe-react-gateway-sdk'
+import { SafeAppAccessPolicyTypes, TokenType } from '@gnosis.pm/safe-react-gateway-sdk'
 import { ethers } from 'ethers'
-import SafeTokenWidget, { CLAIMING_APP_URL } from '..'
-import { NextRouter } from 'next/router'
+import SafeTokenWidget from '..'
 import { hexZeroPad } from 'ethers/lib/utils'
 import { AppRoutes } from '@/config/routes'
+import * as useSafeApps from '@/hooks/safe-apps/useSafeApps'
+
+const MOCK_CLAIMING_APP_URL = 'https://fake.claiming-app.safe.global'
 
 describe('SafeTokenWidget', () => {
   const fakeSafeAddress = hexZeroPad('0x1', 20)
@@ -20,7 +22,26 @@ describe('SafeTokenWidget', () => {
           query: {
             safe: fakeSafeAddress,
           },
-        } as any as NextRouter),
+        } as any),
+    )
+    jest.spyOn(useSafeApps, 'useSafeApps').mockImplementation(
+      () =>
+        ({
+          allSafeApps: [
+            {
+              id: 61,
+              url: MOCK_CLAIMING_APP_URL,
+              chainIds: ['4'],
+              name: '$SAFE Claiming App',
+              description: '',
+              iconUrl: '',
+              tags: '',
+              accessControl: {
+                type: SafeAppAccessPolicyTypes.NoRestrictions,
+              },
+            },
+          ],
+        } as any),
     )
   })
 
@@ -126,7 +147,7 @@ describe('SafeTokenWidget', () => {
     const result = render(<SafeTokenWidget />)
     await waitFor(() => {
       expect(result.baseElement).toContainHTML(
-        `href="${AppRoutes.safe.apps}?safe=${fakeSafeAddress}&appUrl=${CLAIMING_APP_URL}"`,
+        `href="${AppRoutes.safe.apps}?safe=${fakeSafeAddress}&appUrl=${MOCK_CLAIMING_APP_URL}"`,
       )
     })
   })

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -1,5 +1,6 @@
 import { SAFE_TOKEN_ADDRESSES } from '@/config/constants'
 import { AppRoutes } from '@/config/routes'
+import { useSafeApps } from '@/hooks/safe-apps/useSafeApps'
 import useBalances from '@/hooks/useBalances'
 import useChainId from '@/hooks/useChainId'
 import { OVERVIEW_EVENTS } from '@/services/analytics'
@@ -8,14 +9,14 @@ import { safeFormatUnits } from '@/utils/formatters'
 import { Box, ButtonBase, Skeleton, Tooltip, Typography } from '@mui/material'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { useMemo } from 'react'
 import Track from '../Track'
 
 import SafeTokenIcon from './safe_token.svg'
 
 import css from './styles.module.css'
 
-// TODO: once listed on safe apps list, get the url from there?
-export const CLAIMING_APP_URL = 'https://safe-apps.dev.gnosisdev.com/safe-claiming-app/'
+export const CLAIMING_APP_ID = 61
 
 export const getSafeTokenAddress = (chainId: string): string => {
   return SAFE_TOKEN_ADDRESSES[chainId]
@@ -25,13 +26,16 @@ const SafeTokenWidget = () => {
   const balances = useBalances()
   const chainId = useChainId()
   const router = useRouter()
+  const apps = useSafeApps()
+
+  const claimingApp = useMemo(() => apps.allSafeApps.find((appData) => appData.id === 61), [apps.allSafeApps])
 
   const tokenAddress = getSafeTokenAddress(chainId)
   if (!tokenAddress) {
     return null
   }
 
-  const url = `${AppRoutes.safe.apps}?safe=${router.query.safe}&appUrl=${CLAIMING_APP_URL}`
+  const url = `${AppRoutes.safe.apps}?safe=${router.query.safe}&appUrl=${claimingApp?.url}`
 
   const safeBalance = balances.balances.items.find((balanceItem) => balanceItem.tokenInfo.address === tokenAddress)
 

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -38,7 +38,7 @@ const SafeTokenWidget = () => {
     return null
   }
 
-  const url = `${AppRoutes.safe.apps}?safe=${router.query.safe}&appUrl=${claimingApp?.url}`
+  const url = claimingApp ? `${AppRoutes.safe.apps}?safe=${router.query.safe}&appUrl=${claimingApp?.url}` : undefined
 
   const safeBalance = balances.balances.items.find((balanceItem) => balanceItem.tokenInfo.address === tokenAddress)
 
@@ -47,14 +47,15 @@ const SafeTokenWidget = () => {
 
   return (
     <Box className={css.buttonContainer}>
-      <Tooltip title="Open $SAFE Claiming App">
+      <Tooltip title={url ? 'Open $SAFE Claiming App' : ''}>
         <span>
           <Track {...OVERVIEW_EVENTS.SAFE_TOKEN_WIDGET}>
-            <Link href={url} passHref>
+            <Link href={url || '#'} passHref>
               <ButtonBase
                 aria-describedby={'safe-token-widget'}
                 sx={{ alignSelf: 'stretch' }}
                 className={css.tokenButton}
+                disabled={url === undefined}
               >
                 <SafeTokenIcon />
                 <Typography lineHeight="16px" fontWeight={700}>

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -16,7 +16,7 @@ import SafeTokenIcon from './safe_token.svg'
 
 import css from './styles.module.css'
 
-export const CLAIMING_APP_ID = 61
+const CLAIMING_APP_NAME = '$SAFE Claiming App'
 
 export const getSafeTokenAddress = (chainId: string): string => {
   return SAFE_TOKEN_ADDRESSES[chainId]
@@ -28,7 +28,10 @@ const SafeTokenWidget = () => {
   const router = useRouter()
   const apps = useSafeApps()
 
-  const claimingApp = useMemo(() => apps.allSafeApps.find((appData) => appData.id === 61), [apps.allSafeApps])
+  const claimingApp = useMemo(
+    () => apps.allSafeApps.find((appData) => appData.name === CLAIMING_APP_NAME),
+    [apps.allSafeApps],
+  )
 
   const tokenAddress = getSafeTokenAddress(chainId)
   if (!tokenAddress) {

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -47,7 +47,7 @@ const SafeTokenWidget = () => {
 
   return (
     <Box className={css.buttonContainer}>
-      <Tooltip title={url ? 'Open $SAFE Claiming App' : ''}>
+      <Tooltip title={url ? `Open ${CLAIMING_APP_NAME}` : ''}>
         <span>
           <Track {...OVERVIEW_EVENTS.SAFE_TOKEN_WIDGET}>
             <Link href={url || '#'} passHref>


### PR DESCRIPTION
## What it solves
Fetches the claiming app url for the `SafeTokenWidget` from the config service / apps list.

## How to test it
Witness the updated URL on the safe token widget.

## Analytics changes
None 

## Screenshots
