### PR TITLE
Refactor: extract redirect + encode URL params

### DIFF
--- a/src/components/common/SafeTokenWidget/__tests__/SafeTokenWidget.test.tsx
+++ b/src/components/common/SafeTokenWidget/__tests__/SafeTokenWidget.test.tsx
@@ -126,7 +126,7 @@ describe('SafeTokenWidget', () => {
     const result = render(<SafeTokenWidget />)
     await waitFor(() => {
       expect(result.baseElement).toContainHTML(
-        `href="${AppRoutes.safe.apps}?safe=${fakeSafeAddress}&appUrl=${CLAIMING_APP_URL}"`,
+        `href="${AppRoutes.safe.apps}?safe=${fakeSafeAddress}&appUrl=${encodeURIComponent(CLAIMING_APP_URL)}"`,
       )
     })
   })

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -31,7 +31,7 @@ const SafeTokenWidget = () => {
     return null
   }
 
-  const url = `${AppRoutes.safe.apps}?safe=${router.query.safe}&appUrl=${CLAIMING_APP_URL}`
+  const url = `${AppRoutes.safe.apps}?safe=${router.query.safe}&appUrl=${encodeURIComponent(CLAIMING_APP_URL)}`
 
   const safeBalance = balances.balances.items.find((balanceItem) => balanceItem.tokenInfo.address === tokenAddress)
 

--- a/src/components/create-safe/status/hooks/useWatchSafeCreation.test.ts
+++ b/src/components/create-safe/status/hooks/useWatchSafeCreation.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@/tests/test-utils'
 import { SafeCreationStatus } from '@/components/create-safe/status/useSafeCreation'
 import * as router from 'next/router'
 import { NextRouter } from 'next/router'
+import { type SafeInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import * as web3 from '@/hooks/wallets/web3'
 import * as pendingSafe from '@/components/create-safe/status/usePendingSafeCreation'
 import * as chainIdModule from '@/hooks/useChainId'
@@ -14,15 +15,13 @@ import { CONFIG_SERVICE_CHAINS } from '@/tests/mocks'
 describe('useWatchSafeCreation', () => {
   beforeEach(() => {
     jest.resetAllMocks()
+    jest.spyOn(pendingSafe, 'pollSafeInfo').mockImplementation(jest.fn(() => Promise.resolve({} as SafeInfo)))
 
     const mockProvider: Web3Provider = new Web3Provider(jest.fn())
     jest.spyOn(web3, 'useWeb3').mockImplementation(() => mockProvider)
   })
 
   it('should clear the tx hash if it exists on ERROR or REVERTED', () => {
-    // Prevent backOff logging after test is completed
-    jest.spyOn(pendingSafe, 'pollSafeInfo').mockImplementation(jest.fn())
-
     const setStatusSpy = jest.fn()
     const setPendingSafeSpy = jest.fn()
 
@@ -41,9 +40,6 @@ describe('useWatchSafeCreation', () => {
   })
 
   it('should not clear the tx hash if it doesnt exist on ERROR or REVERTED', () => {
-    // Prevent backOff logging after test is completed
-    jest.spyOn(pendingSafe, 'pollSafeInfo').mockImplementation(jest.fn())
-
     const setStatusSpy = jest.fn()
     const setPendingSafeSpy = jest.fn()
 

--- a/src/components/dashboard/FeaturedApps/FeaturedApps.tsx
+++ b/src/components/dashboard/FeaturedApps/FeaturedApps.tsx
@@ -26,7 +26,7 @@ const StyledGridItem = styled(Grid)`
 `
 
 const getSafeAppUrl = (appUrl: string, chainId: string) => {
-  return `${SAFE_REACT_URL}/share/safe-app?appUrl=${appUrl}&chainId=${chainId}`
+  return `${SAFE_REACT_URL}/share/safe-app?appUrl=${encodeURIComponent(appUrl)}&chainId=${chainId}`
 }
 
 export const FeaturedApps = (): ReactElement | null => {

--- a/src/components/safe-apps/AppCard/index.tsx
+++ b/src/components/safe-apps/AppCard/index.tsx
@@ -56,32 +56,11 @@ const AppCardContainer = ({ url, children, variant }: AppCardContainerProps): Re
   const height = variant === 'compact' ? AppCardVariantHeights.compact : AppCardVariantHeights.default
   const aspectRatio = variant === 'compact' ? AppCardVariantAspectRatio.compact : AppCardVariantAspectRatio.default
 
-  if (url) {
-    return (
-      <Link href={url}>
-        <a rel="noreferrer">
-          <Card
-            sx={({ palette }) => ({
-              height,
-              aspectRatio,
-              transition: 'background-color 0.3s ease-in-out, border 0.3s ease-in-out',
-              '&:hover': {
-                backgroundColor: palette.primary.background,
-                border: `2px solid ${palette.primary.light}`,
-              },
-            })}
-          >
-            {children}
-          </Card>
-        </a>
-      </Link>
-    )
-  }
-
-  return (
+  const card = (
     <Card
       sx={({ palette }) => ({
         height,
+        aspectRatio,
         transition: 'background-color 0.3s ease-in-out, border 0.3s ease-in-out',
         '&:hover': {
           backgroundColor: palette.primary.background,
@@ -92,12 +71,25 @@ const AppCardContainer = ({ url, children, variant }: AppCardContainerProps): Re
       {children}
     </Card>
   )
+
+  if (url) {
+    return (
+      <Link href={url}>
+        <a rel="noreferrer">{card}</a>
+      </Link>
+    )
+  }
+
+  return card
 }
 
 const CompactAppCard = ({ url, safeApp, onPin, pinned, shareUrl }: CompactSafeAppCardProps): ReactElement => (
   <AppCardContainer url={url} variant="compact">
     <div className={styles.compactCardContainer}>
+      {/* App logo */}
       <img src={safeApp.iconUrl} style={{ width: 52, height: 52 }} alt={`${safeApp.name} logo`} />
+
+      {/* Share button */}
       <CopyButton
         text={shareUrl}
         initialToolTipText={`Copy share URL for ${safeApp.name}`}
@@ -105,6 +97,8 @@ const CompactAppCard = ({ url, safeApp, onPin, pinned, shareUrl }: CompactSafeAp
       >
         <ShareIcon width={16} alt="Share icon" />
       </CopyButton>
+
+      {/* Pin/unpin button */}
       {onPin && (
         <IconButton
           aria-label={`${pinned ? 'Unpin' : 'Pin'} ${safeApp.name}`}
@@ -127,9 +121,11 @@ const CompactAppCard = ({ url, safeApp, onPin, pinned, shareUrl }: CompactSafeAp
 const AppCard = ({ safeApp, pinned, onPin, onDelete, variant = 'default' }: AppCardProps): ReactElement => {
   const router = useRouter()
   const currentChain = useCurrentChain()
+  const origin = typeof window !== 'undefined' ? window.location.origin : ''
+  const appUrlQuery = encodeURIComponent(safeApp.url)
 
-  const shareUrl = `${window.location.origin}${AppRoutes.share.safeApp}?appUrl=${safeApp.url}&chain=${currentChain?.shortName}`
-  const url = router.query.safe ? `${AppRoutes.safe.apps}?safe=${router.query.safe}&appUrl=${safeApp.url}` : shareUrl
+  const shareUrl = `${origin}${AppRoutes.share.safeApp}?appUrl=${appUrlQuery}&chain=${currentChain?.shortName}`
+  const url = router.query.safe ? `${AppRoutes.safe.apps}?safe=${router.query.safe}&appUrl=${appUrlQuery}` : shareUrl
 
   if (variant === 'compact') {
     return <CompactAppCard url={url} safeApp={safeApp} pinned={pinned} onPin={onPin} shareUrl={shareUrl} />
@@ -143,6 +139,7 @@ const AppCard = ({ safeApp, pinned, onPin, onDelete, variant = 'default' }: AppC
         }
         action={
           <>
+            {/* Share button */}
             <CopyButton
               text={shareUrl}
               initialToolTipText={`Copy share URL for ${safeApp.name}`}
@@ -150,6 +147,8 @@ const AppCard = ({ safeApp, pinned, onPin, onDelete, variant = 'default' }: AppC
             >
               <ShareIcon width={16} alt="Share icon" />
             </CopyButton>
+
+            {/* Pin/unpin button */}
             {onPin && (
               <IconButton
                 aria-label={`${pinned ? 'Unpin' : 'Pin'} ${safeApp.name}`}
@@ -165,6 +164,8 @@ const AppCard = ({ safeApp, pinned, onPin, onDelete, variant = 'default' }: AppC
                 {pinned ? <BookmarkIcon /> : <BookmarkBorderIcon />}
               </IconButton>
             )}
+
+            {/* Delete custom app button */}
             {onDelete && (
               <IconButton
                 aria-label={`Delete ${safeApp.name}`}

--- a/src/components/safe-apps/SafeAppLandingPage/AppActions.tsx
+++ b/src/components/safe-apps/SafeAppLandingPage/AppActions.tsx
@@ -32,7 +32,8 @@ const AppActions = ({ wallet, onConnectWallet, safes, chain, appUrl }: Props): R
   let button: React.ReactNode
   switch (true) {
     case hasWallet && hasSafes:
-      const href = `${AppRoutes.safe.apps}?appUrl=${appUrl}&safe=${chain.shortName}:${safeToUse}`
+      const href = `${AppRoutes.safe.apps}?appUrl=${encodeURIComponent(appUrl)}&safe=${chain.shortName}:${safeToUse}`
+
       button = (
         <Button variant="contained" sx={{ width: CTA_BUTTON_WIDTH }} disabled={!safeToUse} href={href}>
           Use app
@@ -40,7 +41,8 @@ const AppActions = ({ wallet, onConnectWallet, safes, chain, appUrl }: Props): R
       )
       break
     case shouldCreateSafe:
-      const createSafeHrefWithRedirect = `${AppRoutes.open}?safeViewRedirectURL=${AppRoutes.safe.apps}?appUrl=${appUrl}`
+      const redirect = encodeURIComponent(`${AppRoutes.safe.apps}?appUrl=${appUrl}`)
+      const createSafeHrefWithRedirect = `${AppRoutes.open}?safeViewRedirectURL=${redirect}`
       button = (
         <Button variant="contained" sx={{ width: CTA_BUTTON_WIDTH }} href={createSafeHrefWithRedirect}>
           Create new Safe

--- a/src/components/safe-apps/SafeAppLandingPage/index.tsx
+++ b/src/components/safe-apps/SafeAppLandingPage/index.tsx
@@ -86,7 +86,9 @@ const SafeAppLanding = ({ appUrl, chain }: Props) => {
             {showDemo && (
               <Grid xs={12} sm={12} md={6}>
                 <TryDemo
-                  demoUrl={`${AppRoutes.safe.apps}?safe=${SAFE_APPS_DEMO_SAFE_MAINNET}&appUrl=${appUrl}`}
+                  demoUrl={`${AppRoutes.safe.apps}?safe=${SAFE_APPS_DEMO_SAFE_MAINNET}&appUrl=${encodeURIComponent(
+                    appUrl,
+                  )}`}
                   onClick={handleDemoClick}
                 />
               </Grid>


### PR DESCRIPTION
## What it solves
* Encodes the safeApp URL param so that its own query params don't mix with the outer URL query
* Extracts the redirection logic in Safe creation into a function

Ideally we should generate URLs using the `url` library's formatter. But for now this fixes the issue.
