### PR TITLE
feat: add NFT apps to assets page

### DIFF
--- a/src/components/nfts/NftGrid/index.tsx
+++ b/src/components/nfts/NftGrid/index.tsx
@@ -16,8 +16,8 @@ const NftGrid = ({
   return (
     <>
       {Object.entries(collections).map(([address, nfts]) => (
-        <Box key={address} pb={4}>
-          <Typography variant="h6" mb={1}>
+        <Box key={address}>
+          <Typography component="h2" variant="subtitle1" fontWeight={700} my={2}>
             {nfts[0].tokenName}
           </Typography>
 

--- a/src/pages/balances/nfts.tsx
+++ b/src/pages/balances/nfts.tsx
@@ -1,7 +1,7 @@
-import { type ReactElement, useState } from 'react'
+import { type ReactElement, useState, useMemo } from 'react'
 import type { NextPage } from 'next'
 import Head from 'next/head'
-import { Alert, AlertTitle, Box, CircularProgress } from '@mui/material'
+import { Alert, AlertTitle, Box, CircularProgress, Grid, Typography } from '@mui/material'
 import useCollectibles from '@/hooks/useCollectibles'
 import Nfts from '@/components/nfts'
 import { Breadcrumbs } from '@/components/common/Breadcrumbs'
@@ -12,6 +12,8 @@ import ErrorMessage from '@/components/tx/ErrorMessage'
 import InfiniteScroll from '@/components/common/InfiniteScroll'
 import PagePlaceholder from '@/components/common/PagePlaceholder'
 import NftIcon from '@/public/images/nft.svg'
+import { useSafeApps } from '@/hooks/safe-apps/useSafeApps'
+import { AppCard } from '@/components/safe-apps/AppCard'
 
 const NftPage = ({
   pageUrl,
@@ -51,6 +53,24 @@ const NftPage = ({
   )
 }
 
+const NftApps = (): ReactElement => {
+  const NFT_APPS_TAG = 'nft'
+
+  const { allSafeApps } = useSafeApps()
+
+  const nftApps = useMemo(() => allSafeApps.filter((app) => app.tags?.includes(NFT_APPS_TAG)), [allSafeApps])
+
+  return (
+    <Grid container spacing={3}>
+      {nftApps.map((nftApp) => (
+        <Grid item xs={12} md={4} lg={3} key={nftApp.id}>
+          <AppCard safeApp={nftApp} />
+        </Grid>
+      ))}
+    </Grid>
+  )
+}
+
 const NFTs: NextPage = () => {
   const [pages, setPages] = useState<string[]>([''])
 
@@ -69,10 +89,20 @@ const NFTs: NextPage = () => {
       <NavTabs tabs={balancesNavItems} />
 
       <Box py={3}>
-        <Alert severity="info" sx={{ marginBottom: 6 }}>
+        <Alert severity="info">
           <AlertTitle>Use Safe Apps to view your NFT portfolio</AlertTitle>
           Get the most optimal experience with Safe Apps. View your collections, buy or sell NFTs, and more.
         </Alert>
+
+        <Typography component="h2" variant="subtitle1" fontWeight={700} my={2}>
+          NFT Apps
+        </Typography>
+
+        <NftApps />
+
+        <Typography component="h2" variant="subtitle1" fontWeight={700} my={2}>
+          NFTs
+        </Typography>
 
         {pages.map((pageUrl, index) => (
           <NftPage key={index} pageUrl={pageUrl} onNextPage={index === pages.length - 1 ? onNextPage : undefined} />

--- a/src/pages/balances/nfts.tsx
+++ b/src/pages/balances/nfts.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useState, useMemo } from 'react'
+import { type ReactElement, useState, useMemo, memo } from 'react'
 import type { NextPage } from 'next'
 import Head from 'next/head'
 import { Alert, AlertTitle, Box, CircularProgress, Grid, Typography } from '@mui/material'
@@ -53,12 +53,13 @@ const NftPage = ({
   )
 }
 
-const NftApps = (): ReactElement | null => {
+// `React.memo` requires a `displayName`
+const NftApps = memo(function NftApps(): ReactElement | null {
   const NFT_APPS_TAG = 'nft'
 
   const { allSafeApps } = useSafeApps()
 
-  const nftApps = useMemo(() => allSafeApps.filter((app) => app.tags?.includes(NFT_APPS_TAG)), [allSafeApps])
+  const nftApps = useMemo(() => allSafeApps.filter((app) => app.tags.includes(NFT_APPS_TAG)), [allSafeApps])
 
   if (nftApps.length === 0) {
     return null
@@ -78,7 +79,7 @@ const NftApps = (): ReactElement | null => {
       </Grid>
     </>
   )
-}
+})
 
 const NFTs: NextPage = () => {
   const [pages, setPages] = useState<string[]>([''])

--- a/src/pages/balances/nfts.tsx
+++ b/src/pages/balances/nfts.tsx
@@ -53,12 +53,16 @@ const NftPage = ({
   )
 }
 
-const NftApps = (): ReactElement => {
+const NftApps = (): ReactElement | null => {
   const NFT_APPS_TAG = 'nft'
 
   const { allSafeApps } = useSafeApps()
 
   const nftApps = useMemo(() => allSafeApps.filter((app) => app.tags?.includes(NFT_APPS_TAG)), [allSafeApps])
+
+  if (nftApps.length === 0) {
+    return null
+  }
 
   return (
     <Grid container spacing={3}>

--- a/src/pages/balances/nfts.tsx
+++ b/src/pages/balances/nfts.tsx
@@ -65,13 +65,18 @@ const NftApps = (): ReactElement | null => {
   }
 
   return (
-    <Grid container spacing={3}>
-      {nftApps.map((nftApp) => (
-        <Grid item xs={12} md={4} lg={3} key={nftApp.id}>
-          <AppCard safeApp={nftApp} />
-        </Grid>
-      ))}
-    </Grid>
+    <>
+      <Typography component="h2" variant="subtitle1" fontWeight={700} my={2}>
+        NFT Apps
+      </Typography>
+      <Grid container spacing={3}>
+        {nftApps.map((nftApp) => (
+          <Grid item xs={12} md={4} lg={3} key={nftApp.id}>
+            <AppCard safeApp={nftApp} />
+          </Grid>
+        ))}
+      </Grid>
+    </>
   )
 }
 
@@ -98,15 +103,7 @@ const NFTs: NextPage = () => {
           Get the most optimal experience with Safe Apps. View your collections, buy or sell NFTs, and more.
         </Alert>
 
-        <Typography component="h2" variant="subtitle1" fontWeight={700} my={2}>
-          NFT Apps
-        </Typography>
-
         <NftApps />
-
-        <Typography component="h2" variant="subtitle1" fontWeight={700} my={2}>
-          NFTs
-        </Typography>
 
         {pages.map((pageUrl, index) => (
           <NftPage key={index} pageUrl={pageUrl} onNextPage={index === pages.length - 1 ? onNextPage : undefined} />


### PR DESCRIPTION
## What it solves

Resolves #638

## How this PR fixes it

A new `NFTApps` component, which displays apps tagged with `'nfts'`, has been added to the top of the NFTs page. If no tagged apps were found, it does not show.

## How to test it

Open the NFTs page and observe the NFT apps.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/192279895-23aca7ff-1636-4447-a929-6c7a8eab02fa.png)