### PR TITLE
fix: simulation of queued transactions

### DIFF
--- a/src/components/tx/TxSimulation/__tests__/utils.test.ts
+++ b/src/components/tx/TxSimulation/__tests__/utils.test.ts
@@ -11,6 +11,8 @@ import { generatePreValidatedSignature } from '@gnosis.pm/safe-core-sdk/dist/src
 import { hexZeroPad } from 'ethers/lib/utils'
 import * as Web3 from '@/hooks/wallets/web3'
 
+const SIGNATURE_LENGTH = 65 * 2
+
 describe('simulation utils', () => {
   const safeContractInterface = new ethers.utils.Interface(getSafeSingletonDeployment({ version: '1.3.0' })?.abi || [])
   const multiSendContractInterface = new ethers.utils.Interface(
@@ -186,6 +188,7 @@ describe('simulation utils', () => {
 
       // Do add preValidatedSignature of connected owner as the tx is only partially signed
       expect(decodedTxData[9]).toContain(getPreValidatedSignature(ownerAddress))
+      expect(decodedTxData[9]).toHaveLength(SIGNATURE_LENGTH * 2 + 2)
       // Do not overwrite the threshold
       expect(tenderlyPayload.state_objects).toBeUndefined()
     })

--- a/src/components/tx/TxSimulation/utils.ts
+++ b/src/components/tx/TxSimulation/utils.ts
@@ -166,6 +166,7 @@ const getNonceOverwrite = (params: SimulationTxParams): number | undefined => {
   Safe storage layout can be found here:
   https://github.com/gnosis/safe-contracts/blob/main/contracts/libraries/GnosisSafeStorage.sol */
 export const THRESHOLD_STORAGE_POSITION = hexZeroPad('0x4', 32)
+export const THRESHOLD_OVERWRITE = hexZeroPad('0x1', 32)
 /* We need to overwrite the nonce if we simulate a (partially) signed transaction which is not at the top position of the tx queue.
   The nonce can be found in storage slot 5 and uses a full 32 bytes slot. */
 export const NONCE_STORAGE_POSITION = hexZeroPad('0x5', 32)
@@ -177,7 +178,7 @@ const getStateOverwrites = (params: SimulationTxParams) => {
   const storageOverwrites: Record<string, string> = {} as Record<string, string>
 
   if (isThresholdOverwrite) {
-    storageOverwrites[THRESHOLD_STORAGE_POSITION] = hexZeroPad('0x1', 32)
+    storageOverwrites[THRESHOLD_STORAGE_POSITION] = THRESHOLD_OVERWRITE
   }
   if (nonceOverwrite) {
     storageOverwrites[NONCE_STORAGE_POSITION] = hexZeroPad(BigNumber.from(nonceOverwrite).toHexString(), 32)

--- a/src/components/tx/TxSimulation/utils.ts
+++ b/src/components/tx/TxSimulation/utils.ts
@@ -69,18 +69,16 @@ export const _getSingleTransactionPayload = (
 ): Pick<TenderlySimulatePayload, 'to' | 'input'> => {
   // If a transaction is executable we simulate with the proposed/selected gasLimit and the actual signatures
   let transaction = params.transactions
-  console.log('Before', transaction, transaction.encodedSignatures())
   const hasOwnerSignature = transaction.signatures.has(params.executionOwner)
   // If the owner's sig is missing and the tx threshold is not reached we add the owner's preValidated signature
   const needsOwnerSignature = !hasOwnerSignature && transaction.signatures.size < params.safe.threshold
   if (needsOwnerSignature) {
-    console.log('Adding sig')
     const simulatedTransaction = new EthSafeTransaction(transaction.data)
+
     transaction.signatures.forEach((signature) => {
       simulatedTransaction.addSignature(signature)
     })
     simulatedTransaction.addSignature(generatePreValidatedSignature(params.executionOwner))
-    console.log('New', simulatedTransaction, simulatedTransaction.encodedSignatures())
 
     transaction = simulatedTransaction
   }

--- a/src/components/tx/TxSimulation/utils.ts
+++ b/src/components/tx/TxSimulation/utils.ts
@@ -67,12 +67,19 @@ export const _getSingleTransactionPayload = (
 ): Pick<TenderlySimulatePayload, 'to' | 'input'> => {
   // If a transaction is executable we simulate with the proposed/selected gasLimit and the actual signatures
   let transaction = params.transactions
+  console.log('Before', transaction, transaction.encodedSignatures())
   const hasOwnerSignature = transaction.signatures.has(params.executionOwner)
   // If the owner's sig is missing and the tx threshold is not reached we add the owner's preValidated signature
   const needsOwnerSignature = !hasOwnerSignature && transaction.signatures.size < params.safe.threshold
   if (needsOwnerSignature) {
-    const simulatedTransaction = new EthSafeTransaction(params.transactions.data)
+    console.log('Adding sig')
+    const simulatedTransaction = new EthSafeTransaction(transaction.data)
+    transaction.signatures.forEach((signature) => {
+      simulatedTransaction.addSignature(signature)
+    })
     simulatedTransaction.addSignature(generatePreValidatedSignature(params.executionOwner))
+    console.log('New', simulatedTransaction, simulatedTransaction.encodedSignatures())
+
     transaction = simulatedTransaction
   }
 


### PR DESCRIPTION
## What it solves
-(partially) signed transactions, which are not at the top of the queue. Could not be simulated successfully. They would run into an GS026 error.

Resolves #597 

## How this PR fixes it
- If a transaction has signatures we add those to the simulated transactions signatures
- We check if the simulated txs nonce is higher than the safe's nonce.
If this is true, we overwrite the nonce for the simulation.

## How to test it
- Queue 2 or more transactions and sign them.
- now try to simulate the transaction with the higher nonce

## Analytics changes
None

