### PR TITLE
test: add tests to `<SingleTx />`

### DIFF
--- a/src/components/transactions/SingleTx/SingleTx.test.tsx
+++ b/src/components/transactions/SingleTx/SingleTx.test.tsx
@@ -3,14 +3,13 @@ import SingleTx from '@/pages/transactions/tx'
 import * as useSafeInfo from '@/hooks/useSafeInfo'
 import { SafeInfo, TransactionDetails } from '@gnosis.pm/safe-react-gateway-sdk'
 
+const MOCK_SAFE_ADDRESS = '0x0000000000000000000000000000000000005AFE'
 const SAFE_ADDRESS = 'rin:0x87a57cBf742CC1Fc702D0E9BF595b1E056693e2f'
 
 jest.mock('next/router', () => ({
   useRouter() {
     return {
-      query: {
-        id: 'multisig_0x87a57cBf742CC1Fc702D0E9BF595b1E056693e2f_0x236da79434c398bf98b204e6f3d93d',
-      },
+      query: '',
     }
   },
 }))
@@ -41,10 +40,67 @@ const txDetails = {
 
 describe('SingleTx', () => {
   it('renders <SingleTx />', async () => {
+    const useRouter = jest.spyOn(require('next/router'), 'useRouter')
+    useRouter.mockImplementation(() => ({
+      query: {
+        id: 'multisig_0x87a57cBf742CC1Fc702D0E9BF595b1E056693e2f_0x236da79434c398bf98b204e6f3d93d',
+      },
+    }))
+
     const { getByTestId } = render(<SingleTx />)
 
     await act(() => Promise.resolve())
 
     expect(getByTestId('single-tx')).toBeInTheDocument()
+  })
+
+  it('renders <ErrorMessage /> when there is an error in the URL', async () => {
+    const useRouter = jest.spyOn(require('next/router'), 'useRouter')
+
+    useRouter.mockImplementation(() => ({
+      query: {
+        foo: 'multisig_0x87a57cBf742CC1Fc702D0E9BF595b1E056693e2f_0x236da79434c398bf98b204e6f3d93d',
+      },
+    }))
+
+    const { queryByText } = render(<SingleTx />)
+
+    expect(queryByText('Failed to load transaction')).toBeInTheDocument()
+  })
+
+  it('renders <ErrorMessage /> when the transaction is not found', async () => {
+    const useRouter = jest.spyOn(require('next/router'), 'useRouter')
+    useRouter.mockImplementation(() => ({
+      query: {
+        id: 'dummy',
+      },
+    }))
+
+    const { queryByText } = render(<SingleTx />)
+
+    expect(queryByText('Failed to load transaction')).toBeInTheDocument()
+  })
+
+  it('renders <ErrorMessage /> when transaction is not from the opened Safe', async () => {
+    const useRouter = jest.spyOn(require('next/router'), 'useRouter')
+    useRouter.mockImplementation(() => ({
+      query: {
+        id: 'multisig_0x87a57cBf742CC1Fc702D0E9BF595b1E056693e2f_0x236da79434c398bf98b204e6f3d93d',
+      },
+    }))
+
+    jest.spyOn(useSafeInfo, 'default').mockImplementation(() => ({
+      safeAddress: MOCK_SAFE_ADDRESS,
+      safe: {} as SafeInfo,
+      safeError: undefined,
+      safeLoading: false,
+      safeLoaded: true,
+    }))
+
+    const { queryByText } = render(<SingleTx />)
+
+    await act(() => Promise.resolve())
+
+    expect(queryByText('Failed to load transaction')).toBeInTheDocument()
   })
 })

--- a/src/components/transactions/SingleTx/SingleTx.test.tsx
+++ b/src/components/transactions/SingleTx/SingleTx.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from '@/tests/test-utils'
+import { act, fireEvent, render } from '@/tests/test-utils'
 import SingleTx from '@/pages/transactions/tx'
 import * as useSafeInfo from '@/hooks/useSafeInfo'
 import { SafeInfo, TransactionDetails } from '@gnosis.pm/safe-react-gateway-sdk'
@@ -54,7 +54,7 @@ describe('SingleTx', () => {
     expect(getByTestId('single-tx')).toBeInTheDocument()
   })
 
-  it('renders <ErrorMessage /> when there is an error in the URL', async () => {
+  it('renders <ErrorMessage /> and error description when there is an error in the URL', async () => {
     const useRouter = jest.spyOn(require('next/router'), 'useRouter')
 
     useRouter.mockImplementation(() => ({
@@ -66,9 +66,14 @@ describe('SingleTx', () => {
     const { queryByText } = render(<SingleTx />)
 
     expect(queryByText('Failed to load transaction')).toBeInTheDocument()
+
+    const button = queryByText('Details')
+    fireEvent.click(button!)
+
+    expect(queryByText("Couldn't retrieve the transaction details. Please review the URL.")).toBeInTheDocument()
   })
 
-  it('renders <ErrorMessage /> when the transaction is not found', async () => {
+  it('renders <ErrorMessage /> and error description when the transaction is not found', async () => {
     const useRouter = jest.spyOn(require('next/router'), 'useRouter')
     useRouter.mockImplementation(() => ({
       query: {
@@ -84,9 +89,14 @@ describe('SingleTx', () => {
     await act(() => Promise.resolve())
 
     expect(queryByText('Failed to load transaction')).toBeInTheDocument()
+
+    const button = queryByText('Details')
+    fireEvent.click(button!)
+
+    expect(queryByText('Transaction with id dummy not found in this Safe')).toBeInTheDocument()
   })
 
-  it('renders <ErrorMessage /> when transaction is not from the opened Safe', async () => {
+  it('renders <ErrorMessage /> and error description when transaction is not from the opened Safe', async () => {
     const useRouter = jest.spyOn(require('next/router'), 'useRouter')
     useRouter.mockImplementation(() => ({
       query: {
@@ -107,5 +117,14 @@ describe('SingleTx', () => {
     await act(() => Promise.resolve())
 
     expect(queryByText('Failed to load transaction')).toBeInTheDocument()
+
+    const button = queryByText('Details')
+    fireEvent.click(button!)
+
+    expect(
+      queryByText(
+        'Transaction with id multisig_0x87a57cBf742CC1Fc702D0E9BF595b1E056693e2f_0x236da79434c398bf98b204e6f3d93d not found in this Safe',
+      ),
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/transactions/SingleTx/SingleTx.test.tsx
+++ b/src/components/transactions/SingleTx/SingleTx.test.tsx
@@ -1,0 +1,50 @@
+import { act, render } from '@/tests/test-utils'
+import SingleTx from '@/pages/transactions/tx'
+import * as useSafeInfo from '@/hooks/useSafeInfo'
+import { SafeInfo, TransactionDetails } from '@gnosis.pm/safe-react-gateway-sdk'
+
+const SAFE_ADDRESS = 'rin:0x87a57cBf742CC1Fc702D0E9BF595b1E056693e2f'
+
+jest.mock('next/router', () => ({
+  useRouter() {
+    return {
+      query: {
+        id: 'multisig_0x87a57cBf742CC1Fc702D0E9BF595b1E056693e2f_0x236da79434c398bf98b204e6f3d93d',
+      },
+    }
+  },
+}))
+
+jest.mock('@gnosis.pm/safe-react-gateway-sdk', () => ({
+  ...jest.requireActual('@gnosis.pm/safe-react-gateway-sdk'),
+  getTransactionDetails: jest.fn(() => Promise.resolve(txDetails)),
+}))
+
+jest.spyOn(useSafeInfo, 'default').mockImplementation(() => ({
+  safeAddress: SAFE_ADDRESS,
+  safe: {} as SafeInfo,
+  safeError: undefined,
+  safeLoading: false,
+  safeLoaded: true,
+}))
+
+// Minimum mock to render <SingleTx />
+const txDetails = {
+  safeAddress: SAFE_ADDRESS,
+  txInfo: {
+    type: 'Custom',
+    to: {
+      value: '0xc778417E063141139Fce010982780140Aa0cD5Ab',
+    },
+  },
+} as TransactionDetails
+
+describe('SingleTx', () => {
+  it('renders <SingleTx />', async () => {
+    const { getByTestId } = render(<SingleTx />)
+
+    await act(() => Promise.resolve())
+
+    expect(getByTestId('single-tx')).toBeInTheDocument()
+  })
+})

--- a/src/components/transactions/SingleTx/SingleTx.test.tsx
+++ b/src/components/transactions/SingleTx/SingleTx.test.tsx
@@ -76,7 +76,12 @@ describe('SingleTx', () => {
       },
     }))
 
+    const getTransactionDetails = jest.spyOn(require('@gnosis.pm/safe-react-gateway-sdk'), 'getTransactionDetails')
+    getTransactionDetails.mockImplementation(() => Promise.resolve([]))
+
     const { queryByText } = render(<SingleTx />)
+
+    await act(() => Promise.resolve())
 
     expect(queryByText('Failed to load transaction')).toBeInTheDocument()
   })

--- a/src/components/transactions/SingleTx/index.tsx
+++ b/src/components/transactions/SingleTx/index.tsx
@@ -17,9 +17,9 @@ const SingleTxGrid = ({ txDetails }: { txDetails: TransactionDetails }): ReactEl
   const dateLabel: DateLabel = makeDateLabelFromTx(tx)
 
   return (
-    <TxListGrid data-testid="single-tx-grid">
+    <TxListGrid>
       <TxDateLabel item={dateLabel} />
-      <ExpandableTransactionItem item={tx} txDetails={txDetails} />
+      <ExpandableTransactionItem item={tx} txDetails={txDetails} testId="single-tx" />
     </TxListGrid>
   )
 }

--- a/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
+++ b/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
@@ -10,13 +10,18 @@ import { BatchExecuteHoverContext } from '@/components/transactions/BatchExecute
 import css from './styles.module.css'
 import classNames from 'classnames'
 
-interface ExpandableTransactionItemProps {
+type ExpandableTransactionItemProps = {
   isGrouped?: boolean
   item: Transaction
   txDetails?: TransactionDetails
 }
 
-export const ExpandableTransactionItem = ({ isGrouped = false, item, txDetails }: ExpandableTransactionItemProps) => {
+export const ExpandableTransactionItem = ({
+  isGrouped = false,
+  item,
+  txDetails,
+  testId,
+}: ExpandableTransactionItemProps & { testId?: string }) => {
   const hoverContext = useContext(BatchExecuteHoverContext)
 
   const isBatched = hoverContext.activeHover.includes(item.transaction.id)
@@ -31,6 +36,7 @@ export const ExpandableTransactionItem = ({ isGrouped = false, item, txDetails }
       elevation={0}
       defaultExpanded={!!txDetails}
       className={classNames({ [css.batched]: isBatched })}
+      data-testid={testId}
     >
       <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ justifyContent: 'flex-start', overflowX: 'auto' }}>
         <TxSummary item={item} isGrouped={isGrouped} />


### PR DESCRIPTION
## What it solves
<SingleTx /> tests (part of https://github.com/safe-global/web-core/pull/609)

Test cases:
1. Safe contains transaction (happy path)
2. Url is wrong
3. txId is wrong
4. Safe does not contain the transaction

