### PR TITLE
fix: use NFT placeholder in transaction list

### DIFF
--- a/src/components/transactions/TxType/index.tsx
+++ b/src/components/transactions/TxType/index.tsx
@@ -1,5 +1,6 @@
 import ImageFallback from '@/components/common/ImageFallback'
 import { useTransactionType } from '@/hooks/useTransactionType'
+import { isTransferTxInfo, isERC721Transfer } from '@/utils/transaction-guards'
 import { TransactionSummary } from '@gnosis.pm/safe-react-gateway-sdk'
 import { Box } from '@mui/material'
 import css from './styles.module.css'
@@ -11,9 +12,14 @@ type TxTypeProps = {
 const TxType = ({ tx }: TxTypeProps) => {
   const type = useTransactionType(tx)
 
+  const fallbackSrc =
+    isTransferTxInfo(tx.txInfo) && isERC721Transfer(tx.txInfo?.transferInfo)
+      ? '/images/nft-placeholder.png'
+      : '/images/custom.svg'
+
   return (
     <Box className={css.txType}>
-      <ImageFallback src={type.icon} fallbackSrc="/images/custom.svg" alt="transaction type" width={16} height={16} />
+      <ImageFallback src={type.icon} fallbackSrc={fallbackSrc} alt="Transaction type" width={16} height={16} />
       {type.text}
     </Box>
   )

--- a/src/hooks/useTransactionType.ts
+++ b/src/hooks/useTransactionType.ts
@@ -7,7 +7,7 @@ import {
   type TransactionSummary,
 } from '@gnosis.pm/safe-react-gateway-sdk'
 
-import { isCancellationTxInfo, isModuleExecutionInfo, isTxQueued } from '@/utils/transaction-guards'
+import { isCancellationTxInfo, isERC721Transfer, isModuleExecutionInfo, isTxQueued } from '@/utils/transaction-guards'
 import { DEFAULT_MODULE_NAME } from '@/components/settings/SafeModules'
 
 const getTxTo = ({ txInfo }: Pick<TransactionSummary, 'txInfo'>): AddressEx | undefined => {
@@ -45,9 +45,18 @@ const getTxType = (tx: TransactionSummary): TxType => {
     case TransactionInfoType.TRANSFER: {
       const isSendTx = tx.txInfo.direction === TransferDirection.OUTGOING
 
+      const text = isSendTx ? (isTxQueued(tx.txStatus) ? 'Send' : 'Sent') : 'Received'
+
+      if (isERC721Transfer(tx.txInfo.transferInfo)) {
+        return {
+          icon: tx.txInfo.transferInfo?.logoUri || '/images/nft-placeholder.png',
+          text,
+        }
+      }
+
       return {
         icon: isSendTx ? '/images/outgoing.svg' : '/images/incoming.svg',
-        text: isSendTx ? (isTxQueued(tx.txStatus) ? 'Send' : 'Sent') : 'Received',
+        text,
       }
     }
     case TransactionInfoType.SETTINGS_CHANGE: {


### PR DESCRIPTION
## What it solves

Resolves #628

## How this PR fixes it

ERC721 transfers now show the `logoUri` (if available) or fallback to the `nft-placeholder.png` when not.

## How to test it

The transaction list of `eth:0xc6400A5584db71e41B0E5dFbdC769b54B91256CD/transactions/history` contains many NFT transactions with no `logoUri`. Observe the placeholder.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/192233695-e2fb1837-09c9-40ae-b6d8-44985371d09e.png)

![image](https://user-images.githubusercontent.com/20442784/192233663-07af78a1-67b5-4a0f-aa6e-3dd94abd4471.png)
