### PR TITLE
Chore: serve from /app

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,8 @@ import withBundleAnalyzer from '@next/bundle-analyzer'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  basePath: '/app',
+
   reactStrictMode: false,
   eslint: {
     dirs: ['src'],
@@ -29,8 +31,8 @@ const nextConfig = {
   async rewrites() {
     return [
       {
-        source: '/:safe([a-z]+\\:0x[a-fA-F0-9]{40})/:path*',
-        destination: '/:path*?safe=:safe',
+        source: '/app/:safe([a-z]+\\:0x[a-fA-F0-9]{40})/:path*',
+        destination: '/app/:path*?safe=:safe',
       },
     ]
   },

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,7 +1,7 @@
-/:safe/balances /balances?safe=:safe
-/:safe/balances/* /balances/:splat?safe=:safe
-/:safe/settings /settings?safe=:safe
-/:safe/settings/* /settings/:splat?safe=:safe
-/:safe/transactions/queue /transactions/queue?safe=:safe
-/:safe/address-book /address-book?safe=:safe
-/:safe/home /home?safe=:safe
+/app/:safe/balances /app/balances?safe=:safe
+/app/:safe/balances/* /app/balances/:splat?safe=:safe
+/app/:safe/settings /app/settings?safe=:safe
+/app/:safe/settings/* /app/settings/:splat?safe=:safe
+/app/:safe/transactions/queue /app/transactions/queue?safe=:safe
+/app/:safe/address-book /app/address-book?safe=:safe
+/app/:safe/home /app/home?safe=:safe

--- a/public/favicons/site.webmanifest
+++ b/public/favicons/site.webmanifest
@@ -1,17 +1,22 @@
 {
   "name": "Safe",
   "short_name": "Safe",
+  "description": "Safe is the most trusted platform to manage digital assets on Ethereum.",
   "icons": [
     {
-      "src": "/favicons/android-chrome-192x192.png",
+      "src": "/app/favicons/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/favicons/android-chrome-512x512.png",
+      "src": "/app/favicons/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }
   ],
-  "display": "standalone"
+  "display": "standalone",
+  "start_url": "/app",
+  "display": "fullscreen",
+  "theme_color": "#121312",
+  "background_color": "#ffffff"
 }

--- a/src/components/common/AppStoreButton/index.tsx
+++ b/src/components/common/AppStoreButton/index.tsx
@@ -24,7 +24,7 @@ const AppstoreButton = ({ placement }: { placement: keyof typeof LINKS }): React
   return (
     <a href={LINKS[placement]} target="_blank" rel="noreferrer" onClick={onClick}>
       <img
-        src={isDarkMode ? '/images/appstore-light.svg' : '/images/appstore.svg'}
+        src={isDarkMode ? '/app/images/appstore-light.svg' : '/app/images/appstore.svg'}
         alt="Download on the App Store"
         className={css.button}
       />

--- a/src/components/common/QRCode/index.tsx
+++ b/src/components/common/QRCode/index.tsx
@@ -15,7 +15,7 @@ const QRCode = ({ value, size }: { value?: string; size: number }): ReactElement
       bgColor={palette.background.paper}
       fgColor={palette.text.primary}
       imageSettings={{
-        src: '/images/safe-logo-green.png',
+        src: '/app/images/safe-logo-green.png',
         width: QR_LOGO_SIZE,
         height: QR_LOGO_SIZE,
         excavate: true,

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -53,7 +53,7 @@ const SafeTokenWidget = () => {
       <Tooltip title={url ? `Open ${claimingApp?.name}` : ''}>
         <span>
           <Track {...OVERVIEW_EVENTS.SAFE_TOKEN_WIDGET}>
-            <Link href={url || '#'} passHref>
+            <Link href={url || ''} passHref>
               <ButtonBase
                 aria-describedby={'safe-token-widget'}
                 sx={{ alignSelf: 'stretch' }}

--- a/src/components/common/TokenIcon/index.tsx
+++ b/src/components/common/TokenIcon/index.tsx
@@ -11,7 +11,7 @@ const TokenIcon = ({
   tokenSymbol?: string
   size?: number
 }): ReactElement | null => {
-  const FALLBACK_ICON = '/images/token-placeholder.svg'
+  const FALLBACK_ICON = '/app/images/token-placeholder.svg'
 
   return !logoUri ? null : (
     <ImageFallback src={logoUri} alt={tokenSymbol} fallbackSrc={FALLBACK_ICON} height={size} className={css.image} />

--- a/src/components/nfts/NftCard/index.tsx
+++ b/src/components/nfts/NftCard/index.tsx
@@ -8,7 +8,7 @@ const NftCard = ({ nft, onSendClick }: { nft: SafeCollectibleResponse; onSendCli
   <Card className={css.card}>
     <CardContent>
       <div className={css.imageWrapper}>
-        <img src={nft.imageUri || '/images/nft-placeholder.png'} alt={`${nft.tokenName} #${nft.id}`} />
+        <img src={nft.imageUri || '/app/images/nft-placeholder.png'} alt={`${nft.tokenName} #${nft.id}`} />
       </div>
 
       <Typography fontWeight="bold" variant="body2">

--- a/src/components/safe-apps/AddCustomAppModal.tsx
+++ b/src/components/safe-apps/AddCustomAppModal.tsx
@@ -37,7 +37,7 @@ type CustomAppFormData = {
 }
 
 const TEXT_FIELD_HEIGHT = '56px'
-const APP_LOGO_FALLBACK_IMAGE = '/images/apps-icon.svg'
+const APP_LOGO_FALLBACK_IMAGE = '/app/images/apps-icon.svg'
 const HELP_LINK = 'https://docs.gnosis-safe.io/build/sdks/safe-apps'
 
 const AddCustomAppModal = ({ open, onClose, onSave, safeAppsList }: Props) => {

--- a/src/components/safe-apps/SafeAppsModalLabel/index.tsx
+++ b/src/components/safe-apps/SafeAppsModalLabel/index.tsx
@@ -3,7 +3,7 @@ import { Typography, Box } from '@mui/material'
 
 import css from './styles.module.css'
 
-const APP_LOGO_FALLBACK_IMAGE = '/images/apps-icon.svg'
+const APP_LOGO_FALLBACK_IMAGE = '/app/images/apps-icon.svg'
 
 const SafeAppsModalLabel = ({ app }: { app?: SafeAppData }) => {
   if (!app) {

--- a/src/hooks/usePathRewrite.ts
+++ b/src/hooks/usePathRewrite.ts
@@ -19,7 +19,7 @@ const usePathRewrite = () => {
     if (!safe) return
 
     // Move the Safe address to the path
-    let newPath = router.pathname.replace(/^\//, `/${safe}/`)
+    let newPath = router.pathname.replace(/^\//, `/app/${safe}/`)
 
     // Preserve other query params
     if (Object.keys(restQuery).length) {
@@ -54,7 +54,7 @@ export const use404Rewrite = (): boolean => {
   useEffect(() => {
     if (typeof location === 'undefined') return
     const currentPath = location.pathname
-    const re = /^\/([^/]+?:0x[0-9a-fA-F]{40})/
+    const re = /^\/app\/([^/]+?:0x[0-9a-fA-F]{40})/
     const [, pathSafe] = currentPath.match(re) || []
 
     if (pathSafe) {

--- a/src/hooks/useTransactionType.ts
+++ b/src/hooks/useTransactionType.ts
@@ -38,7 +38,7 @@ const getTxType = (tx: TransactionSummary): TxType => {
   switch (tx.txInfo.type) {
     case TransactionInfoType.CREATION: {
       return {
-        icon: toAddress?.logoUri || '/images/settings.svg',
+        icon: toAddress?.logoUri || '/app/images/settings.svg',
         text: 'Safe created',
       }
     }
@@ -46,7 +46,7 @@ const getTxType = (tx: TransactionSummary): TxType => {
       const isSendTx = tx.txInfo.direction === TransferDirection.OUTGOING
 
       return {
-        icon: isSendTx ? '/images/outgoing.svg' : '/images/incoming.svg',
+        icon: isSendTx ? '/app/images/outgoing.svg' : '/app/images/incoming.svg',
         text: isSendTx ? (isTxQueued(tx.txStatus) ? 'Send' : 'Sent') : 'Received',
       }
     }
@@ -56,21 +56,21 @@ const getTxType = (tx: TransactionSummary): TxType => {
       const isDeleteGuard = tx.txInfo.settingsInfo?.type === SettingsInfoType.DELETE_GUARD
 
       return {
-        icon: '/images/settings.svg',
+        icon: '/app/images/settings.svg',
         text: isDeleteGuard ? 'deleteGuard' : tx.txInfo.dataDecoded.method,
       }
     }
     case TransactionInfoType.CUSTOM: {
       if (isModuleExecutionInfo(tx.executionInfo)) {
         return {
-          icon: toAddress?.logoUri || '/images/settings.svg',
+          icon: toAddress?.logoUri || '/app/images/settings.svg',
           text: toAddress?.name || DEFAULT_MODULE_NAME,
         }
       }
 
       if (isCancellationTxInfo(tx.txInfo)) {
         return {
-          icon: '/images/circle-cross-red.svg',
+          icon: '/app/images/circle-cross-red.svg',
           text: 'On-chain rejection',
         }
       }
@@ -83,13 +83,13 @@ const getTxType = (tx: TransactionSummary): TxType => {
       }
 
       return {
-        icon: toAddress?.logoUri || '/images/custom.svg',
+        icon: toAddress?.logoUri || '/app/images/custom.svg',
         text: toAddress?.name || 'Contract interaction',
       }
     }
     default: {
       return {
-        icon: '/images/custom.svg',
+        icon: '/app/images/custom.svg',
         text: 'Contract interaction',
       }
     }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -82,6 +82,8 @@ const SafeWebCore = ({ Component, pageProps }: AppProps): ReactElement => {
           content="Safe is the most trusted platform to manage digital assets on Ethereum (formerly known as the Gnosis Safe multisig)."
         />
 
+        <base href="/app" />
+
         <link rel="dns-prefetch" href={GATEWAY_URL} />
         <link rel="preconnect" href={GATEWAY_URL} crossOrigin="" />
 
@@ -89,12 +91,12 @@ const SafeWebCore = ({ Component, pageProps }: AppProps): ReactElement => {
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <meta httpEquiv="Content-Security-Policy" content={ContentSecurityPolicy} />
         {IS_PRODUCTION && <meta httpEquiv="Strict-Transport-Security" content={StrictTransportSecurity} />}
-        <link rel="shortcut icon" href="/favicons/favicon.ico" />
-        <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png" />
-        <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png" />
-        <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png" />
-        <link rel="manifest" href="/favicons/site.webmanifest" />
-        <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#000" />
+        <link rel="shortcut icon" href="/app/favicons/favicon.ico" />
+        <link rel="apple-touch-icon" sizes="180x180" href="/app/favicons/apple-touch-icon.png" />
+        <link rel="icon" type="image/png" sizes="32x32" href="/app/favicons/favicon-32x32.png" />
+        <link rel="icon" type="image/png" sizes="16x16" href="/app/favicons/favicon-16x16.png" />
+        <link rel="manifest" href="/app/favicons/site.webmanifest" />
+        <link rel="mask-icon" href="/app/favicons/safari-pinned-tab.svg" color="#000" />
       </Head>
 
       <AppProviders>

--- a/src/services/onboard.ts
+++ b/src/services/onboard.ts
@@ -41,7 +41,7 @@ export const createOnboard = (chainConfigs: ChainInfo[]): OnboardAPI => {
 
     appMetadata: {
       name: 'Safe',
-      icon: '/images/safe-logo-green.png',
+      icon: '/app/images/safe-logo-green.png',
       description: 'Please select a wallet to connect to Safe',
       recommendedInjectedWallets: getRecommendedInjectedWallets(),
     },

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -5,14 +5,14 @@
   font-family: 'DM Sans';
   font-display: swap;
   font-weight: 400;
-  src: url('/fonts/dm-sans-v11-latin-ext-regular.woff2') format('woff2');
+  src: url('/app/fonts/dm-sans-v11-latin-ext-regular.woff2') format('woff2');
 }
 
 @font-face {
   font-family: 'DM Sans';
   font-display: swap;
   font-weight: bold;
-  src: url('/fonts/dm-sans-v11-latin-ext-700.woff2') format('woff2');
+  src: url('/app/fonts/dm-sans-v11-latin-ext-700.woff2') format('woff2');
 }
 
 html,


### PR DESCRIPTION
## What it solves
In preparation for a potential temporary deployment to the old domain in a subfolder rather than the root, I've added `/app` as the base path.

We could parametrize it as a BASE_PATH var, but since it's temporary, I think it's easier to keep the string and then just grep and clean it up once we move to a new domain w/o a subfolder.