### PR TITLE
fix: Redirect to single tx view when rejecting a tx

### DIFF
--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -149,7 +149,7 @@ const SignOrExecuteForm = ({
 
     // If txId isn't passed in props, it's a newly created tx
     // Redirect to the single tx view
-    if (redirectToTx && !txId) {
+    if ((redirectToTx && !txId) || isRejection) {
       router.push({
         pathname: AppRoutes.transactions.tx,
         query: { safe: router.query.safe, id },


### PR DESCRIPTION
## What it solves

Resolves #656 

## How this PR fixes it

Redirects to the single tx view when rejecting an existing transaction.

## How to test it

1. Open the Safe
2. Create a reject tx
3. Observe being navigated to the single tx view
