### PR TITLE
fix: use processing instead of mining

### DIFF
--- a/src/components/create-safe/status/CreationStatus.tsx
+++ b/src/components/create-safe/status/CreationStatus.tsx
@@ -35,7 +35,7 @@ const getStep = (status: SafeCreationStatus) => {
         description: 'Waiting for wallet connection',
         instruction: 'Please make sure your wallet is connected on the correct network.',
       }
-    case SafeCreationStatus.MINING:
+    case SafeCreationStatus.PROCESSING:
       return {
         image: loading,
         description: 'Step 2/2: Transaction is being executed.',
@@ -56,7 +56,7 @@ const getStep = (status: SafeCreationStatus) => {
     case SafeCreationStatus.TIMEOUT:
       return {
         image: error,
-        description: 'Transaction was not found. Be aware that it might still be mined.',
+        description: 'Transaction was not found. Be aware that it might still be processed.',
         instruction: 'You can cancel or retry the Safe creation process.',
       }
     case SafeCreationStatus.SUCCESS:

--- a/src/components/create-safe/status/usePendingSafeCreation.ts
+++ b/src/components/create-safe/status/usePendingSafeCreation.ts
@@ -79,7 +79,7 @@ export const usePendingSafeCreation = ({ txHash, setStatus }: Props) => {
       setStatus(txStatus)
     }
 
-    setStatus(SafeCreationStatus.MINING)
+    setStatus(SafeCreationStatus.PROCESSING)
     monitorTx()
   }, [txHash, provider, setStatus, chainId])
 }

--- a/src/components/create-safe/status/useSafeCreation.test.ts
+++ b/src/components/create-safe/status/useSafeCreation.test.ts
@@ -46,7 +46,7 @@ describe('useSafeCreation', () => {
     expect(result.current.status).toBe(SafeCreationStatus.AWAITING)
   })
 
-  it('should return MINING if there is a txHash', async () => {
+  it('should return PROCESSING if there is a txHash', async () => {
     const mockSafe: Safe = new Safe()
     mockSafe.getAddress = jest.fn(() => '0x0')
     jest.spyOn(pendingSafe, 'usePendingSafe').mockImplementation(() => [
@@ -63,7 +63,7 @@ describe('useSafeCreation', () => {
     ])
 
     const { result } = renderHook(() => useSafeCreation())
-    expect(result.current.status).toBe(SafeCreationStatus.MINING)
+    expect(result.current.status).toBe(SafeCreationStatus.PROCESSING)
   })
 
   it('should return SUCCESS if the safe creation promise resolves', async () => {

--- a/src/components/create-safe/status/useSafeCreation.ts
+++ b/src/components/create-safe/status/useSafeCreation.ts
@@ -21,7 +21,7 @@ import { isWalletRejection } from '@/utils/wallets'
 export enum SafeCreationStatus {
   AWAITING = 'AWAITING',
   AWAITING_WALLET = 'AWAITING_WALLET',
-  MINING = 'MINING',
+  PROCESSING = 'PROCESSING',
   ERROR = 'ERROR',
   REVERTED = 'REVERTED',
   TIMEOUT = 'TIMEOUT',
@@ -96,7 +96,7 @@ export const useSafeCreation = () => {
     (txHash: string) => {
       trackEvent(CREATE_SAFE_EVENTS.SUBMIT_CREATE_SAFE)
 
-      setStatus(SafeCreationStatus.MINING)
+      setStatus(SafeCreationStatus.PROCESSING)
       setPendingSafe((prev) => (prev ? { ...prev, txHash } : undefined))
     },
     [setPendingSafe],

--- a/src/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx.tsx
+++ b/src/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx.tsx
@@ -95,9 +95,9 @@ const ReviewSpendingLimitTx = ({ params, onSubmit }: ReviewTokenTxProps): ReactE
     <form onSubmit={handleSubmit}>
       <DialogContent>
         <Typography variant="body2" mb={4}>
-          Spending limit transactions only appear in the interface once they are successfully mined and indexed. Pending
-          transactions can only be viewed in your signer wallet application or under your wallet address on a Blockchain
-          Explorer.
+          Spending limit transactions only appear in the interface once they are successfully processed and indexed.
+          Pending transactions can only be viewed in your signer wallet application or under your wallet address on a
+          Blockchain Explorer.
         </Typography>
         {token && <TokenTransferReview amount={params.amount} tokenInfo={token.tokenInfo} />}
 

--- a/src/hooks/useTransactionStatus.ts
+++ b/src/hooks/useTransactionStatus.ts
@@ -13,7 +13,7 @@ const STATUS_LABELS: Record<TxLocalStatus, string> = {
   [TransactionStatus.FAILED]: 'Failed',
   [TransactionStatus.SUCCESS]: 'Success',
   [PendingStatus.SUBMITTING]: 'Submitting',
-  [PendingStatus.MINING]: 'Mining',
+  [PendingStatus.PROCESSING]: 'Processing',
   [PendingStatus.INDEXING]: 'Indexing',
 }
 

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -13,11 +13,11 @@ const TxNotifications = {
   [TxEvent.SIGNATURE_PROPOSED]: 'You successfully signed the transaction.',
   [TxEvent.SIGNATURE_PROPOSE_FAILED]: 'Failed to send the signature. Please try again.',
   [TxEvent.EXECUTING]: 'Please confirm the execution in your wallet.',
-  [TxEvent.MINING]: 'Your transaction is being processed.',
-  [TxEvent.MINING_MODULE]:
+  [TxEvent.PROCESSING]: 'Your transaction is being processed.',
+  [TxEvent.PROCESSING_MODULE]:
     'Your transaction has been submitted and will appear in the interface only after it has been successfully processed and indexed.',
   [TxEvent.AWAITING_ON_CHAIN_SIGNATURE]: 'An on-chain signature request was submitted.',
-  [TxEvent.MINED]: 'Your transaction was successfully processed and is now being indexed.',
+  [TxEvent.PROCESSED]: 'Your transaction was successfully processed and is now being indexed.',
   [TxEvent.REVERTED]: 'Transaction reverted. Please check your gas settings.',
   [TxEvent.SUCCESS]: 'Your transaction was successfully executed.',
   [TxEvent.FAILED]: 'Your transaction was unsuccessful.',

--- a/src/hooks/useTxPendingStatuses.ts
+++ b/src/hooks/useTxPendingStatuses.ts
@@ -8,8 +8,8 @@ import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 
 const pendingStatuses: Partial<Record<TxEvent, PendingStatus | null>> = {
   [TxEvent.EXECUTING]: PendingStatus.SUBMITTING,
-  [TxEvent.MINING]: PendingStatus.MINING,
-  [TxEvent.MINED]: PendingStatus.INDEXING,
+  [TxEvent.PROCESSING]: PendingStatus.PROCESSING,
+  [TxEvent.PROCESSED]: PendingStatus.INDEXING,
   [TxEvent.SUCCESS]: null,
   [TxEvent.REVERTED]: null,
   [TxEvent.FAILED]: null,
@@ -24,17 +24,17 @@ const useTxMonitor = (): void => {
   // Prevent `waitForTx` from monitoring the same tx more than once
   const monitoredTxs = useRef<{ [txId: string]: boolean }>({})
 
-  // Monitor pending transaction mining progress
+  // Monitor pending transaction mining/validating progress
   useEffect(() => {
     if (!provider || !pendingTxEntriesOnChain) {
       return
     }
 
     for (const [txId, { txHash, status }] of pendingTxEntriesOnChain) {
-      const isMining = status === PendingStatus.MINING
+      const isProcessing = status === PendingStatus.PROCESSING
       const isMonitored = monitoredTxs.current[txId]
 
-      if (!txHash || !isMining || isMonitored) {
+      if (!txHash || !isProcessing || isMonitored) {
         continue
       }
 

--- a/src/hooks/useTxTracking.ts
+++ b/src/hooks/useTxTracking.ts
@@ -4,7 +4,7 @@ import { useEffect } from 'react'
 
 const events = {
   [TxEvent.SIGNED]: WALLET_EVENTS.OFF_CHAIN_SIGNATURE,
-  [TxEvent.MINING]: WALLET_EVENTS.ON_CHAIN_INTERACTION,
+  [TxEvent.PROCESSING]: WALLET_EVENTS.ON_CHAIN_INTERACTION,
 }
 
 export const useTxTracking = (): void => {

--- a/src/services/tx/__tests__/txEvents.test.ts
+++ b/src/services/tx/__tests__/txEvents.test.ts
@@ -6,8 +6,8 @@ const tx = {
 } as unknown as SafeTransaction
 
 describe('txEvents', () => {
-  it('should dispatch and subscribe to the MINING event', () => {
-    const event = TxEvent.MINING
+  it('should dispatch and subscribe to the PROCESSING event', () => {
+    const event = TxEvent.PROCESSING
 
     const detail = {
       txId: '123',

--- a/src/services/tx/__tests__/txMonitor.test.ts
+++ b/src/services/tx/__tests__/txMonitor.test.ts
@@ -21,8 +21,8 @@ describe('txMonitor', () => {
   })
 
   describe('waitForTx', () => {
-    // Mined:
-    it("doesn't emit an event if the tx was successfully mined", async () => {
+    // Mined/validated:
+    it("doesn't emit an event if the tx was successfully mined/validated", async () => {
       const receipt = {
         status: 1,
       } as TransactionReceipt
@@ -34,7 +34,7 @@ describe('txMonitor', () => {
       expect(txDispatchSpy).not.toHaveBeenCalled()
     })
 
-    // Not mined:
+    // Not mined/validated:
     it("emits a FAILED event if waitForTransaction isn't blocking and no receipt was returned", async () => {
       // Can return null if waitForTransaction is non-blocking:
       // https://docs.ethers.io/v5/single-page/#/v5/api/providers/provider/-%23-Provider-waitForTransaction
@@ -47,7 +47,7 @@ describe('txMonitor', () => {
       expect(txDispatchSpy).toHaveBeenCalledWith('FAILED', { txId: '0x0', error: expect.any(Error) })
     })
 
-    it('emits a FAILED event if the tx mining timed out', async () => {
+    it('emits a FAILED event if the tx mining/validating timed out', async () => {
       waitForTxSpy.mockImplementationOnce(
         () => Promise.resolve(null) as unknown as ReturnType<typeof provider.waitForTransaction>,
       )
@@ -56,7 +56,7 @@ describe('txMonitor', () => {
 
       expect(txDispatchSpy).toHaveBeenCalledWith('FAILED', {
         txId: '0x0',
-        error: new Error('Transaction not mined in 6.5 minutes. Be aware that it might still be mined.'),
+        error: new Error('Transaction not processed in 6.5 minutes. Be aware that it might still be processed.'),
       })
     })
 

--- a/src/services/tx/__tests__/txSender.test.ts
+++ b/src/services/tx/__tests__/txSender.test.ts
@@ -245,8 +245,8 @@ describe('txSender', () => {
 
       expect(mockSafeSDK.executeTransaction).toHaveBeenCalled()
       expect(txEvents.txDispatch).toHaveBeenCalledWith('EXECUTING', { txId })
-      expect(txEvents.txDispatch).toHaveBeenCalledWith('MINING', { txId })
-      expect(txEvents.txDispatch).toHaveBeenCalledWith('MINED', { receipt: {}, txId })
+      expect(txEvents.txDispatch).toHaveBeenCalledWith('PROCESSING', { txId })
+      expect(txEvents.txDispatch).toHaveBeenCalledWith('PROCESSED', { receipt: {}, txId })
     })
 
     it('should fail executing a tx', async () => {
@@ -290,7 +290,7 @@ describe('txSender', () => {
 
       expect(mockSafeSDK.executeTransaction).toHaveBeenCalled()
       expect(txEvents.txDispatch).toHaveBeenCalledWith('EXECUTING', { txId })
-      expect(txEvents.txDispatch).toHaveBeenCalledWith('MINING', { txId })
+      expect(txEvents.txDispatch).toHaveBeenCalledWith('PROCESSING', { txId })
       expect(txEvents.txDispatch).toHaveBeenCalledWith('REVERTED', {
         txId,
         receipt: { status: 0 },

--- a/src/services/tx/txEvents.ts
+++ b/src/services/tx/txEvents.ts
@@ -11,9 +11,9 @@ export enum TxEvent {
   SIGNATURE_PROPOSE_FAILED = 'SIGNATURE_PROPOSE_FAILED',
   AWAITING_ON_CHAIN_SIGNATURE = 'AWAITING_ON_CHAIN_SIGNATURE',
   EXECUTING = 'EXECUTING',
-  MINING = 'MINING',
-  MINING_MODULE = 'MINING_MODULE',
-  MINED = 'MINED',
+  PROCESSING = 'PROCESSING',
+  PROCESSING_MODULE = 'PROCESSING_MODULE',
+  PROCESSED = 'PROCESSED',
   REVERTED = 'REVERTED',
   FAILED = 'FAILED',
   SUCCESS = 'SUCCESS',
@@ -31,9 +31,9 @@ interface TxEvents {
   [TxEvent.SIGNATURE_PROPOSED]: { txId: string }
   [TxEvent.AWAITING_ON_CHAIN_SIGNATURE]: Id
   [TxEvent.EXECUTING]: Id
-  [TxEvent.MINING]: Id & { txHash: string }
-  [TxEvent.MINING_MODULE]: Id & { txHash: string }
-  [TxEvent.MINED]: Id & { receipt: ContractReceipt }
+  [TxEvent.PROCESSING]: Id & { txHash: string }
+  [TxEvent.PROCESSING_MODULE]: Id & { txHash: string }
+  [TxEvent.PROCESSED]: Id & { receipt: ContractReceipt }
   [TxEvent.REVERTED]: Id & { error: Error; receipt: ContractReceipt }
   [TxEvent.FAILED]: Id & { error: Error }
   [TxEvent.SUCCESS]: Id

--- a/src/services/tx/txMonitor.ts
+++ b/src/services/tx/txMonitor.ts
@@ -8,12 +8,14 @@ export const waitForTx = async (provider: JsonRpcProvider, txId: string, txHash:
   const TIMEOUT_MINUTES = 6.5
 
   try {
-    // Return receipt after 1 additional block was mined or until timeout
+    // Return receipt after 1 additional block was mined/validated or until timeout
     // https://docs.ethers.io/v5/single-page/#/v5/api/providers/provider/-%23-Provider-waitForTransaction
     const receipt = await provider.waitForTransaction(txHash, 1, TIMEOUT_MINUTES * 60_000)
 
     if (!receipt) {
-      throw new Error(`Transaction not mined in ${TIMEOUT_MINUTES} minutes. Be aware that it might still be mined.`)
+      throw new Error(
+        `Transaction not processed in ${TIMEOUT_MINUTES} minutes. Be aware that it might still be processed.`,
+      )
     }
 
     if (didRevert(receipt)) {
@@ -24,7 +26,7 @@ export const waitForTx = async (provider: JsonRpcProvider, txId: string, txHash:
       })
     }
 
-    // Tx successfully mined but we don't dispatch SUCCESS as this may be faster than our indexer
+    // Tx successfully mined/validated but we don't dispatch SUCCESS as this may be faster than our indexer
   } catch (error) {
     txDispatch(TxEvent.FAILED, {
       txId,

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -242,16 +242,16 @@ export const dispatchTxExecution = async (
     throw error
   }
 
-  txDispatch(TxEvent.MINING, { txId, txHash: result.hash })
+  txDispatch(TxEvent.PROCESSING, { txId, txHash: result.hash })
 
-  // Asynchronously watch the tx to be mined
+  // Asynchronously watch the tx to be mined/validated
   result.transactionResponse
     ?.wait()
     .then((receipt) => {
       if (didRevert(receipt)) {
         txDispatch(TxEvent.REVERTED, { txId, receipt, error: new Error('Transaction reverted by EVM') })
       } else {
-        txDispatch(TxEvent.MINED, { txId, receipt })
+        txDispatch(TxEvent.PROCESSED, { txId, receipt })
       }
     })
     .catch((error) => {
@@ -285,7 +285,7 @@ export const dispatchBatchExecution = async (
   }
 
   txs.forEach(({ txId }) => {
-    txDispatch(TxEvent.MINING, { txId, txHash: result!.hash, groupKey })
+    txDispatch(TxEvent.PROCESSING, { txId, txHash: result!.hash, groupKey })
   })
 
   result.transactionResponse
@@ -302,7 +302,7 @@ export const dispatchBatchExecution = async (
         })
       } else {
         txs.forEach(({ txId }) => {
-          txDispatch(TxEvent.MINED, {
+          txDispatch(TxEvent.PROCESSED, {
             txId,
             receipt,
             groupKey,
@@ -353,7 +353,7 @@ export const dispatchSpendingLimitTxExecution = async (
     throw error
   }
 
-  txDispatch(TxEvent.MINING_MODULE, {
+  txDispatch(TxEvent.PROCESSING_MODULE, {
     groupKey: id,
     txHash: result.hash,
   })
@@ -364,7 +364,7 @@ export const dispatchSpendingLimitTxExecution = async (
       if (didRevert(receipt)) {
         txDispatch(TxEvent.REVERTED, { groupKey: id, receipt, error: new Error('Transaction reverted by EVM') })
       } else {
-        txDispatch(TxEvent.MINED, { groupKey: id, receipt })
+        txDispatch(TxEvent.PROCESSED, { groupKey: id, receipt })
       }
     })
     .catch((error) => {

--- a/src/store/pendingTxsSlice.ts
+++ b/src/store/pendingTxsSlice.ts
@@ -4,7 +4,7 @@ import type { RootState } from '@/store'
 
 export enum PendingStatus {
   SUBMITTING = 'SUBMITTING',
-  MINING = 'MINING',
+  PROCESSING = 'PROCESSING',
   INDEXING = 'INDEXING',
 }
 


### PR DESCRIPTION
## What it solves

Accomodating statuses for PoS

## How this PR fixes it

All instances of mining/mined have been changed to processing/processed in order to accomodate for PoS.

## How to test it

- Create and execute a transaction. Observe the notification regards it as "processing" the transaction and the status is now also "Processing".
- Adding a spending limit now says "Spending limit transactions only appear in the interface once they are successfully processed and indexed." in the modal.
- Transactions that timeout (by underpricing the gas) should throw "Transaction not processed in 6.5 minutes. Be aware that it might still be processed."