### PR TITLE
fix: Allow blobs in CSP

### DIFF
--- a/src/config/securityHeaders.ts
+++ b/src/config/securityHeaders.ts
@@ -18,6 +18,7 @@ export const ContentSecurityPolicy = `
  frame-src *;
  style-src 'self' 'unsafe-inline' https://*.getbeamer.com https://*.googleapis.com;
  font-src 'self' data:; 
+ worker-src 'self' blob:;
  img-src * data:;
 `
   .replace(/\s{2,}/g, ' ')


### PR DESCRIPTION
## What it solves

Resolves #629 

Opening the QR file upload spawns a worker that tries to access a `blob`.

## How this PR fixes it

Allows `blob` in the CSP

## How to test it

1. Open the Safe
2. Create a new Safe
3. Open the QR Modal when adding a new owner
4. Observe app not crashing
