### PR TITLE
Fix: go to dashboard after adding a safe

### DIFF
--- a/src/components/load-safe/steps/SafeReviewStep.tsx
+++ b/src/components/load-safe/steps/SafeReviewStep.tsx
@@ -84,7 +84,7 @@ const SafeReviewStep = ({ params, onBack }: Props) => {
     trackEvent(LOAD_SAFE_EVENTS.GO_TO_SAFE)
 
     router.push({
-      pathname: AppRoutes.index,
+      pathname: AppRoutes.home,
       query: { safe: `${currentChain?.shortName}:${safeAddress}` },
     })
   }


### PR DESCRIPTION
## What it solves

Resolves a regression after #570. It goes to the dashboard after adding a Safe.
