### PR TITLE
fix: remove unnecessary queue dependency

### DIFF
--- a/src/hooks/loadables/useLoadTxQueue.ts
+++ b/src/hooks/loadables/useLoadTxQueue.ts
@@ -6,7 +6,7 @@ import { Errors, logError } from '@/services/exceptions'
 
 export const useLoadTxQueue = (): AsyncResult<TransactionListPage> => {
   const { safe, safeAddress, safeLoaded } = useSafeInfo()
-  const { chainId, txQueuedTag, txHistoryTag } = safe
+  const { chainId, txQueuedTag } = safe
 
   // Re-fetch when chainId/address, or txQueueTag change
   const [data, error, loading] = useAsync<TransactionListPage | undefined>(
@@ -14,9 +14,8 @@ export const useLoadTxQueue = (): AsyncResult<TransactionListPage> => {
       if (!safeLoaded) return
       return getTransactionQueue(chainId, safeAddress)
     },
-    // N.B. we reload when either txQueuedTag or txHistoryTag changes
-    // @TODO: evaluate if txHistoryTag should be included in the reload
-    [safeLoaded, chainId, safeAddress, txQueuedTag, txHistoryTag],
+    // N.B. we reload when txQueuedTag changes
+    [safeLoaded, chainId, safeAddress, txQueuedTag],
     false,
   )
 


### PR DESCRIPTION
## What it solves

Remove unnecessary queue loading dependency.

## How this PR fixes it

Queue polling does not rely on the `txHistoryTag` anymore.

Both the `txQueueTag` and `txHistoryTag` are [updated at the same time by the gateway](https://github.com/safe-global/safe-client-gateway/blob/main/src/routes/safes/handlers/safes.rs#L29-L33), using the [latest transaction timestamps](https://github.com/safe-global/safe-client-gateway/blob/main/src/routes/safes/handlers/safes.rs#L80-L143).

## How to test it

Queue a transaction then execute it. Observe that the transaction moves to the history as before.
