### PR TITLE
fix: show total of queued transactions by nonce

### DIFF
--- a/src/components/dashboard/PendingTxs/PendingTxsList.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxsList.tsx
@@ -88,7 +88,7 @@ const PendingTxsList = ({ size = 4 }: { size?: number }): ReactElement | null =>
         <Typography component="h2" variant="subtitle1" fontWeight={700} mb={2}>
           Transaction queue {totalQueuedTxs ? ` (${totalQueuedTxs})` : ''}
         </Typography>
-        {totalQueuedTxs !== '0' && <ViewAllLink url={url} />}
+        {queuedTxns.length > 0 && <ViewAllLink url={url} />}
       </StyledWidgetTitle>
       <WidgetBody>{getWidgetBody()}</WidgetBody>
     </WidgetContainer>

--- a/src/components/dashboard/PendingTxs/PendingTxsList.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxsList.tsx
@@ -11,6 +11,7 @@ import useTxQueue from '@/hooks/useTxQueue'
 import { AppRoutes } from '@/config/routes'
 import PagePlaceholder from '@/components/common/PagePlaceholder'
 import NoTransactionsIcon from '@/public/images/no-transactions.svg'
+import { getQueuedTransactionCount } from '@/utils/transactions'
 
 const SkeletonWrapper = styled.div`
   border-radius: 8px;
@@ -49,7 +50,7 @@ const PendingTxsList = ({ size = 4 }: { size?: number }): ReactElement | null =>
     isMultisigExecutionInfo(item.transaction.executionInfo) ? item.transaction.executionInfo.nonce : '',
   ).slice(0, size)
 
-  const totalQueuedTxs = queuedTxns.length
+  const totalQueuedTxs = getQueuedTransactionCount(page)
 
   const LoadingState = useMemo(
     () => (
@@ -87,7 +88,7 @@ const PendingTxsList = ({ size = 4 }: { size?: number }): ReactElement | null =>
         <Typography component="h2" variant="subtitle1" fontWeight={700} mb={2}>
           Transaction queue {totalQueuedTxs ? ` (${totalQueuedTxs})` : ''}
         </Typography>
-        {totalQueuedTxs > 0 && <ViewAllLink url={url} />}
+        {totalQueuedTxs !== '0' && <ViewAllLink url={url} />}
       </StyledWidgetTitle>
       <WidgetBody>{getWidgetBody()}</WidgetBody>
     </WidgetContainer>

--- a/src/utils/__tests__/transactions.test.ts
+++ b/src/utils/__tests__/transactions.test.ts
@@ -1,0 +1,62 @@
+import { ConflictHeader, DateLabel, Label, Transaction } from '@gnosis.pm/safe-react-gateway-sdk'
+import { getQueuedTransactionCount } from '../transactions'
+
+describe('transactions', () => {
+  describe('getQueuedTransactionCount', () => {
+    it('should return 0 if no txPage is provided', () => {
+      expect(getQueuedTransactionCount()).toBe('0')
+    })
+
+    it('should return 0 if no results exist', () => {
+      const txPage = {
+        next: undefined,
+        previous: undefined,
+        results: [],
+      }
+      expect(getQueuedTransactionCount(txPage)).toBe('0')
+    })
+
+    it('should only return the count of transactions', () => {
+      const txPage = {
+        next: undefined,
+        previous: undefined,
+        results: [
+          { timestamp: 0, type: 'DATE_LABEL' } as DateLabel,
+          { label: 'Next', type: 'LABEL' } as Label,
+          { nonce: 0, type: 'CONFLICT_HEADER' } as ConflictHeader,
+        ],
+      }
+      expect(getQueuedTransactionCount(txPage)).toBe('0')
+    })
+
+    it('should return > n if there is a next page', () => {
+      const txPage = {
+        next: 'fakeNextUrl.com',
+        previous: undefined,
+        results: [
+          { type: 'TRANSACTION', transaction: { executionInfo: { type: 'MULTISIG', nonce: 0 } } } as Transaction,
+          { type: 'TRANSACTION', transaction: { executionInfo: { type: 'MULTISIG', nonce: 1 } } } as Transaction,
+        ],
+      }
+      expect(getQueuedTransactionCount(txPage)).toBe('> 2')
+    })
+
+    it('should only count transactions of different nonces', () => {
+      const txPage = {
+        next: undefined,
+        previous: undefined,
+        results: [
+          {
+            type: 'TRANSACTION',
+            transaction: { executionInfo: { type: 'MULTISIG', nonce: 0 } },
+          } as Transaction,
+          {
+            type: 'TRANSACTION',
+            transaction: { executionInfo: { type: 'MULTISIG', nonce: 0 } },
+          } as Transaction,
+        ],
+      }
+      expect(getQueuedTransactionCount(txPage)).toBe('1')
+    })
+  })
+})


### PR DESCRIPTION
## What it solves

Resolves #624

## How this PR fixes it

The queue count is calculated based on differing nonces.

## How to test it

Queue a transaction and create a rejection for it. Observe that the dashboard does not count two, but one.