### PR TITLE
fix: abstract trailing zero removal logic

### DIFF
--- a/src/utils/__tests__/formatters.test.ts
+++ b/src/utils/__tests__/formatters.test.ts
@@ -1,9 +1,20 @@
 import * as formatters from '@/utils/formatters'
 
 describe('formatters', () => {
-  describe('safeFormatUnits', () => {
-    // FIXME: Remove when temporary fix is removed from `safeFormatUnits`
+  describe('removeTrailingZeros', () => {
     it('strips trailing 0s', () => {
+      const result1 = formatters._removeTrailingZeros('1.000000000000000000')
+      expect(result1).toBe('1')
+
+      const result2 = formatters._removeTrailingZeros('1.00001000000')
+      expect(result2).toBe('1.00001')
+
+      const result3 = formatters._removeTrailingZeros('1')
+      expect(result3).toBe('1')
+    })
+  })
+  describe('safeFormatUnits', () => {
+    it('formats to gwei by default', () => {
       const result1 = formatters.safeFormatUnits('1')
       expect(result1).toBe('0.000000001')
 

--- a/src/utils/__tests__/formatters.test.ts
+++ b/src/utils/__tests__/formatters.test.ts
@@ -3,14 +3,28 @@ import * as formatters from '@/utils/formatters'
 describe('formatters', () => {
   describe('removeTrailingZeros', () => {
     it('strips trailing 0s', () => {
-      const result1 = formatters._removeTrailingZeros('1.000000000000000000')
-      expect(result1).toBe('1')
+      expect(formatters._removeTrailingZeros('0')).toBe('0')
+      expect(formatters._removeTrailingZeros('0.000')).toBe('0')
 
-      const result2 = formatters._removeTrailingZeros('1.00001000000')
-      expect(result2).toBe('1.00001')
+      expect(formatters._removeTrailingZeros('10')).toBe('10')
+      expect(formatters._removeTrailingZeros('100')).toBe('100')
 
-      const result3 = formatters._removeTrailingZeros('1')
-      expect(result3).toBe('1')
+      expect(formatters._removeTrailingZeros('0.100')).toBe('0.1')
+      expect(formatters._removeTrailingZeros('0.010')).toBe('0.01')
+
+      expect(formatters._removeTrailingZeros('1.101')).toBe('1.101')
+      expect(formatters._removeTrailingZeros('1.100')).toBe('1.1')
+      expect(formatters._removeTrailingZeros('1.100010')).toBe('1.10001')
+
+      expect(formatters._removeTrailingZeros('100.11')).toBe('100.11')
+      expect(formatters._removeTrailingZeros('100.10')).toBe('100.1')
+
+      expect(
+        formatters._removeTrailingZeros('1000000000000000000000000000000000000000000000000000000000000000001'),
+      ).toBe('1000000000000000000000000000000000000000000000000000000000000000001')
+      expect(
+        formatters._removeTrailingZeros('1000000000000000000000000000000000000000000000000000000000000000001.100'),
+      ).toBe('1000000000000000000000000000000000000000000000000000000000000000001.1')
     })
   })
   describe('safeFormatUnits', () => {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -5,6 +5,7 @@ import { formatAmount } from './formatNumber'
 const GWEI = 'gwei'
 
 export const _removeTrailingZeros = (value: string): string => {
+  // Match `.0` or `0*` after non-zero decimals by "Positive Lookbehind Assertion"
   return value.replace(/(\.0*|(?<=(\..*))0*)$/, '')
 }
 

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -5,17 +5,7 @@ import { formatAmount } from './formatNumber'
 const GWEI = 'gwei'
 
 export const _removeTrailingZeros = (value: string): string => {
-  let [integer, fractions] = value.split('.')
-
-  if (!fractions) {
-    return value
-  }
-
-  while (fractions[fractions.length - 1] === '0') {
-    fractions = fractions.substring(0, fractions.length - 1)
-  }
-
-  return fractions ? `${integer}.${fractions}` : integer
+  return value.replace(/(\.0*|(?<=(\..*))0*)$/, '')
 }
 
 /**

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -4,6 +4,20 @@ import { formatAmount } from './formatNumber'
 
 const GWEI = 'gwei'
 
+export const _removeTrailingZeros = (value: string): string => {
+  let [integer, fractions] = value.split('.')
+
+  if (!fractions) {
+    return value
+  }
+
+  while (fractions[fractions.length - 1] === '0') {
+    fractions = fractions.substring(0, fractions.length - 1)
+  }
+
+  return fractions ? `${integer}.${fractions}` : integer
+}
+
 /**
  * Converts value to raw, specified decimal precision
  * @param value value in unspecified unit
@@ -14,20 +28,8 @@ export const safeFormatUnits = (value: BigNumberish, decimals: number | string =
   try {
     const formattedAmount = formatUnits(value, decimals)
 
-    // FIXME: Temporary fix as ethers' `formatFixed` doesn't strip trailing 0s
-    // for very high/low amounts, we can't `parseFloat` as it returns exponentials
-
-    let [integer, fractions] = formattedAmount.split('.')
-
-    if (!fractions) {
-      return formattedAmount
-    }
-
-    while (fractions[fractions.length - 1] === '0') {
-      fractions = fractions.substring(0, fractions.length - 1)
-    }
-
-    return fractions ? `${integer}.${fractions}` : integer
+    // ethers' `formatFixed` doesn't remove trailing 0s and using `parseFloat` can return exponentials
+    return _removeTrailingZeros(formattedAmount)
   } catch (err) {
     console.error('Error formatting units', err)
     return ''


### PR DESCRIPTION
## What it solves

Resolves `safeFormatUnits` FIXMEs

## How this PR fixes it

Trailing zero removal logic has been abstracted into its own function and tests added.

## How to test it

The unit tests should pass and all token amount display, i.e. Safe token amount, spending limit amount/spent and assets to send should display as before.