### PR TITLE
fix: Parse transaction values to string in safe apps modal

### DIFF
--- a/src/components/safe-apps/AppFrame/useAppCommunicator.ts
+++ b/src/components/safe-apps/AppFrame/useAppCommunicator.ts
@@ -20,6 +20,7 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import useIsGranted from '@/hooks/useIsGranted'
 import { useCurrentChain } from '@/hooks/useChains'
 import { createSafeAppsWeb3Provider } from '@/hooks/wallets/web3'
+import { BigNumber } from '@ethersproject/bignumber'
 
 export enum CommunicatorMessages {
   REJECT_TRANSACTION_MESSAGE = 'Transaction was rejected',
@@ -130,10 +131,13 @@ const useAppCommunicator = (
     communicator?.on(Methods.sendTransactions, (msg) => {
       const { txs, params } = msg.data.params as SendTransactionsParams
 
-      const transactions = txs.map(({ to, ...rest }) => ({
-        to: getAddress(to),
-        ...rest,
-      }))
+      const transactions = txs.map(({ to, value, ...rest }) => {
+        return {
+          to: getAddress(to),
+          value: BigNumber.from(value).toString(),
+          ...rest,
+        }
+      })
 
       onConfirmTransactions(transactions, msg.data.id, params)
     })


### PR DESCRIPTION
## What it solves

Resolves #631 

## How this PR fixes it

Transaction values in the communicator are parsed with BigNumber to make sure that they are strings and not hex to avoid incompatibility issues down the line like `safeTxGas` estimation. This is in line with how it is handled in [safe-react](https://github.com/safe-global/safe-react/blob/5625253248eec5bcb08b25242eebca110dd4afdd/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx#L58).

## How to test it

Follow steps from the issue: #631 

Other cases to test:

1. Open any safe app
2. Create a transaction
3. Observe no errors in the modal
