### PR TITLE
fix: display collection image

### DIFF
--- a/src/components/nfts/NftGrid/index.tsx
+++ b/src/components/nfts/NftGrid/index.tsx
@@ -3,6 +3,7 @@ import groupBy from 'lodash/groupBy'
 import { Box, Divider, Grid, Typography } from '@mui/material'
 import { SafeCollectibleResponse } from '@gnosis.pm/safe-react-gateway-sdk'
 import NftCard from '../NftCard'
+import ImageFallback from '@/components/common/ImageFallback'
 
 const NftGrid = ({
   collectibles,
@@ -21,16 +22,19 @@ const NftGrid = ({
           <Box key={address} pb={4}>
             <Grid container alignItems="center" pb={2}>
               <Grid item xs={1}>
-                {logoUri && (
-                  <img src={logoUri} alt={`${tokenName} collection icon`} style={{ height: '45px', width: '45px' }} />
-                )}
+                <ImageFallback
+                  src={logoUri}
+                  alt={`${tokenName} collection icon`}
+                  fallbackSrc="/images/nft-placeholder.png"
+                  height="45px"
+                />
               </Grid>
-              <Grid item xs={1}>
-                <Typography variant="h6" mb={1}>
+              <Grid item>
+                <Typography variant="h6" mb={1} mr={2}>
                   {tokenName}
                 </Typography>
               </Grid>
-              <Grid item xs={10}>
+              <Grid item xs>
                 <Divider flexItem />
               </Grid>
             </Grid>

--- a/src/components/nfts/NftGrid/index.tsx
+++ b/src/components/nfts/NftGrid/index.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement } from 'react'
 import groupBy from 'lodash/groupBy'
-import { Box, Grid, Typography } from '@mui/material'
+import { Box, Divider, Grid, Typography } from '@mui/material'
 import { SafeCollectibleResponse } from '@gnosis.pm/safe-react-gateway-sdk'
 import NftCard from '../NftCard'
 
@@ -15,21 +15,36 @@ const NftGrid = ({
 
   return (
     <>
-      {Object.entries(collections).map(([address, nfts]) => (
-        <Box key={address} pb={4}>
-          <Typography variant="h6" mb={1}>
-            {nfts[0].tokenName}
-          </Typography>
-
-          <Grid container spacing={3}>
-            {nfts.map((nft) => (
-              <Grid item xs={12} md={4} lg={3} key={nft.address + nft.id}>
-                <NftCard nft={nft} onSendClick={onSendClick ? () => onSendClick(nft) : undefined} />
+      {Object.entries(collections).map(([address, nfts]) => {
+        const { logoUri, tokenName } = nfts[0]
+        return (
+          <Box key={address} pb={4}>
+            <Grid container alignItems="center" pb={2}>
+              <Grid item xs={1}>
+                {logoUri && (
+                  <img src={logoUri} alt={`${tokenName} collection icon`} style={{ height: '45px', width: '45px' }} />
+                )}
               </Grid>
-            ))}
-          </Grid>
-        </Box>
-      ))}
+              <Grid item xs={1}>
+                <Typography variant="h6" mb={1}>
+                  {tokenName}
+                </Typography>
+              </Grid>
+              <Grid item xs={10}>
+                <Divider flexItem />
+              </Grid>
+            </Grid>
+
+            <Grid container spacing={3}>
+              {nfts.map((nft) => (
+                <Grid item xs={12} md={4} lg={3} key={nft.address + nft.id}>
+                  <NftCard nft={nft} onSendClick={onSendClick ? () => onSendClick(nft) : undefined} />
+                </Grid>
+              ))}
+            </Grid>
+          </Box>
+        )
+      })}
     </>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves #634 

## How this PR fixes it

The collection `logoUri` is now displayed next to the title of an NFT collection.

## How to test it

Open `eth:0x8675B754342754A30A2AeF474D114d8460bca19b/balances/nfts` and observe the "Flowers" logo next to the collection title.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/192243619-a6ba0117-16c1-48ab-8cc6-2025d80698b6.png)