### PR TITLE
feat: invalid mastercopy notification

### DIFF
--- a/src/components/common/Notifications/index.tsx
+++ b/src/components/common/Notifications/index.tsx
@@ -8,7 +8,7 @@ import NextLink from 'next/link'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
 import Track from '../Track'
-import { isRelativeUrlWithoutProtocol } from '@/utils/url'
+import { isRelativeUrl } from '@/utils/url'
 
 const toastStyle = { position: 'static', margin: 1 }
 
@@ -23,7 +23,7 @@ export const NotificationLink = ({
     return null
   }
 
-  const isExternal = !isRelativeUrlWithoutProtocol(link.href)
+  const isExternal = !isRelativeUrl(link.href)
 
   return (
     <Track {...OVERVIEW_EVENTS.NOTIFICATION_INTERACTION} label={link.title}>

--- a/src/components/common/Notifications/index.tsx
+++ b/src/components/common/Notifications/index.tsx
@@ -8,6 +8,7 @@ import NextLink from 'next/link'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
 import Track from '../Track'
+import { isRelativeUrlWithoutProtocol } from '@/utils/url'
 
 const toastStyle = { position: 'static', margin: 1 }
 
@@ -22,10 +23,16 @@ export const NotificationLink = ({
     return null
   }
 
+  const isExternal = !isRelativeUrlWithoutProtocol(link.href)
+
   return (
     <Track {...OVERVIEW_EVENTS.NOTIFICATION_INTERACTION} label={link.title}>
       <NextLink href={link.href} passHref>
-        <Link className={css.link} onClick={onClick}>
+        <Link
+          className={css.link}
+          onClick={onClick}
+          {...(isExternal && { target: '_blank', rel: 'noopener noreferrer' })}
+        >
           {link.title} <ChevronRightIcon />
         </Link>
       </NextLink>

--- a/src/services/__tests__/safeContracts.test.ts
+++ b/src/services/__tests__/safeContracts.test.ts
@@ -1,6 +1,52 @@
-import { _getValidatedGetContractProps } from '../contracts/safeContracts'
+import { getMasterCopies } from '@gnosis.pm/safe-react-gateway-sdk'
+import { _getValidatedGetContractProps, isValidMasterCopy } from '../contracts/safeContracts'
+
+jest.mock('@gnosis.pm/safe-react-gateway-sdk', () => ({
+  getMasterCopies: jest.fn(),
+}))
 
 describe('safeContracts', () => {
+  describe('isValidMasterCopy', () => {
+    it('returns false if address is not contained in result', async () => {
+      ;(getMasterCopies as jest.Mock).mockResolvedValue([
+        {
+          address: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552',
+          version: '1.3.0',
+          deployer: 'Gnosis',
+          deployedBlockNumber: 12504268,
+          lastIndexedBlockNumber: 14927028,
+          l2: false,
+        },
+      ])
+
+      const isValid = await isValidMasterCopy('1', '0x0000000000000000000000000000000000000005')
+      expect(isValid).toBe(false)
+    })
+
+    it('returns true if address is contained in list', async () => {
+      ;(getMasterCopies as jest.Mock).mockResolvedValue([
+        {
+          address: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552',
+          version: '1.3.0',
+          deployer: 'Gnosis',
+          deployedBlockNumber: 12504268,
+          lastIndexedBlockNumber: 14927028,
+          l2: false,
+        },
+        {
+          address: '0x3E5c63644E683549055b9Be8653de26E0B4CD36E',
+          version: '1.3.0+L2',
+          deployer: 'Gnosis',
+          deployedBlockNumber: 12504423,
+          lastIndexedBlockNumber: 14927028,
+          l2: true,
+        },
+      ])
+
+      const isValid = await isValidMasterCopy('1', '0x3E5c63644E683549055b9Be8653de26E0B4CD36E')
+      expect(isValid).toBe(true)
+    })
+  })
   describe('getValidatedGetContractProps', () => {
     it('should return the correct props', () => {
       expect(_getValidatedGetContractProps('1', '1.1.1')).toEqual({

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -12,11 +12,17 @@ import { LATEST_SAFE_VERSION } from '@/config/constants'
 import { Contract } from 'ethers'
 import { Interface } from '@ethersproject/abi'
 import semverSatisfies from 'semver/functions/satisfies'
-import { SafeInfo, type ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
+import { getMasterCopies, SafeInfo, type ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import type { GetContractProps, SafeVersion } from '@gnosis.pm/safe-core-sdk-types'
 import { type Compatibility_fallback_handler } from '@/types/contracts/Compatibility_fallback_handler'
 import { type Sign_message_lib } from '@/types/contracts/Sign_message_lib'
 import { createEthersAdapter, isValidSafeVersion } from '@/hooks/coreSDK/safeCoreSDK'
+import { sameAddress } from '@/utils/addresses'
+
+export const isValidMasterCopy = async (chainId: string, address: string): Promise<boolean> => {
+  const masterCopies = await getMasterCopies(chainId)
+  return masterCopies.some((masterCopy) => sameAddress(masterCopy.address, address))
+}
 
 export const _getValidatedGetContractProps = (
   chainId: string,

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -10,14 +10,14 @@ const invalidProtocolRegex = /^(\W*)(javascript|data|vbscript)/im
 const ctrlCharactersRegex = /[\u0000-\u001F\u007F-\u009F\u2000-\u200D\uFEFF]/gim
 const urlSchemeRegex = /^([^:]+):/gm
 const relativeFirstCharacters = ['.', '/']
-const isRelativeUrlWithoutProtocol = (url: string): boolean => {
+const isRelativeUrl = (url: string): boolean => {
   return relativeFirstCharacters.indexOf(url[0]) > -1
 }
 
 const sanitizeUrl = (url: string): string => {
   const sanitizedUrl = url.replace(ctrlCharactersRegex, '').trim()
 
-  if (isRelativeUrlWithoutProtocol(sanitizedUrl)) {
+  if (isRelativeUrl(sanitizedUrl)) {
     return sanitizedUrl
   }
 
@@ -34,4 +34,4 @@ const sanitizeUrl = (url: string): string => {
   return sanitizedUrl
 }
 
-export { trimTrailingSlash, isSameUrl, sanitizeUrl, isRelativeUrlWithoutProtocol }
+export { trimTrailingSlash, isSameUrl, sanitizeUrl, isRelativeUrl }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -34,4 +34,4 @@ const sanitizeUrl = (url: string): string => {
   return sanitizedUrl
 }
 
-export { trimTrailingSlash, isSameUrl, sanitizeUrl }
+export { trimTrailingSlash, isSameUrl, sanitizeUrl, isRelativeUrlWithoutProtocol }


### PR DESCRIPTION
## What it solves

Notifying users of invalid mastercopies

## How this PR fixes it

When switching Safes, the mastercopy is verified for validity and a notification dispatched if it is invalid.

## How to test it

Open a Safe with an invalid mastercopy (`matic:0x5B7e9a88237Ca67591e751186b10623Db5653045`) and observe the invalid mastercopy notification. Switching between Safes should trigger this only when the master copy is invalid. The CLI link should open in a new window.

Any currently present links, i.e. to update the Safe, should open in the current tab.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/191947037-6a56dc9e-c8b7-4519-8308-4fb259ef76fc.png)