### PR TITLE
fix: Hide result length from tx list when there are no results

### DIFF
--- a/src/components/common/PaginatedTxns/index.tsx
+++ b/src/components/common/PaginatedTxns/index.tsx
@@ -49,7 +49,7 @@ const TxPage = ({
         </Box>
       )}
 
-      {page?.results.length && <TxList items={page.results} />}
+      {page && page.results.length > 0 && <TxList items={page.results} />}
 
       {isQueue && page?.results.length === 0 && <NoQueuedTxns />}
 


### PR DESCRIPTION
## What it solves

Small fix for the tx list displaying "0" when there are no results.

## How to test

1. Open the Queue on a safe with no transactions
2. Observe no "0" visible in content area

## Screenshots

Before:
<img width="739" alt="Screenshot 2022-09-20 at 10 36 43" src="https://user-images.githubusercontent.com/5880855/191210090-f0d0401a-a2d8-49d7-aa85-1651750d44c1.png">

After:
<img width="749" alt="Screenshot 2022-09-20 at 10 36 34" src="https://user-images.githubusercontent.com/5880855/191210139-b896e4cc-495a-4ec6-bc4e-3fbaacdf1bcf.png">
