### PR TITLE
fix: add nonce of transaction to execute to label

### DIFF
--- a/src/components/transactions/GroupLabel/index.test.ts
+++ b/src/components/transactions/GroupLabel/index.test.ts
@@ -1,0 +1,124 @@
+import { renderHook } from '@/tests/test-utils'
+import { Label, SafeInfo, Transaction } from '@gnosis.pm/safe-react-gateway-sdk'
+import { useGroupLabel } from '.'
+import * as useSafeInfoHook from '@/hooks/useSafeInfo'
+import * as useTxQueueHook from '@/hooks/useTxQueue'
+
+describe('GroupLabel', () => {
+  describe('useGroupLabel', () => {
+    it('should return Next if given a Next label', () => {
+      const label = {
+        label: 'Next',
+        type: 'LABEL',
+      } as Label
+
+      const { result } = renderHook(() => useGroupLabel(label))
+
+      expect(result.current).toBe('Next')
+    })
+
+    it('should return Next if given there is no multisig transaction in the page', () => {
+      const label = {
+        label: 'Next',
+        type: 'LABEL',
+      } as Label
+
+      jest.spyOn(useTxQueueHook, 'default').mockImplementation(() => ({
+        loading: false,
+        page: {
+          results: [
+            // Label
+            label,
+            // Module transaction
+            {
+              transaction: {
+                executionInfo: { type: 'MODULE' },
+              },
+            } as Transaction,
+          ],
+        },
+      }))
+
+      const { result } = renderHook(() => useGroupLabel(label))
+
+      expect(result.current).toBe('Next')
+    })
+
+    it('should return a modified Queue label when there is a Queued and Next label in the page', () => {
+      const label = {
+        label: 'Queued',
+        type: 'LABEL',
+      } as Label
+
+      jest.spyOn(useTxQueueHook, 'default').mockImplementation(() => ({
+        loading: false,
+        page: {
+          results: [
+            // Label
+            {
+              label: 'Next',
+              type: 'LABEL',
+            } as Label,
+            // Multisig transaction
+            {
+              transaction: {
+                executionInfo: { type: 'MULTISIG', nonce: 1 },
+              },
+              type: 'TRANSACTION',
+            } as Transaction,
+            // Label
+            label,
+            // Multisig transaction
+            {
+              transaction: {
+                executionInfo: { type: 'MULTISIG', nonce: 2 },
+              },
+              type: 'TRANSACTION',
+            } as Transaction,
+          ],
+        },
+      }))
+
+      const { result } = renderHook(() => useGroupLabel(label))
+
+      expect(result.current).toBe('Queued - transaction with nonce 1 needs to be executed first')
+    })
+
+    it('should return a modified Queue label when there is a transaction with an out of order nonce in the page', () => {
+      const label = {
+        label: 'Queued',
+        type: 'LABEL',
+      } as Label
+
+      jest.spyOn(useTxQueueHook, 'default').mockImplementation(() => ({
+        loading: false,
+        page: {
+          results: [
+            // Label
+            label,
+            // Multisig transaction
+            {
+              transaction: {
+                executionInfo: { type: 'MULTISIG', nonce: 123 },
+              },
+              type: 'TRANSACTION',
+            } as Transaction,
+          ],
+        },
+      }))
+
+      jest.spyOn(useSafeInfoHook, 'default').mockImplementation(() => ({
+        safeAddress: '0x0',
+        safeLoaded: true,
+        safeLoading: false,
+        safe: {
+          nonce: 7,
+        } as SafeInfo,
+      }))
+
+      const { result } = renderHook(() => useGroupLabel(label))
+
+      expect(result.current).toBe('Queued - transaction with nonce 7 needs to be executed first')
+    })
+  })
+})

--- a/src/components/transactions/GroupLabel/index.test.ts
+++ b/src/components/transactions/GroupLabel/index.test.ts
@@ -5,6 +5,10 @@ import * as useSafeInfoHook from '@/hooks/useSafeInfo'
 import * as useTxQueueHook from '@/hooks/useTxQueue'
 
 describe('GroupLabel', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
   describe('useGroupLabel', () => {
     it('should return Next if given a Next label', () => {
       const label = {
@@ -77,6 +81,15 @@ describe('GroupLabel', () => {
             } as Transaction,
           ],
         },
+      }))
+
+      jest.spyOn(useSafeInfoHook, 'default').mockImplementation(() => ({
+        safeAddress: '0x0',
+        safeLoaded: true,
+        safeLoading: false,
+        safe: {
+          nonce: 1,
+        } as SafeInfo,
       }))
 
       const { result } = renderHook(() => useGroupLabel(label))

--- a/src/components/transactions/GroupLabel/index.tsx
+++ b/src/components/transactions/GroupLabel/index.tsx
@@ -2,14 +2,19 @@ import { type ReactElement } from 'react'
 import { Label, LabelValue } from '@gnosis.pm/safe-react-gateway-sdk'
 import css from './styles.module.css'
 import useTxQueue from '@/hooks/useTxQueue'
-import { isMultisigExecutionInfo, isTransactionListItem } from '@/utils/transaction-guards'
+import { isLabelListItem, isMultisigExecutionInfo, isTransactionListItem } from '@/utils/transaction-guards'
 
 const GroupLabel = ({ item }: { item: Label }): ReactElement => {
   let label: string | LabelValue = item.label
 
   const { page } = useTxQueue()
 
-  if (label === LabelValue.Queued && !page?.next) {
+  const labels = page?.results.filter(isLabelListItem)
+
+  // Current page has both 'Queued' and 'Next' labels
+  const hasBothLabels = labels && labels.length > 1
+
+  if (hasBothLabels && label === LabelValue.Queued) {
     const firstTx = page?.results.find(isTransactionListItem)
 
     if (firstTx && isMultisigExecutionInfo(firstTx.transaction.executionInfo)) {

--- a/src/components/transactions/GroupLabel/index.tsx
+++ b/src/components/transactions/GroupLabel/index.tsx
@@ -9,7 +9,7 @@ const GroupLabel = ({ item }: { item: Label }): ReactElement => {
 
   const { page } = useTxQueue()
 
-  if (label === LabelValue.Queued) {
+  if (label === LabelValue.Queued && !page?.next) {
     const firstTx = page?.results.find(isTransactionListItem)
 
     if (firstTx && isMultisigExecutionInfo(firstTx.transaction.executionInfo)) {

--- a/src/components/transactions/GroupLabel/index.tsx
+++ b/src/components/transactions/GroupLabel/index.tsx
@@ -9,16 +9,17 @@ const GroupLabel = ({ item }: { item: Label }): ReactElement => {
 
   const { page } = useTxQueue()
 
-  const labels = page?.results.filter(isLabelListItem)
+  // 'Queued' is returned when there is one tx in queue OR after the 'Next' tx when there is > 1 tx in queue
+  // We're dealing with 'Queued' txs that can be executed only after 'Next' txs
+  if (label === LabelValue.Queued) {
+    const hasNext = page?.results.some((tx) => isLabelListItem(tx) && tx !== item)
 
-  // First page has both 'Queued' and 'Next' labels
-  const hasBothLabels = labels && labels.length > 1
+    if (hasNext) {
+      const firstTx = page?.results.find(isTransactionListItem)
 
-  if (hasBothLabels && label === LabelValue.Queued) {
-    const firstTx = page?.results.find(isTransactionListItem)
-
-    if (firstTx && isMultisigExecutionInfo(firstTx.transaction.executionInfo)) {
-      label = `${label} - transaction with nonce ${firstTx.transaction.executionInfo.nonce} needs to be executed first`
+      if (firstTx && isMultisigExecutionInfo(firstTx.transaction.executionInfo)) {
+        label = `${label} - transaction with nonce ${firstTx.transaction.executionInfo.nonce} needs to be executed first`
+      }
     }
   }
 

--- a/src/components/transactions/GroupLabel/index.tsx
+++ b/src/components/transactions/GroupLabel/index.tsx
@@ -1,9 +1,23 @@
 import { type ReactElement } from 'react'
-import { Label } from '@gnosis.pm/safe-react-gateway-sdk'
+import { Label, LabelValue } from '@gnosis.pm/safe-react-gateway-sdk'
 import css from './styles.module.css'
+import useTxQueue from '@/hooks/useTxQueue'
+import { isMultisigExecutionInfo, isTransactionListItem } from '@/utils/transaction-guards'
 
 const GroupLabel = ({ item }: { item: Label }): ReactElement => {
-  return <div className={css.container}>{item.label}</div>
+  let label: string | LabelValue = item.label
+
+  const { page } = useTxQueue()
+
+  if (label === LabelValue.Queued) {
+    const firstTx = page?.results.find(isTransactionListItem)
+
+    if (firstTx && isMultisigExecutionInfo(firstTx.transaction.executionInfo)) {
+      label = `${label} - transaction with nonce ${firstTx.transaction.executionInfo.nonce} needs to be executed first`
+    }
+  }
+
+  return <div className={css.container}>{label}</div>
 }
 
 export default GroupLabel

--- a/src/components/transactions/GroupLabel/index.tsx
+++ b/src/components/transactions/GroupLabel/index.tsx
@@ -11,7 +11,7 @@ const GroupLabel = ({ item }: { item: Label }): ReactElement => {
 
   const labels = page?.results.filter(isLabelListItem)
 
-  // Current page has both 'Queued' and 'Next' labels
+  // First page has both 'Queued' and 'Next' labels
   const hasBothLabels = labels && labels.length > 1
 
   if (hasBothLabels && label === LabelValue.Queued) {

--- a/src/components/transactions/GroupLabel/index.tsx
+++ b/src/components/transactions/GroupLabel/index.tsx
@@ -3,23 +3,35 @@ import { Label, LabelValue } from '@gnosis.pm/safe-react-gateway-sdk'
 import css from './styles.module.css'
 import useTxQueue from '@/hooks/useTxQueue'
 import { isLabelListItem, isMultisigExecutionInfo, isTransactionListItem } from '@/utils/transaction-guards'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 const GroupLabel = ({ item }: { item: Label }): ReactElement => {
   let label: string | LabelValue = item.label
 
   const { page } = useTxQueue()
+  const { safe } = useSafeInfo()
 
-  // 'Queued' is returned when there is one tx in queue OR after the 'Next' tx when there is > 1 tx in queue
-  // We're dealing with 'Queued' txs that can be executed only after 'Next' txs
-  if (label === LabelValue.Queued) {
-    const hasNext = page?.results.some((tx) => isLabelListItem(tx) && tx !== item)
+  /**
+   * 'Next' label is returned when the first transaction has a correct nonce
+   * 'Queued' label is returned after 'Next' OR when the first transaction has an out of order nonce
+   *
+   * We want to append to the 'Queue' label if:
+   * - There is a 'Next' label on the first page
+   * - The first transaction has an out of order nonce
+   */
 
-    if (hasNext) {
-      const firstTx = page?.results.find(isTransactionListItem)
+  if (label === LabelValue.Queued && page) {
+    const hasNext = page.results.some((tx) => isLabelListItem(tx) && tx !== item)
+    const firstTx = page.results.find(isTransactionListItem)
 
-      if (firstTx && isMultisigExecutionInfo(firstTx.transaction.executionInfo)) {
-        label = `${label} - transaction with nonce ${firstTx.transaction.executionInfo.nonce} needs to be executed first`
-      }
+    if (
+      firstTx &&
+      isMultisigExecutionInfo(firstTx.transaction.executionInfo) &&
+      (hasNext || firstTx.transaction.executionInfo.nonce !== safe.nonce)
+    ) {
+      const nextNonce = hasNext ? firstTx.transaction.executionInfo.nonce : safe.nonce
+
+      label = `${label} - transaction with nonce ${nextNonce} needs to be executed first`
     }
   }
 

--- a/src/components/transactions/GroupLabel/index.tsx
+++ b/src/components/transactions/GroupLabel/index.tsx
@@ -21,21 +21,16 @@ export const useGroupLabel = (item: Label): string => {
     return label
   }
 
-  const getQueueLabel = (nonce: number) => {
-    return `${label} - transaction with nonce ${nonce} needs to be executed first`
+  const hasNextLabel = page.results.some((tx) => isLabelListItem(tx) && tx !== item)
+  const nonceInFuture = firstTx.transaction.executionInfo.nonce !== safe.nonce
+
+  if (!hasNextLabel && !nonceInFuture) {
+    return label
   }
 
-  // There is also a 'Next' label on the page of the queue
-  if (page.results.some((tx) => isLabelListItem(tx) && tx !== item)) {
-    return getQueueLabel(firstTx.transaction.executionInfo.nonce)
-  }
+  const nextNonce = nonceInFuture ? safe.nonce : firstTx.transaction.executionInfo.nonce
 
-  // First transaction has an out of order nonce
-  if (firstTx.transaction.executionInfo.nonce !== safe.nonce) {
-    return getQueueLabel(safe.nonce)
-  }
-
-  return label
+  return `${label} - transaction with nonce ${nextNonce} needs to be executed first`
 }
 
 const GroupLabel = ({ item }: { item: Label }): ReactElement => {


### PR DESCRIPTION
## What it solves

Resolves #655 

## How this PR fixes it

" - transaction with nonce {{nonce}} needs to be executed first" has been added to "Queued" labels.

## How to test it

Queue two transactions. Observe the extra text on the second `LABEL`.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/192316665-ab2a4416-c2fe-479d-87ef-d832fce770fd.png)