### PR TITLE
fix: Use eth_sign when connected via WC

### DIFF
--- a/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.test.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.test.tsx
@@ -72,8 +72,7 @@ describe('SignOrExecuteForm', () => {
       .mockImplementation(jest.fn(() => Promise.resolve({ txId: '0x12' } as TransactionDetails)))
 
     jest.spyOn(txSender, 'dispatchTxExecution').mockImplementation(jest.fn())
-    jest.spyOn(walletUtils, 'isHardwareWallet').mockImplementation(jest.fn())
-    jest.spyOn(walletUtils, 'isSafeMobileWallet').mockImplementation(jest.fn())
+    jest.spyOn(walletUtils, 'shouldUseEthSignMethod').mockImplementation(jest.fn())
   })
 
   it('displays decoded data if there is a tx', () => {

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -15,7 +15,7 @@ import useGasLimit from '@/hooks/useGasLimit'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import AdvancedParams, { type AdvancedParameters, useAdvancedParams } from '@/components/tx/AdvancedParams'
-import { isHardwareWallet, isSafeMobileWallet, isSmartContractWallet } from '@/hooks/wallets/wallets'
+import { isHardwareWallet, isSafeMobileWallet, isSmartContractWallet, isWalletConnect } from '@/hooks/wallets/wallets'
 import DecodedTx from '../DecodedTx'
 import ExecuteCheckbox from '../ExecuteCheckbox'
 import { logError, Errors } from '@/services/exceptions'
@@ -101,7 +101,8 @@ const SignOrExecuteForm = ({
   const onSign = async (): Promise<string> => {
     const [connectedWallet, createdTx, provider] = assertSubmittable()
 
-    const shouldEthSign = isHardwareWallet(connectedWallet) || isSafeMobileWallet(connectedWallet)
+    const shouldEthSign =
+      isHardwareWallet(connectedWallet) || isSafeMobileWallet(connectedWallet) || isWalletConnect(connectedWallet)
     const smartContractWallet = await isSmartContractWallet(connectedWallet)
     const signedTx = smartContractWallet
       ? await dispatchOnChainSigning(createdTx, provider, txId)

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -15,7 +15,7 @@ import useGasLimit from '@/hooks/useGasLimit'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import AdvancedParams, { type AdvancedParameters, useAdvancedParams } from '@/components/tx/AdvancedParams'
-import { isHardwareWallet, isSafeMobileWallet, isSmartContractWallet, isWalletConnect } from '@/hooks/wallets/wallets'
+import { isSmartContractWallet, shouldUseEthSignMethod } from '@/hooks/wallets/wallets'
 import DecodedTx from '../DecodedTx'
 import ExecuteCheckbox from '../ExecuteCheckbox'
 import { logError, Errors } from '@/services/exceptions'
@@ -101,8 +101,7 @@ const SignOrExecuteForm = ({
   const onSign = async (): Promise<string> => {
     const [connectedWallet, createdTx, provider] = assertSubmittable()
 
-    const shouldEthSign =
-      isHardwareWallet(connectedWallet) || isSafeMobileWallet(connectedWallet) || isWalletConnect(connectedWallet)
+    const shouldEthSign = shouldUseEthSignMethod(connectedWallet)
     const smartContractWallet = await isSmartContractWallet(connectedWallet)
     const signedTx = smartContractWallet
       ? await dispatchOnChainSigning(createdTx, provider, txId)

--- a/src/hooks/wallets/wallets.test.ts
+++ b/src/hooks/wallets/wallets.test.ts
@@ -1,0 +1,71 @@
+import { shouldUseEthSignMethod } from '@/hooks/wallets/wallets'
+import { ConnectedWallet } from '@/services/onboard'
+import { ZERO_ADDRESS } from '@gnosis.pm/safe-core-sdk/dist/src/utils/constants'
+import { EIP1193Provider } from '@web3-onboard/core'
+
+describe('shouldUseEthSignMethod', () => {
+  it('returns true for Ledger wallets', () => {
+    const mockWallet: ConnectedWallet = {
+      address: ZERO_ADDRESS,
+      chainId: '4',
+      label: 'Ledger',
+      provider: null as unknown as EIP1193Provider,
+    }
+
+    const result = shouldUseEthSignMethod(mockWallet)
+
+    expect(result).toBe(true)
+  })
+
+  it('returns true for Trezor wallets', () => {
+    const mockWallet: ConnectedWallet = {
+      address: ZERO_ADDRESS,
+      chainId: '4',
+      label: 'Trezor',
+      provider: null as unknown as EIP1193Provider,
+    }
+
+    const result = shouldUseEthSignMethod(mockWallet)
+
+    expect(result).toBe(true)
+  })
+
+  it('returns true for Safe mobile pairing', () => {
+    const mockWallet: ConnectedWallet = {
+      address: ZERO_ADDRESS,
+      chainId: '4',
+      label: 'Safe Mobile',
+      provider: null as unknown as EIP1193Provider,
+    }
+
+    const result = shouldUseEthSignMethod(mockWallet)
+
+    expect(result).toBe(true)
+  })
+
+  it('returns true for WalletConnect', () => {
+    const mockWallet: ConnectedWallet = {
+      address: ZERO_ADDRESS,
+      chainId: '4',
+      label: 'WalletConnect',
+      provider: null as unknown as EIP1193Provider,
+    }
+
+    const result = shouldUseEthSignMethod(mockWallet)
+
+    expect(result).toBe(true)
+  })
+
+  it('returns false for MetaMask', () => {
+    const mockWallet: ConnectedWallet = {
+      address: ZERO_ADDRESS,
+      chainId: '4',
+      label: 'MetaMask',
+      provider: null as unknown as EIP1193Provider,
+    }
+
+    const result = shouldUseEthSignMethod(mockWallet)
+
+    expect(result).toBe(false)
+  })
+})

--- a/src/hooks/wallets/wallets.ts
+++ b/src/hooks/wallets/wallets.ts
@@ -91,6 +91,10 @@ export const isHardwareWallet = (wallet: ConnectedWallet): boolean => {
   return [WALLET_KEYS.LEDGER, WALLET_KEYS.TREZOR].includes(wallet.label.toUpperCase() as WALLET_KEYS)
 }
 
+export const isWalletConnect = (wallet: ConnectedWallet): boolean => {
+  return wallet.label.toUpperCase() === WALLET_KEYS.WALLETCONNECT
+}
+
 export const isSafeMobileWallet = (wallet: ConnectedWallet): boolean => {
   return wallet.label === PAIRING_MODULE_LABEL
 }

--- a/src/hooks/wallets/wallets.ts
+++ b/src/hooks/wallets/wallets.ts
@@ -110,3 +110,7 @@ export const isSmartContractWallet = async (wallet: ConnectedWallet) => {
 
   return code !== EMPTY_DATA
 }
+
+export const shouldUseEthSignMethod = (wallet: ConnectedWallet) => {
+  return isHardwareWallet(wallet) || isSafeMobileWallet(wallet) || isWalletConnect(wallet)
+}


### PR DESCRIPTION
## What it solves

Resolves #503 

## How this PR fixes it

Uses `eth_sign` when signing a transaction via WalletConnect

## How to test it

1. Open the Safe
2. Connect to the safe via mobile MM app
3. Create/Sign a transaction
4. Observe no error
5. Observe a window popping up on the mobile MM app