### PR TITLE
Fix: error button style

### DIFF
--- a/src/components/address-book/RemoveDialog/index.tsx
+++ b/src/components/address-book/RemoveDialog/index.tsx
@@ -32,7 +32,7 @@ const RemoveDialog = ({ handleClose, address }: { handleClose: () => void; addre
 
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
-        <Button onClick={handleConfirm} variant="contained" disableElevation color="error">
+        <Button onClick={handleConfirm} variant="danger" disableElevation>
           Delete
         </Button>
       </DialogActions>

--- a/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -113,7 +113,7 @@ const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
 
           <ChainSwitcher fullWidth />
 
-          <Button onClick={handleDisconnect} color="error" variant="contained" size="small" fullWidth disableElevation>
+          <Button onClick={handleDisconnect} variant="danger" size="small" fullWidth disableElevation>
             Disconnect
           </Button>
         </Paper>

--- a/src/components/safe-apps/RemoveCustomAppModal.tsx
+++ b/src/components/safe-apps/RemoveCustomAppModal.tsx
@@ -19,7 +19,7 @@ const RemoveCustomAppModal = ({ open, onClose, onConfirm, app }: Props) => (
     </DialogContent>
     <DialogActions disableSpacing>
       <Button onClick={onClose}>Cancel</Button>
-      <Button color="error" variant="contained" onClick={() => onConfirm(app.id)}>
+      <Button variant="danger" onClick={() => onConfirm(app.id)}>
         Remove
       </Button>
     </DialogActions>

--- a/src/components/sidebar/SafeListRemoveDialog/index.tsx
+++ b/src/components/sidebar/SafeListRemoveDialog/index.tsx
@@ -38,7 +38,7 @@ const SafeListRemoveDialog = ({
 
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
-        <Button onClick={handleConfirm} variant="contained" disableElevation color="error">
+        <Button onClick={handleConfirm} variant="danger" disableElevation>
           Delete
         </Button>
       </DialogActions>

--- a/src/components/transactions/RejectTxButton/index.tsx
+++ b/src/components/transactions/RejectTxButton/index.tsx
@@ -49,7 +49,7 @@ const RejectTxButton = ({
             </span>
           </Tooltip>
         ) : (
-          <Button onClick={onClick} color="error" variant="contained" disabled={isDisabled} size="stretched">
+          <Button onClick={onClick} variant="danger" disabled={isDisabled} size="stretched">
             Reject
           </Button>
         )}

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -15,6 +15,12 @@ declare global {
   }
 }
 
+declare module '@mui/material/Button' {
+  interface ButtonPropsVariantOverrides {
+    danger: true
+  }
+}
+
 declare module '*.svg' {
   const content: any
   export const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -125,6 +125,17 @@ const initTheme = (darkMode: boolean) => {
               padding: '12px 48px',
             },
           },
+          {
+            props: { variant: 'danger' },
+            style: ({ theme }) => ({
+              backgroundColor: theme.palette.error.background,
+              color: theme.palette.error.main,
+              '&:hover': {
+                color: theme.palette.error.dark,
+                backgroundColor: theme.palette.error.light,
+              },
+            }),
+          },
         ],
         styleOverrides: {
           sizeSmall: {


### PR DESCRIPTION
## What it solves
As per Figma, the "dangerous" CTA should look like this:

<img width="271" alt="Screenshot 2022-09-22 at 13 50 40" src="https://user-images.githubusercontent.com/381895/191740155-2087ef89-f7d0-4780-aedb-e0febc0958b7.png">
