### PR TITLE
style: Align spending limit icons with their text

### DIFF
--- a/src/components/settings/SpendingLimits/NoSpendingLimits.tsx
+++ b/src/components/settings/SpendingLimits/NoSpendingLimits.tsx
@@ -11,7 +11,7 @@ export const NoSpendingLimits = () => {
         <BeneficiaryIcon />
       </Grid>
       <Grid item sm={10}>
-        <Typography marginTop={2}>
+        <Typography>
           <b>Select beneficiary</b>
         </Typography>
         <Typography>
@@ -24,7 +24,7 @@ export const NoSpendingLimits = () => {
         <AssetAmountIcon />
       </Grid>
       <Grid item sm={10}>
-        <Typography marginTop={2}>
+        <Typography>
           <b>Select asset and amount</b>
         </Typography>
         <Typography>You can set allowances for any asset stored in your Safe</Typography>
@@ -34,7 +34,7 @@ export const NoSpendingLimits = () => {
         <TimeIcon />
       </Grid>
       <Grid item sm={10}>
-        <Typography marginTop={2}>
+        <Typography>
           <b>Select time</b>
         </Typography>
         <Typography>


### PR DESCRIPTION
## What it solves

Resolves #619 

## How this PR fixes it

Removes top margin for the text elements. This was a leftover from when we had a different layout.

## How to test it

1. Open a Safe without spending limits
2. Navigate to Settings / Spending limits
3. Observe Icons are aligned with their text

## Screenshots

<img width="1262" alt="Screenshot 2022-09-26 at 13 05 25" src="https://user-images.githubusercontent.com/5880855/192261088-961ad0ca-3602-4e37-8e8c-3958117bda4d.png">
