### PR TITLE
fix: jumpy review tx modal

### DIFF
--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -69,7 +69,7 @@ const GasParams = ({ params, isExecution, onEdit }: GasParamsProps): ReactElemen
         ) : (
           <Typography>
             Signing the transaction with nonce&nbsp;
-            {nonce !== 0 || safeNonce === 0 ? (
+            {nonce !== undefined ? (
               nonce
             ) : (
               <Skeleton variant="text" sx={{ display: 'inline-block', minWidth: '2em' }} />

--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -4,7 +4,6 @@ import { useCurrentChain } from '@/hooks/useChains'
 import { formatVisualAmount } from '@/utils/formatters'
 import { type AdvancedParameters } from '../AdvancedParams/types'
 import { trackEvent, MODALS_EVENTS } from '@/services/analytics'
-import useSafeInfo from '@/hooks/useSafeInfo'
 
 const GasDetail = ({ name, value, isLoading }: { name: string; value: string; isLoading: boolean }): ReactElement => {
   const valueSkeleton = <Skeleton variant="text" sx={{ minWidth: '5em' }} />
@@ -26,8 +25,6 @@ type GasParamsProps = {
 
 const GasParams = ({ params, isExecution, onEdit }: GasParamsProps): ReactElement => {
   const { nonce, userNonce, safeTxGas, gasLimit, maxFeePerGas, maxPriorityFeePerGas } = params
-  const { safe } = useSafeInfo()
-  const safeNonce = safe.nonce
 
   const onChangeExpand = (_: SyntheticEvent, expanded: boolean) => {
     trackEvent({ ...MODALS_EVENTS.ESTIMATION, label: expanded ? 'Open' : 'Close' })

--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -4,6 +4,7 @@ import { useCurrentChain } from '@/hooks/useChains'
 import { formatVisualAmount } from '@/utils/formatters'
 import { type AdvancedParameters } from '../AdvancedParams/types'
 import { trackEvent, MODALS_EVENTS } from '@/services/analytics'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 const GasDetail = ({ name, value, isLoading }: { name: string; value: string; isLoading: boolean }): ReactElement => {
   const valueSkeleton = <Skeleton variant="text" sx={{ minWidth: '5em' }} />
@@ -25,6 +26,8 @@ type GasParamsProps = {
 
 const GasParams = ({ params, isExecution, onEdit }: GasParamsProps): ReactElement => {
   const { nonce, userNonce, safeTxGas, gasLimit, maxFeePerGas, maxPriorityFeePerGas } = params
+  const { safe } = useSafeInfo()
+  const safeNonce = safe.nonce
 
   const onChangeExpand = (_: SyntheticEvent, expanded: boolean) => {
     trackEvent({ ...MODALS_EVENTS.ESTIMATION, label: expanded ? 'Open' : 'Close' })
@@ -66,7 +69,7 @@ const GasParams = ({ params, isExecution, onEdit }: GasParamsProps): ReactElemen
         ) : (
           <Typography>
             Signing the transaction with nonce&nbsp;
-            {nonce !== undefined ? (
+            {nonce !== 0 || safeNonce === 0 ? (
               nonce
             ) : (
               <Skeleton variant="text" sx={{ display: 'inline-block', minWidth: '2em' }} />

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -76,7 +76,7 @@ const SignOrExecuteForm = ({
   const { gasLimit, gasLimitError, gasLimitLoading } = useGasLimit(willExecute ? tx : undefined)
 
   const [advancedParams, setAdvancedParams] = useAdvancedParams({
-    nonce: tx?.data.nonce || 0,
+    nonce: tx?.data.nonce,
     gasLimit,
     safeTxGas: tx?.data.safeTxGas,
   })

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -191,14 +191,12 @@ const SignOrExecuteForm = ({
           onFormSubmit={onAdvancedSubmit}
         />
 
-        {safeTx && (
-          <TxSimulation
-            gasLimit={advancedParams.gasLimit?.toNumber()}
-            transactions={safeTx}
-            canExecute={canExecute}
-            disabled={submitDisabled}
-          />
-        )}
+        <TxSimulation
+          gasLimit={advancedParams.gasLimit?.toNumber()}
+          transactions={safeTx}
+          canExecute={canExecute}
+          disabled={submitDisabled}
+        />
 
         {(error || (willExecute && gasLimitError)) && (
           <ErrorMessage error={error || gasLimitError}>

--- a/src/components/tx/TxSimulation/index.tsx
+++ b/src/components/tx/TxSimulation/index.tsx
@@ -1,4 +1,4 @@
-import { AccordionSummary, Accordion, Button, Typography, CircularProgress } from '@mui/material'
+import { AccordionSummary, Accordion, Button, Typography, CircularProgress, Skeleton, Box } from '@mui/material'
 import { ReactElement } from 'react'
 
 import Track from '@/components/common/Track'
@@ -16,7 +16,7 @@ import css from './styles.module.css'
 import classNames from 'classnames'
 
 export type TxSimulationProps = {
-  transactions: SimulationTxParams['transactions']
+  transactions?: SimulationTxParams['transactions']
   gasLimit?: number
   canExecute: boolean
   disabled: boolean
@@ -84,6 +84,16 @@ export const TxSimulation = (props: TxSimulationProps): ReactElement | null => {
   const chain = useCurrentChain()
   if (!chain || !isTxSimulationEnabled(chain)) {
     return null
+  }
+
+  if (!props.transactions) {
+    return (
+      <Box sx={{ mt: 2 }}>
+        <div className={css.skeletonWrapper}>
+          <Skeleton variant="rectangular" height={58} />
+        </div>
+      </Box>
+    )
   }
 
   return <TxSimulationBlock {...props} />

--- a/src/components/tx/TxSimulation/index.tsx
+++ b/src/components/tx/TxSimulation/index.tsx
@@ -1,4 +1,4 @@
-import { AccordionSummary, Accordion, Button, Typography, CircularProgress, Skeleton, Box } from '@mui/material'
+import { AccordionSummary, Accordion, Button, Typography, CircularProgress, Skeleton } from '@mui/material'
 import { ReactElement } from 'react'
 
 import Track from '@/components/common/Track'
@@ -88,11 +88,9 @@ export const TxSimulation = (props: TxSimulationProps): ReactElement | null => {
 
   if (!props.transactions) {
     return (
-      <Box sx={{ mt: 2 }}>
-        <div className={css.skeletonWrapper}>
-          <Skeleton variant="rectangular" height={58} />
-        </div>
-      </Box>
+      <div className={css.skeletonWrapper}>
+        <Skeleton variant="rectangular" height={58} />
+      </div>
     )
   }
 

--- a/src/components/tx/TxSimulation/styles.module.css
+++ b/src/components/tx/TxSimulation/styles.module.css
@@ -14,4 +14,5 @@
 .skeletonWrapper {
   border-radius: 8px;
   overflow: hidden;
+  margin-top: var(--space-2);
 }

--- a/src/components/tx/TxSimulation/styles.module.css
+++ b/src/components/tx/TxSimulation/styles.module.css
@@ -10,3 +10,8 @@
 .result {
   border: none;
 }
+
+.skeletonWrapper {
+  border-radius: 8px;
+  overflow: hidden;
+}


### PR DESCRIPTION
## What it solves
- do not display nonce `0` while waiting for the estimations endpoint
- renders a Skeleton while waiting for the Simulation parameters

## How to test it
1. Go to a Safe and create a transaction
2. On the review modal, while the nonce is being retrieved, a Skeleton is displayed
3. In the same modal, a Skeleton component displays before the Simulation's accordion

## Screenshots
![Screenshot 2022-09-26 at 15 33 17](https://user-images.githubusercontent.com/32431609/192290132-cd694674-56fb-4a8a-8eb5-c07a3c7e7745.png)
