### PR TITLE
fix: formatting no currency

### DIFF
--- a/src/utils/__tests__/formatNumber.test.ts
+++ b/src/utils/__tests__/formatNumber.test.ts
@@ -153,23 +153,32 @@ describe('formatNumber', () => {
 
   describe('formatCurrency', () => {
     it('returns the correct number of decimals', () => {
-      const amount1 = 1
+      const amount1 = 0
 
-      expect(formatCurrency(amount1, 'JPY')).toBe('1 JPY')
-      expect(formatCurrency(amount1, 'IQD')).toBe('1 IQD')
-      expect(formatCurrency(amount1, 'USD')).toBe('1.00 USD')
-      expect(formatCurrency(amount1, 'EUR')).toBe('1.00 EUR')
-      expect(formatCurrency(amount1, 'GBP')).toBe('1.00 GBP')
-      expect(formatCurrency(amount1, 'BHD')).toBe('1.000 BHD')
+      expect(formatCurrency(amount1, 'JPY')).toBe('0 JPY')
+      expect(formatCurrency(amount1, 'IQD')).toBe('0 IQD')
+      expect(formatCurrency(amount1, 'USD')).toBe('0.00 USD')
+      expect(formatCurrency(amount1, 'EUR')).toBe('0.00 EUR')
+      expect(formatCurrency(amount1, 'GBP')).toBe('0.00 GBP')
+      expect(formatCurrency(amount1, 'BHD')).toBe('0.000 BHD')
 
-      const amount2 = '1.7777'
+      const amount2 = 1
 
-      expect(formatCurrency(amount2, 'JPY')).toBe('2 JPY')
-      expect(formatCurrency(amount2, 'IQD')).toBe('2 IQD')
-      expect(formatCurrency(amount2, 'USD')).toBe('1.78 USD')
-      expect(formatCurrency(amount2, 'EUR')).toBe('1.78 EUR')
-      expect(formatCurrency(amount2, 'GBP')).toBe('1.78 GBP')
-      expect(formatCurrency(amount2, 'BHD')).toBe('1.778 BHD')
+      expect(formatCurrency(amount2, 'JPY')).toBe('1 JPY')
+      expect(formatCurrency(amount2, 'IQD')).toBe('1 IQD')
+      expect(formatCurrency(amount2, 'USD')).toBe('1.00 USD')
+      expect(formatCurrency(amount2, 'EUR')).toBe('1.00 EUR')
+      expect(formatCurrency(amount2, 'GBP')).toBe('1.00 GBP')
+      expect(formatCurrency(amount2, 'BHD')).toBe('1.000 BHD')
+
+      const amount3 = '1.7777'
+
+      expect(formatCurrency(amount3, 'JPY')).toBe('2 JPY')
+      expect(formatCurrency(amount3, 'IQD')).toBe('2 IQD')
+      expect(formatCurrency(amount3, 'USD')).toBe('1.78 USD')
+      expect(formatCurrency(amount3, 'EUR')).toBe('1.78 EUR')
+      expect(formatCurrency(amount3, 'GBP')).toBe('1.78 GBP')
+      expect(formatCurrency(amount3, 'BHD')).toBe('1.778 BHD')
     })
 
     it('should use M symbol for numbers between 100,000,000 and 999,999,500', () => {

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -114,15 +114,13 @@ export const formatAmountWithPrecision = (
 
 // Fiat formatting
 
-const getMinimumCurrencyDenominator = (number: string | number, currency: string): number => {
-  const float = Number(number)
-
+const getMinimumCurrencyDenominator = (currency: string): number => {
   const formatter = new Intl.NumberFormat(undefined, {
     style: 'currency',
     currency,
   })
 
-  const fraction = formatter.formatToParts(float).find(({ type }) => type === 'fraction')
+  const fraction = formatter.formatToParts(1).find(({ type }) => type === 'fraction')
 
   // Currencies may not have decimals, i.e. JPY
   return fraction ? Number(`0.${'1'.padStart(fraction.value.length, '0')}`) : 1
@@ -135,7 +133,7 @@ const getCurrencyFormatterMaxFractionDigits = (
   const float = Number(number)
 
   if (float < 1_000_000) {
-    const [, decimals] = getMinimumCurrencyDenominator(number, currency).toString().split('.')
+    const [, decimals] = getMinimumCurrencyDenominator(currency).toString().split('.')
     return decimals?.length ?? 0
   }
 
@@ -167,7 +165,7 @@ export const formatCurrency = (number: string | number, currency: string): strin
   // Note: we will be able to achieve the following once the `roundingMode` option is supported
   // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#parameters
 
-  const minimum = getMinimumCurrencyDenominator(number, currency)
+  const minimum = getMinimumCurrencyDenominator(currency)
 
   const currencyFormatter = (float: number): string => {
     const options = getCurrencyFormatterOptions(number, currency)
@@ -180,7 +178,7 @@ export const formatCurrency = (number: string | number, currency: string): strin
     const amount = parts
       .filter(({ type }) => type !== 'currency' && type !== 'literal') // Remove currency code and whitespace
       .map((part) => {
-        if (float >= minimum) {
+        if (float >= 0) {
           return part
         }
 

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -1,3 +1,5 @@
+import { memoize } from 'lodash'
+
 // These follow the guideline of "How to format amounts"
 // https://github.com/5afe/safe/wiki/How-to-format-amounts
 
@@ -114,7 +116,7 @@ export const formatAmountWithPrecision = (
 
 // Fiat formatting
 
-const getMinimumCurrencyDenominator = (currency: string): number => {
+const getMinimumCurrencyDenominator = memoize((currency: string): number => {
   const formatter = new Intl.NumberFormat(undefined, {
     style: 'currency',
     currency,
@@ -124,7 +126,7 @@ const getMinimumCurrencyDenominator = (currency: string): number => {
 
   // Currencies may not have decimals, i.e. JPY
   return fraction ? Number(`0.${'1'.padStart(fraction.value.length, '0')}`) : 1
-}
+})
 
 const getCurrencyFormatterMaxFractionDigits = (
   number: string | number,

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -117,12 +117,14 @@ export const formatAmountWithPrecision = (
 // Fiat formatting
 
 const getMinimumCurrencyDenominator = memoize((currency: string): number => {
+  const BASE_VALUE = 1
+
   const formatter = new Intl.NumberFormat(undefined, {
     style: 'currency',
     currency,
   })
 
-  const fraction = formatter.formatToParts(1).find(({ type }) => type === 'fraction')
+  const fraction = formatter.formatToParts(BASE_VALUE).find(({ type }) => type === 'fraction')
 
   // Currencies may not have decimals, i.e. JPY
   return fraction ? Number(`0.${'1'.padStart(fraction.value.length, '0')}`) : 1


### PR DESCRIPTION
## What it solves

Resolves formatting 0 amounts

## How this PR fixes it

Instead of comparing against the minimum denominator of a currency, the current 'part' of the formatted currency is compared against `0` as that could be the value.

The minimum denominator of a currency is now derived from `1` as well.

## How to test it

All currencies should display as before, especially when no amount is present in a Safe and the `formatNumber` test should pass.