### PR TITLE
Fix: Safe not found alignment

### DIFF
--- a/src/components/common/PageLayout/styles.module.css
+++ b/src/components/common/PageLayout/styles.module.css
@@ -22,6 +22,9 @@
 .content {
   flex: 1;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
 }
 
 .content main {

--- a/src/components/common/PagePlaceholder/styles.module.css
+++ b/src/components/common/PagePlaceholder/styles.module.css
@@ -3,6 +3,6 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100%;
   text-align: center;
+  flex: 1;
 }

--- a/src/components/dashboard/PendingTxs/PendingTxsList.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxsList.tsx
@@ -9,7 +9,6 @@ import PendingTxListItem from './PendingTxListItem'
 import { isMultisigExecutionInfo, isTransactionListItem } from '@/utils/transaction-guards'
 import useTxQueue from '@/hooks/useTxQueue'
 import { AppRoutes } from '@/config/routes'
-import PagePlaceholder from '@/components/common/PagePlaceholder'
 
 const SkeletonWrapper = styled.div`
   border-radius: 8px;
@@ -32,23 +31,20 @@ const StyledEmptyCard = styled(Card)`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  flex-wrap: wrap;
+  align-items: center;
   padding: var(--space-4);
 
   img {
     width: 144px;
     height: auto;
   }
-
-  h3 {
-    font-size: 16px;
-    margin-bottom: 0;
-  }
 `
 
 const EmptyState = (
   <StyledEmptyCard>
-    <PagePlaceholder imageUrl="/images/no-transactions.svg" text="This Safe has no queued transactions" />
+    <img src="/images/no-transactions.svg" alt="No queued transactions" />
+
+    <Typography mt={3}>This Safe has no queued transactions</Typography>
   </StyledEmptyCard>
 )
 


### PR DESCRIPTION
## What it solves

Resolves #593

## How this PR fixes it
Makes the main content wrapper flex box so that the error container can stretch 100% of its height.
