### PR TITLE
Fix: CloudFlare redirects cut off query params

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,6 +1,5 @@
 /:safe/balances/* /balances/:splat?safe=:safe
 /:safe/settings/* /settings/:splat?safe=:safe
-/:safe/transactions/* /transactions/:splat?safe=:safe
+/:safe/transactions/queue/* /transactions/queue/:splat?safe=:safe
 /:safe/address-book /address-book?safe=:safe
-/:safe/apps /apps?safe=:safe
 /:safe/home /home?safe=:safe


### PR DESCRIPTION
## What it solves

Resolves #592

## How this PR fixes it

[CloudFlare Pages' redirects](https://developers.cloudflare.com/pages/platform/redirects/) don't preserve query params, so I had to remove transaction history and apps from the redirect patterns. It also fixes the single tx view.

This app will still work, it will just return a 404 when loading those pages before loading the right page.

## How to test it
Tx history:
* Filter tx history, reload the page
* Observe that the filter is still the same

Single tx:
* Open a single tx page
* Reload the page

Safe Apps:
* Open a Safe App
* Reload the page