### PR TITLE
fix: display NFT images in send form + truncate ID

### DIFF
--- a/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
+++ b/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
@@ -40,7 +40,7 @@ export type SendNftFormProps = {
 }
 
 const NftMenuItem = ({ image, name, description }: { image: string; name: string; description?: string }) => (
-  <Grid container spacing={1} alignItems="center" wrap="nowrap" overflow="hidden" textOverflow="ellipsis">
+  <Grid container spacing={1} alignItems="center" wrap="nowrap">
     <Grid item>
       <Box width={20} height={20} overflow="hidden">
         <ImageFallback src={image} fallbackSrc="/images/nft-placeholder.png" alt={name} height={20} />
@@ -49,7 +49,14 @@ const NftMenuItem = ({ image, name, description }: { image: string; name: string
     <Grid item>
       {name}
       {description && (
-        <Typography variant="caption" color="primary.light" display="block">
+        <Typography
+          variant="caption"
+          color="primary.light"
+          display="block"
+          width="80%"
+          overflow="hidden"
+          textOverflow="ellipsis"
+        >
           {description}
         </Typography>
       )}

--- a/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
+++ b/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
@@ -39,8 +39,8 @@ export type SendNftFormProps = {
   params?: NftTransferParams
 }
 
-const NftMenuItem = ({ image, name, count }: { image: string; name: string; count?: number }) => (
-  <Grid container spacing={1} alignItems="center">
+const NftMenuItem = ({ image, name, description }: { image: string; name: string; description?: string }) => (
+  <Grid container spacing={1} alignItems="center" wrap="nowrap" overflow="hidden" textOverflow="ellipsis">
     <Grid item>
       <Box width={20} height={20} overflow="hidden">
         <ImageFallback src={image} fallbackSrc="/images/nft-placeholder.png" alt={name} height={20} />
@@ -48,9 +48,9 @@ const NftMenuItem = ({ image, name, count }: { image: string; name: string; coun
     </Grid>
     <Grid item>
       {name}
-      {count && (
+      {description && (
         <Typography variant="caption" color="primary.light" display="block">
-          Count: {count} {name}
+          {description}
         </Typography>
       )}
     </Grid>
@@ -137,15 +137,18 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
                     )
                   }
                 >
-                  {collections.map((item) => (
-                    <MenuItem key={item.address} value={item.address}>
-                      <NftMenuItem
-                        image={item.imageUri || item.logoUri}
-                        name={item.tokenName}
-                        count={allNfts.filter((nft) => nft.address === item.address).length}
-                      />
-                    </MenuItem>
-                  ))}
+                  {collections.map((item) => {
+                    const count = allNfts.filter((nft) => nft.address === item.address).length
+                    return (
+                      <MenuItem key={item.address} value={item.address}>
+                        <NftMenuItem
+                          image={item.imageUri || item.logoUri}
+                          name={item.tokenName}
+                          description={`Count: ${count} ${name}`}
+                        />
+                      </MenuItem>
+                    )
+                  })}
                 </Select>
               )}
             />
@@ -165,7 +168,11 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
                 >
                   {selectedTokens.map((item) => (
                     <MenuItem key={item.address + item.id} value={item.id}>
-                      <NftMenuItem image={item.imageUri || item.logoUri} name={`${item.tokenName} #${item.id}`} />
+                      <NftMenuItem
+                        image={item.imageUri || item.logoUri}
+                        name={item.name || item.tokenName}
+                        description={`Token ID: ${item.id}`}
+                      />
                     </MenuItem>
                   ))}
                 </Select>

--- a/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
+++ b/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
@@ -39,26 +39,20 @@ export type SendNftFormProps = {
   params?: NftTransferParams
 }
 
-const NftMenuItem = ({ image, name }: { image: string; name: string }) => (
-  <Grid container spacing={1}>
+const NftMenuItem = ({ image, name, count }: { image: string; name: string; count?: number }) => (
+  <Grid container spacing={1} alignItems="center">
     <Grid item>
       <Box width={20} height={20} overflow="hidden">
         <ImageFallback src={image} fallbackSrc="/images/nft-placeholder.png" alt={name} height={20} />
       </Box>
     </Grid>
-    <Grid item>{name}</Grid>
-  </Grid>
-)
-
-const CollectionMenuItem = ({ address, name }: { address: string; name: string }) => (
-  <Grid container>
-    <Grid item pr={1}>
-      {name}
-    </Grid>
     <Grid item>
-      <Typography component="span" variant="body2" color="primary.light">
-        {address}
-      </Typography>
+      {name}
+      {count && (
+        <Typography variant="caption" color="primary.light" display="block">
+          Count: {count} {name}
+        </Typography>
+      )}
     </Grid>
   </Grid>
 )
@@ -145,7 +139,11 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
                 >
                   {collections.map((item) => (
                     <MenuItem key={item.address} value={item.address}>
-                      <CollectionMenuItem name={item.tokenName} address={item.address} />
+                      <NftMenuItem
+                        image={item.imageUri || item.logoUri}
+                        name={item.tokenName}
+                        count={allNfts.filter((nft) => nft.address === item.address).length}
+                      />
                     </MenuItem>
                   ))}
                 </Select>
@@ -167,7 +165,7 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
                 >
                   {selectedTokens.map((item) => (
                     <MenuItem key={item.address + item.id} value={item.id}>
-                      <NftMenuItem image={item.logoUri} name={`${item.tokenName} #${item.id}`} />
+                      <NftMenuItem image={item.imageUri || item.logoUri} name={`${item.tokenName} #${item.id}`} />
                     </MenuItem>
                   ))}
                 </Select>


### PR DESCRIPTION
## What it solves

Resolves #639 & #640

## How this PR fixes it

The `imageUri || logoUri` or fallback image of an NFT are now showing in the select fields for sending an NFT.

Token ID is now truncated when too long.

## How to test it

Open `rin:0x1230B3d59858296A31053C1b8562Ecf89A2f888b` and send attempt to send an NFT (using impersonator.xyz if necessary). Observe the (fallback) images shown accordingly.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/192269792-d03121a9-8458-4144-9351-7fc3500f3784.png)

![send nft](https://user-images.githubusercontent.com/20442784/192265182-faa02fdf-1878-4c29-a6dc-d4ffb654374f.gif)