### PR TITLE
refactor: abstract context menu

### DIFF
--- a/src/components/common/ContextMenu/index.tsx
+++ b/src/components/common/ContextMenu/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Menu, type MenuProps } from '@mui/material'
+
+import css from './styles.module.css'
+
+const ContextMenu = (props: MenuProps) => <Menu className={css.menu} {...props} />
+
+export default ContextMenu

--- a/src/components/common/ContextMenu/styles.module.css
+++ b/src/components/common/ContextMenu/styles.module.css
@@ -12,6 +12,10 @@
   border-radius: 8px !important;
 }
 
+.menu :global .MuiMenuItem-root:hover {
+  background-color: var(--color-primary-background);
+}
+
 .menu :global .MuiListItemIcon-root {
   min-width: 26px;
 }

--- a/src/components/sidebar/SafeListContextMenu/index.tsx
+++ b/src/components/sidebar/SafeListContextMenu/index.tsx
@@ -2,7 +2,6 @@ import { useState, MouseEvent, type ReactElement } from 'react'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import IconButton from '@mui/material/IconButton'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
-import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import ListItemText from '@mui/material/ListItemText'
 
@@ -12,8 +11,7 @@ import { useAppSelector } from '@/store'
 import { selectAddedSafes } from '@/store/addedSafesSlice'
 import PencilIcon from '@/public/images/sidebar/safe-list/pencil.svg'
 import TrashIcon from '@/public/images/sidebar/safe-list/trash.svg'
-
-import css from './styles.module.css'
+import ContextMenu from '@/components/common/ContextMenu'
 import { trackEvent, OVERVIEW_EVENTS } from '@/services/analytics'
 
 enum ModalType {
@@ -64,17 +62,7 @@ const SafeListContextMenu = ({
       <IconButton edge="end" size="small" onClick={handleOpenContextMenu}>
         <MoreVertIcon sx={({ palette }) => ({ color: palette.border.main })} />
       </IconButton>
-      <Menu
-        className={css.menu}
-        anchorEl={anchorEl}
-        open={!!anchorEl}
-        onClose={handleCloseContextMenu}
-        sx={({ palette }) => ({
-          '.MuiMenuItem-root:hover': {
-            backgroundColor: palette.primary.background,
-          },
-        })}
-      >
+      <ContextMenu anchorEl={anchorEl} open={!!anchorEl} onClose={handleCloseContextMenu}>
         <MenuItem onClick={handleOpenModal(ModalType.RENAME, OVERVIEW_EVENTS.SIDEBAR_RENAME)}>
           <ListItemIcon>
             <PencilIcon alt="Rename" size={16} />
@@ -90,7 +78,7 @@ const SafeListContextMenu = ({
             <ListItemText>Remove</ListItemText>
           </MenuItem>
         )}
-      </Menu>
+      </ContextMenu>
 
       {open[ModalType.RENAME] && (
         <EntryDialog

--- a/src/components/transactions/TxDetails/TxData/Transfer/TransferActions.tsx
+++ b/src/components/transactions/TxDetails/TxData/Transfer/TransferActions.tsx
@@ -1,15 +1,12 @@
 import { MouseEvent, type ReactElement, useState } from 'react'
 import IconButton from '@mui/material/IconButton'
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
-import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import ListItemText from '@mui/material/ListItemText'
 
 import useAddressBook from '@/hooks/useAddressBook'
 import EntryDialog from '@/components/address-book/EntryDialog'
-
-// TODO: We should abstract the context menu in order not to import it like this
-import css from '@/components/sidebar/SafeListContextMenu/styles.module.css'
+import ContextMenu from '@/components/common/ContextMenu'
 import TokenTransferModal from '@/components/tx/modals/TokenTransferModal'
 import { Transfer, TransferDirection } from '@gnosis.pm/safe-react-gateway-sdk'
 import { ZERO_ADDRESS } from '@gnosis.pm/safe-core-sdk/dist/src/utils/constants'
@@ -73,17 +70,7 @@ const TransferActions = ({ address, txInfo }: { address: string; txInfo: Transfe
       <IconButton edge="end" size="small" onClick={handleOpenContextMenu} sx={{ ml: '4px' }}>
         <MoreHorizIcon sx={({ palette }) => ({ color: palette.border.main })} fontSize="small" />
       </IconButton>
-      <Menu
-        className={css.menu}
-        anchorEl={anchorEl}
-        open={!!anchorEl}
-        onClose={handleCloseContextMenu}
-        sx={({ palette }) => ({
-          '.MuiMenuItem-root:hover': {
-            backgroundColor: palette.primary.background,
-          },
-        })}
-      >
+      <ContextMenu anchorEl={anchorEl} open={!!anchorEl} onClose={handleCloseContextMenu}>
         {canSendAgain && (
           <MenuItem onClick={handleOpenModal(ModalType.SEND_AGAIN, TX_LIST_EVENTS.SEND_AGAIN)} disabled={!isGranted}>
             <ListItemText>Send again</ListItemText>
@@ -93,7 +80,7 @@ const TransferActions = ({ address, txInfo }: { address: string; txInfo: Transfe
         <MenuItem onClick={handleOpenModal(ModalType.ADD_TO_AB, TX_LIST_EVENTS.ADDRESS_BOOK)}>
           <ListItemText>Add to address book</ListItemText>
         </MenuItem>
-      </Menu>
+      </ContextMenu>
 
       {open[ModalType.SEND_AGAIN] && (
         <TokenTransferModal onClose={handleCloseModal} initialData={[{ recipient, tokenAddress, amount }]} />

--- a/src/components/transactions/TxDetails/TxData/Transfer/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/Transfer/index.tsx
@@ -31,7 +31,7 @@ const TransferTxInfo = ({ txInfo, txStatus }: TransferTxInfoProps) => {
   return (
     <Box>
       <TransferTxInfoSummary txInfo={txInfo} txStatus={txStatus} />
-      <Box display="flex" alignItems="flex-end">
+      <Box display="flex" alignItems="center">
         <EthHashInfo address={address} shortAddress={false} hasExplorer showCopyButton />
         <TransferActions address={address} txInfo={txInfo} />
       </Box>

--- a/src/components/transactions/TxDetails/TxData/Transfer/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/Transfer/index.tsx
@@ -31,7 +31,7 @@ const TransferTxInfo = ({ txInfo, txStatus }: TransferTxInfoProps) => {
   return (
     <Box>
       <TransferTxInfoSummary txInfo={txInfo} txStatus={txStatus} />
-      <Box display="flex" alignItems="center">
+      <Box display="flex" alignItems="flex-end">
         <EthHashInfo address={address} shortAddress={false} hasExplorer showCopyButton />
         <TransferActions address={address} txInfo={txInfo} />
       </Box>


### PR DESCRIPTION
## What it solves

Resolves TODO/duplicate code

## How this PR fixes it

The context menus from the transaction list and sidebar Safe list have been abstracted into one `ContextMenu` component.

## How to test it

- Expand a transaction and observe that the context menu is as before.
- Observe that the context menu in the sidebar Safe list is as before.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/190996368-c41ee234-8983-4463-b862-9b6cd68e4cd0.png)

![image](https://user-images.githubusercontent.com/20442784/190996392-cf0e0c89-12b8-4b29-a632-6fba857ce7dc.png)