### PR TITLE
Fix: sent NFT preview

### DIFF
--- a/src/components/dashboard/Overview/Overview.tsx
+++ b/src/components/dashboard/Overview/Overview.tsx
@@ -12,6 +12,7 @@ import ChainIndicator from '@/components/common/ChainIndicator'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { AppRoutes } from '@/config/routes'
 import useSafeAddress from '@/hooks/useSafeAddress'
+import useCollectibles from '@/hooks/useCollectibles'
 
 const IdenticonContainer = styled.div`
   position: relative;
@@ -34,7 +35,7 @@ const NetworkLabelContainer = styled.div`
   }
 `
 
-const ValueSkeleton = <Skeleton variant="text" width={30} />
+const ValueSkeleton = () => <Skeleton variant="text" width={30} />
 
 const SkeletonOverview = (
   <Card>
@@ -60,13 +61,17 @@ const SkeletonOverview = (
         <Typography color="inputDefault" fontSize="lg">
           Tokens
         </Typography>
-        <StyledText fontSize="lg">{ValueSkeleton}</StyledText>
+        <StyledText fontSize="lg">
+          <ValueSkeleton />
+        </StyledText>
       </Grid>
       <Grid item xs={3}>
         <Typography color="inputDefault" fontSize="lg">
           NFTs
         </Typography>
-        <StyledText fontSize="lg">{ValueSkeleton}</StyledText>
+        <StyledText fontSize="lg">
+          <ValueSkeleton />
+        </StyledText>
       </Grid>
     </Grid>
   </Card>
@@ -77,12 +82,15 @@ const Overview = (): ReactElement => {
   const safeAddress = useSafeAddress()
   const { safe, safeLoading } = useSafeInfo()
   const { balances } = useBalances()
+  const [nfts] = useCollectibles()
   const chain = useCurrentChain()
   const { chainId } = chain || {}
   const assetsLink = `${AppRoutes.balances.index}?safe=${router.query.safe}`
+  const nftsLink = `${AppRoutes.balances.nfts}?safe=${router.query.safe}`
 
   // Native token is always returned even when its balance is 0
   const tokenCount = useMemo(() => balances.items.filter((token) => token.balance !== '0').length, [balances])
+  const nftsCount = useMemo(() => (nfts ? `${nfts.next ? '>' : ''}${nfts.results.length}` : ''), [nfts])
 
   return (
     <WidgetContainer>
@@ -112,13 +120,24 @@ const Overview = (): ReactElement => {
             </Box>
 
             <Grid container>
-              <Grid item xs>
+              <Grid item xs={3}>
                 <Link href={assetsLink}>
                   <a>
                     <Typography color="border.main" variant="body2">
                       Tokens
                     </Typography>
                     <StyledText fontSize="lg">{tokenCount}</StyledText>
+                  </a>
+                </Link>
+              </Grid>
+
+              <Grid item xs={3}>
+                <Link href={nftsLink}>
+                  <a>
+                    <Typography color="inputDefault" fontSize="lg">
+                      NFTs
+                    </Typography>
+                    <StyledText fontSize="lg">{nftsCount || <ValueSkeleton />}</StyledText>
                   </a>
                 </Link>
               </Grid>

--- a/src/components/dashboard/Overview/Overview.tsx
+++ b/src/components/dashboard/Overview/Overview.tsx
@@ -134,7 +134,7 @@ const Overview = (): ReactElement => {
               <Grid item xs={3}>
                 <Link href={nftsLink}>
                   <a>
-                    <Typography color="inputDefault" fontSize="lg">
+                    <Typography color="border.main" variant="body2">
                       NFTs
                     </Typography>
                     <StyledText fontSize="lg">{nftsCount || <ValueSkeleton />}</StyledText>

--- a/src/components/tx/SendFromBlock/index.tsx
+++ b/src/components/tx/SendFromBlock/index.tsx
@@ -1,9 +1,10 @@
 import { type ReactElement } from 'react'
+import { Box, Typography } from '@mui/material'
+import SouthIcon from '@mui/icons-material/South'
 import css from './styles.module.css'
 import useBalances from '@/hooks/useBalances'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import { formatVisualAmount } from '@/utils/formatters'
-import { Box, Typography } from '@mui/material'
 import EthHashInfo from '@/components/common/EthHashInfo'
 
 const SendFromBlock = (): ReactElement => {
@@ -13,7 +14,7 @@ const SendFromBlock = (): ReactElement => {
   const nativeTokenBalance = nativeToken ? formatVisualAmount(nativeToken.balance, nativeToken.tokenInfo.decimals) : '0'
 
   return (
-    <Box sx={{ borderBottom: ({ palette }) => `1px solid ${palette.divider}` }} pb={2} mb={2}>
+    <Box className={css.container} pb={2} mb={2}>
       <Typography color={({ palette }) => palette.text.secondary} pb={1}>
         Sending from
       </Typography>
@@ -30,6 +31,8 @@ const SendFromBlock = (): ReactElement => {
           </b>
         </Box>
       )}
+
+      <SouthIcon className={css.arrow} />
     </Box>
   )
 }

--- a/src/components/tx/SendFromBlock/styles.module.css
+++ b/src/components/tx/SendFromBlock/styles.module.css
@@ -1,3 +1,17 @@
+.container {
+  border-bottom: 2px solid var(--color-border-light);
+  position: relative;
+}
+
+.arrow {
+  position: absolute;
+  bottom: -12px;
+  left: 50%;
+  margin-left: -12px;
+  color: var(--color-border-light);
+  background-color: var(--color-background-paper);
+}
+
 .balance {
   font-size: 12px;
   line-height: 1.08;

--- a/src/components/tx/modals/NftTransferModal/ReviewNftTx.tsx
+++ b/src/components/tx/modals/NftTransferModal/ReviewNftTx.tsx
@@ -9,6 +9,7 @@ import { createNftTransferParams } from '@/services/tx/tokenTransferParams'
 import { createTx } from '@/services/tx/txSender'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { type NftTransferParams } from '.'
+import ImageFallback from '@/components/common/ImageFallback'
 
 type ReviewNftTxProps = {
   params: NftTransferParams
@@ -17,6 +18,7 @@ type ReviewNftTxProps = {
 
 const ReviewNftTx = ({ params, onSubmit }: ReviewNftTxProps): ReactElement => {
   const { safeAddress, safe } = useSafeInfo()
+  const { token } = params
 
   const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
     if (!safeAddress) return
@@ -26,6 +28,19 @@ const ReviewNftTx = ({ params, onSubmit }: ReviewNftTxProps): ReactElement => {
 
   return (
     <SignOrExecuteForm safeTx={safeTx} isExecutable={safe.threshold === 1} onSubmit={onSubmit} error={safeTxError}>
+      <Box display="flex" flexDirection="column" alignItems="center">
+        <ImageFallback
+          src={token.imageUri || token.logoUri}
+          fallbackSrc="/images/nft-placeholder.png"
+          alt={token.tokenSymbol}
+          height={60}
+          style={{ borderRadius: 4, marginBottom: 'var(--space-1)' }}
+        />
+
+        <Typography color="text.secondary">{token.tokenName}</Typography>
+        <Typography>{token.name || `${token.tokenName} #${token.id}`}</Typography>
+      </Box>
+
       <SendFromBlock />
 
       <Typography color={({ palette }) => palette.text.secondary} pb={1}>

--- a/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
+++ b/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
@@ -120,7 +120,7 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
         <DialogContent>
           <SendFromBlock />
 
-          <FormControl fullWidth sx={{ mb: 2 }}>
+          <FormControl fullWidth sx={{ mb: 2, mt: 1 }}>
             <AddressBookInput name={Field.recipient} label="Recipient" />
           </FormControl>
 

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -104,7 +104,7 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
         <DialogContent>
           <SendFromBlock />
 
-          <FormControl fullWidth sx={{ mb: 2 }}>
+          <FormControl fullWidth sx={{ mb: 2, mt: 1 }}>
             <AddressBookInput name={SendAssetsField.recipient} label="Recipient" />
           </FormControl>
 


### PR DESCRIPTION
## What it solves

Resolves #642

## How this PR fixes it
Adds an NFT preview, in a similar style as the token transfer.
<img width="651" alt="Screenshot 2022-09-26 at 17 00 21" src="https://user-images.githubusercontent.com/381895/192314852-0c0ca38b-0dfd-45d6-ad8d-af4f099aaa74.png">

<img width="623" alt="Screenshot 2022-09-26 at 17 03 39" src="https://user-images.githubusercontent.com/381895/192314912-283a391f-e14d-4a29-aa97-2267544ad2f2.png">

I also restored the NFT count on the Dashboard, using Aaron's Invention™️. 
<img width="560" alt="Screenshot 2022-09-26 at 17 13 38" src="https://user-images.githubusercontent.com/381895/192314891-334f9048-1830-4147-87b3-fd8004aa70f4.png">

## How to test it
Send some NFT.