### PR TITLE
style: Adjust disabled text color in dark mode palette

### DIFF
--- a/src/styles/colors-dark.ts
+++ b/src/styles/colors-dark.ts
@@ -2,7 +2,7 @@ const darkPalette = {
   text: {
     primary: '#FFFFFF',
     secondary: '#636669',
-    disabled: '#303033',
+    disabled: '#636669',
   },
   primary: {
     dark: '#0cb259',

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -54,7 +54,7 @@
 [data-theme='dark'] {
   --color-text-primary: #ffffff;
   --color-text-secondary: #636669;
-  --color-text-disabled: #303033;
+  --color-text-disabled: #636669;
   --color-primary-dark: #0cb259;
   --color-primary-main: #12ff80;
   --color-primary-light: #a1a3a7;


### PR DESCRIPTION
## What it solves

Resolves #618 

## How this PR fixes it

Changes the color of disabled text from #303033 to #636669 in dark mode for better visibility

## How to test it

1. Open the Safe
2. Enable dark mode
3. Execute a queued transaction
4. Edit gas parameters
5. Observe the disabled field(s) text being more visible 

## Screenshots
<img width="636" alt="Screenshot 2022-09-26 at 15 03 09" src="https://user-images.githubusercontent.com/5880855/192283542-a1953b9f-1226-41c6-b803-a90898d5a1b9.png">
