### PR TITLE
Fix: redirect from a bare safe address URL

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,7 @@
+/:safe/balances /balances?safe=:safe
 /:safe/balances/* /balances/:splat?safe=:safe
+/:safe/settings /settings?safe=:safe
 /:safe/settings/* /settings/:splat?safe=:safe
-/:safe/transactions/queue/* /transactions/queue/:splat?safe=:safe
+/:safe/transactions/queue /transactions/queue?safe=:safe
 /:safe/address-book /address-book?safe=:safe
 /:safe/home /home?safe=:safe

--- a/scripts/generate-routes.js
+++ b/scripts/generate-routes.js
@@ -9,7 +9,7 @@ const iterate = (folderName, parentRoute, root) => {
     .sort((a, b) => (isFile(a) ? -1 : 1))
     .forEach((item) => {
       // Skip service files
-      if (/_app|_document|404/.test(item)) return
+      if (/_app|_document/.test(item)) return
 
       // A folder, continue iterating
       if (!isFile(item)) {

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -1,4 +1,5 @@
 export const AppRoutes = {
+  '404': '/404',
   welcome: '/welcome',
   open: '/open',
   load: '/load',

--- a/src/hooks/__tests__/usePathRewrite.test.ts
+++ b/src/hooks/__tests__/usePathRewrite.test.ts
@@ -1,4 +1,4 @@
-import usePathRewrite, { useQueryRewrite } from '@/hooks/usePathRewrite'
+import usePathRewrite, { use404Rewrite } from '@/hooks/usePathRewrite'
 import { act, renderHook } from '@/tests/test-utils'
 
 // mock window history replaceState
@@ -110,7 +110,7 @@ describe('useQueryRewrite', () => {
   })
 
   it('should not redirect if there is no Safe address in the path', async () => {
-    const { result } = renderHook(() => useQueryRewrite())
+    const { result } = renderHook(() => use404Rewrite())
     expect(result.current).toBe(false)
   })
 
@@ -122,7 +122,7 @@ describe('useQueryRewrite', () => {
       },
     })
 
-    const { result } = renderHook(() => useQueryRewrite())
+    const { result } = renderHook(() => use404Rewrite())
     expect(result.current).toBe(true)
     await act(() => Promise.resolve())
     expect(result.current).toBe(true)

--- a/src/hooks/usePathRewrite.ts
+++ b/src/hooks/usePathRewrite.ts
@@ -47,7 +47,7 @@ export default usePathRewrite
 // we rewrite the URL to put the Safe address into the query.
 // This must and will cause a rendering and route change.
 // Thankfully, this will only happen if you reload the page or open this URL from an external link.
-export const useQueryRewrite = (): boolean => {
+export const use404Rewrite = (): boolean => {
   const [redirecting, setRedirecting] = useState<boolean>(true)
   const router = useRouter()
 
@@ -58,7 +58,7 @@ export const useQueryRewrite = (): boolean => {
     const [, pathSafe] = currentPath.match(re) || []
 
     if (pathSafe) {
-      const newPath = currentPath.replace(re, '')
+      const newPath = currentPath.replace(pathSafe, '')
 
       if (newPath !== currentPath) {
         router.replace(`${newPath}?safe=${pathSafe}${location.search ? '&' + location.search.slice(1) : ''}`)

--- a/src/hooks/usePathRewrite.ts
+++ b/src/hooks/usePathRewrite.ts
@@ -58,7 +58,7 @@ export const use404Rewrite = (): boolean => {
     const [, pathSafe] = currentPath.match(re) || []
 
     if (pathSafe) {
-      const newPath = currentPath.replace(pathSafe, '')
+      const newPath = currentPath.replace(re, '') || '/'
 
       if (newPath !== currentPath) {
         router.replace(`${newPath}?safe=${pathSafe}${location.search ? '&' + location.search.slice(1) : ''}`)

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,8 +1,8 @@
 import type { NextPage } from 'next'
-import { useQueryRewrite } from '@/hooks/usePathRewrite'
+import { use404Rewrite } from '@/hooks/usePathRewrite'
 
 const Custom404: NextPage = () => {
-  const isRedirecting = useQueryRewrite()
+  const isRedirecting = use404Rewrite()
 
   return <main>{!isRedirecting && <h1>404 - Page Not Found</h1>}</main>
 }

--- a/src/services/analytics/useGtm.ts
+++ b/src/services/analytics/useGtm.ts
@@ -9,6 +9,7 @@ import { useAppSelector } from '@/store'
 import { CookieType, selectCookies } from '@/store/cookiesSlice'
 import useChainId from '@/hooks/useChainId'
 import { useRouter } from 'next/router'
+import { AppRoutes } from '@/config/routes'
 
 const useGtm = () => {
   const chainId = useChainId()
@@ -29,7 +30,9 @@ const useGtm = () => {
   // Track page views – anononimized by default.
   // Sensitive info, like the safe address or tx id, is always in the query string, which we DO NOT track.
   useEffect(() => {
-    gtmTrackPageview(router.pathname)
+    if (router.pathname !== AppRoutes['404']) {
+      gtmTrackPageview(router.pathname)
+    }
   }, [router.pathname])
 }
 


### PR DESCRIPTION
## What it solves

Resolves #604 

## How this PR fixes it
It was a regression after I added _redirects. The `/` should remain in the URL.