### PR TITLE
fix: don't adjust timestamps + show exact time on history

### DIFF
--- a/src/components/common/DateTime/index.test.tsx
+++ b/src/components/common/DateTime/index.test.tsx
@@ -52,11 +52,28 @@ describe('DateTime', () => {
     expect(queryByText(expected)).toBeInTheDocument()
   })
 
-  it('should render the full date and time on the filter', () => {
+  it('should render the relative time before threshold on the filter', () => {
     ;(useTxFilter as jest.Mock).mockImplementation(() => [{ type: 'Incoming', filter: {} }])
 
     const date = new Date()
-    const days = 1
+    const days = 3
+
+    date.setDate(date.getDate() - days)
+
+    const { queryByText } = render(<DateTime value={date.getTime()} />, {
+      routerProps: { pathname: '/transactions/history' },
+    })
+
+    const expected = formatDateTime(date.getTime())
+
+    expect(queryByText('3 days ago')).toBeInTheDocument()
+  })
+
+  it('should render the full date and time after threshold on the filter', () => {
+    ;(useTxFilter as jest.Mock).mockImplementation(() => [{ type: 'Incoming', filter: {} }])
+
+    const date = new Date()
+    const days = 61
 
     date.setDate(date.getDate() - days)
 

--- a/src/components/common/DateTime/index.test.tsx
+++ b/src/components/common/DateTime/index.test.tsx
@@ -1,0 +1,71 @@
+import { render } from '@/tests/test-utils'
+
+import DateTime from '.'
+import { formatDateTime, formatTime } from '@/utils/date'
+import { useTxFilter } from '@/utils/tx-history-filter'
+
+jest.mock('@/utils/tx-history-filter', () => ({
+  useTxFilter: jest.fn(() => [null, jest.fn()]),
+}))
+
+describe('DateTime', () => {
+  it('should render the relative time before threshold on the queue', () => {
+    const date = new Date()
+    const days = 3
+
+    date.setDate(date.getDate() - days)
+
+    const { queryByText } = render(<DateTime value={date.getTime()} />, {
+      routerProps: { pathname: '/transactions/queue' },
+    })
+
+    expect(queryByText('3 days ago')).toBeInTheDocument()
+  })
+
+  it('should render the full date and time after threshold on the queue', () => {
+    const date = new Date()
+    const days = 61
+
+    date.setDate(date.getDate() - days)
+
+    const { queryByText } = render(<DateTime value={date.getTime()} />, {
+      routerProps: { pathname: '/transactions/queue' },
+    })
+
+    const expected = formatDateTime(date.getTime())
+
+    expect(queryByText(expected)).toBeInTheDocument()
+  })
+
+  it('should render the time on the history', () => {
+    const date = new Date()
+    const days = 1
+
+    date.setDate(date.getDate() - days)
+
+    const { queryByText } = render(<DateTime value={date.getTime()} />, {
+      routerProps: { pathname: '/transactions/history' },
+    })
+
+    const expected = formatTime(date.getTime())
+
+    expect(queryByText(expected)).toBeInTheDocument()
+  })
+
+  it('should render the full date and time on the filter', () => {
+    ;(useTxFilter as jest.Mock).mockImplementation(() => [{ type: 'Incoming', filter: {} }])
+
+    const date = new Date()
+    const days = 1
+
+    date.setDate(date.getDate() - days)
+
+    const { queryByText } = render(<DateTime value={date.getTime()} />, {
+      routerProps: { pathname: '/transactions/history' },
+    })
+
+    const expected = formatDateTime(date.getTime())
+
+    expect(queryByText(expected)).toBeInTheDocument()
+  })
+})

--- a/src/components/common/DateTime/index.tsx
+++ b/src/components/common/DateTime/index.tsx
@@ -1,11 +1,16 @@
 import { ReactElement } from 'react'
 import { Tooltip } from '@mui/material'
 import { formatDateTime, formatTimeInWords } from '@/utils/date'
+import { useRouter } from 'next/router'
+import { AppRoutes } from '@/config/routes'
 
 const DAYS_THRESHOLD = 60
 
 const DateTime = ({ value }: { value: number }): ReactElement => {
-  const displayExactDate = Math.floor((Date.now() - value) / 1000 / 60 / 60 / 24) > DAYS_THRESHOLD
+  const router = useRouter()
+  const isHistory = router.pathname.includes(AppRoutes.transactions.history)
+
+  const displayExactDate = Math.floor((Date.now() - value) / 1000 / 60 / 60 / 24) > DAYS_THRESHOLD || isHistory
 
   return (
     <Tooltip title={displayExactDate ? '' : formatDateTime(value)} placement="top">

--- a/src/components/common/DateTime/index.tsx
+++ b/src/components/common/DateTime/index.tsx
@@ -7,19 +7,25 @@ import { useTxFilter } from '@/utils/tx-history-filter'
 
 const DAYS_THRESHOLD = 60
 
+/**
+ * If queue, show relative time until threshold then show full date and time
+ * If history, show time (as date labels are present)
+ * If filter, show full date and time
+ */
+
 const DateTime = ({ value }: { value: number }): ReactElement => {
   const [filter] = useTxFilter()
-
   const router = useRouter()
-  const isHistory = router.pathname === AppRoutes.transactions.history
+
+  // (non-filtered) history is the endpoint that returns date labels
+  const showTime = router.pathname === AppRoutes.transactions.history && !filter
 
   const isOld = Math.floor((Date.now() - value) / 1000 / 60 / 60 / 24) > DAYS_THRESHOLD
-
-  const displayExactDate = isOld || isHistory
+  const showDateTime = isOld || filter
 
   return (
-    <Tooltip title={displayExactDate ? '' : formatDateTime(value)} placement="top">
-      <span>{filter ? formatDateTime(value) : displayExactDate ? formatTime(value) : formatTimeInWords(value)}</span>
+    <Tooltip title={showDateTime ? '' : formatDateTime(value)} placement="top">
+      <span>{showTime ? formatTime(value) : showDateTime ? formatDateTime(value) : formatTimeInWords(value)}</span>
     </Tooltip>
   )
 }

--- a/src/components/common/DateTime/index.tsx
+++ b/src/components/common/DateTime/index.tsx
@@ -10,7 +10,9 @@ const DateTime = ({ value }: { value: number }): ReactElement => {
   const router = useRouter()
   const isHistory = router.pathname.includes(AppRoutes.transactions.history)
 
-  const displayExactDate = Math.floor((Date.now() - value) / 1000 / 60 / 60 / 24) > DAYS_THRESHOLD || isHistory
+  const isOld = Math.floor((Date.now() - value) / 1000 / 60 / 60 / 24) > DAYS_THRESHOLD
+
+  const displayExactDate = isOld || isHistory
 
   return (
     <Tooltip title={displayExactDate ? '' : formatDateTime(value)} placement="top">

--- a/src/components/common/DateTime/index.tsx
+++ b/src/components/common/DateTime/index.tsx
@@ -1,20 +1,15 @@
 import { ReactElement } from 'react'
 import { Tooltip } from '@mui/material'
 import { formatDateTime, formatTimeInWords } from '@/utils/date'
-import { isToday, startOfDay } from 'date-fns'
 
 const DAYS_THRESHOLD = 60
-
-const getRelevantTimestamp = (value: number) => {
-  return isToday(new Date(value)) ? value : startOfDay(value).getTime()
-}
 
 const DateTime = ({ value }: { value: number }): ReactElement => {
   const displayExactDate = Math.floor((Date.now() - value) / 1000 / 60 / 60 / 24) > DAYS_THRESHOLD
 
   return (
     <Tooltip title={displayExactDate ? '' : formatDateTime(value)} placement="top">
-      <span>{displayExactDate ? formatDateTime(value) : formatTimeInWords(getRelevantTimestamp(value))}</span>
+      <span>{displayExactDate ? formatDateTime(value) : formatTimeInWords(value)}</span>
     </Tooltip>
   )
 }

--- a/src/components/common/DateTime/index.tsx
+++ b/src/components/common/DateTime/index.tsx
@@ -1,14 +1,17 @@
 import { ReactElement } from 'react'
 import { Tooltip } from '@mui/material'
-import { formatDateTime, formatTimeInWords } from '@/utils/date'
+import { formatDateTime, formatTime, formatTimeInWords } from '@/utils/date'
 import { useRouter } from 'next/router'
 import { AppRoutes } from '@/config/routes'
+import { useTxFilter } from '@/utils/tx-history-filter'
 
 const DAYS_THRESHOLD = 60
 
 const DateTime = ({ value }: { value: number }): ReactElement => {
+  const [filter] = useTxFilter()
+
   const router = useRouter()
-  const isHistory = router.pathname.includes(AppRoutes.transactions.history)
+  const isHistory = router.pathname === AppRoutes.transactions.history
 
   const isOld = Math.floor((Date.now() - value) / 1000 / 60 / 60 / 24) > DAYS_THRESHOLD
 
@@ -16,7 +19,7 @@ const DateTime = ({ value }: { value: number }): ReactElement => {
 
   return (
     <Tooltip title={displayExactDate ? '' : formatDateTime(value)} placement="top">
-      <span>{displayExactDate ? formatDateTime(value) : formatTimeInWords(value)}</span>
+      <span>{filter ? formatDateTime(value) : displayExactDate ? formatTime(value) : formatTimeInWords(value)}</span>
     </Tooltip>
   )
 }

--- a/src/components/common/DateTime/index.tsx
+++ b/src/components/common/DateTime/index.tsx
@@ -21,7 +21,7 @@ const DateTime = ({ value }: { value: number }): ReactElement => {
   const showTime = router.pathname === AppRoutes.transactions.history && !filter
 
   const isOld = Math.floor((Date.now() - value) / 1000 / 60 / 60 / 24) > DAYS_THRESHOLD
-  const showDateTime = isOld || filter
+  const showDateTime = isOld
 
   return (
     <Tooltip title={showDateTime ? '' : formatDateTime(value)} placement="top">

--- a/src/components/transactions/SingleTx/SingleTx.test.tsx
+++ b/src/components/transactions/SingleTx/SingleTx.test.tsx
@@ -45,6 +45,7 @@ describe('SingleTx', () => {
       query: {
         id: 'multisig_0x87a57cBf742CC1Fc702D0E9BF595b1E056693e2f_0x236da79434c398bf98b204e6f3d93d',
       },
+      pathname: '',
     }))
 
     const { getByTestId } = render(<SingleTx />)
@@ -61,6 +62,7 @@ describe('SingleTx', () => {
       query: {
         foo: 'multisig_0x87a57cBf742CC1Fc702D0E9BF595b1E056693e2f_0x236da79434c398bf98b204e6f3d93d',
       },
+      pathname: '',
     }))
 
     const { queryByText } = render(<SingleTx />)
@@ -79,6 +81,7 @@ describe('SingleTx', () => {
       query: {
         id: 'dummy',
       },
+      pathname: '',
     }))
 
     const getTransactionDetails = jest.spyOn(require('@gnosis.pm/safe-react-gateway-sdk'), 'getTransactionDetails')
@@ -102,6 +105,7 @@ describe('SingleTx', () => {
       query: {
         id: 'multisig_0x87a57cBf742CC1Fc702D0E9BF595b1E056693e2f_0x236da79434c398bf98b204e6f3d93d',
       },
+      pathname: '',
     }))
 
     jest.spyOn(useSafeInfo, 'default').mockImplementation(() => ({

--- a/src/components/transactions/SingleTx/SingleTx.test.tsx
+++ b/src/components/transactions/SingleTx/SingleTx.test.tsx
@@ -45,7 +45,6 @@ describe('SingleTx', () => {
       query: {
         id: 'multisig_0x87a57cBf742CC1Fc702D0E9BF595b1E056693e2f_0x236da79434c398bf98b204e6f3d93d',
       },
-      pathname: '',
     }))
 
     const { getByTestId } = render(<SingleTx />)
@@ -62,7 +61,6 @@ describe('SingleTx', () => {
       query: {
         foo: 'multisig_0x87a57cBf742CC1Fc702D0E9BF595b1E056693e2f_0x236da79434c398bf98b204e6f3d93d',
       },
-      pathname: '',
     }))
 
     const { queryByText } = render(<SingleTx />)
@@ -81,7 +79,6 @@ describe('SingleTx', () => {
       query: {
         id: 'dummy',
       },
-      pathname: '',
     }))
 
     const getTransactionDetails = jest.spyOn(require('@gnosis.pm/safe-react-gateway-sdk'), 'getTransactionDetails')
@@ -105,7 +102,6 @@ describe('SingleTx', () => {
       query: {
         id: 'multisig_0x87a57cBf742CC1Fc702D0E9BF595b1E056693e2f_0x236da79434c398bf98b204e6f3d93d',
       },
-      pathname: '',
     }))
 
     jest.spyOn(useSafeInfo, 'default').mockImplementation(() => ({


### PR DESCRIPTION
## What it solves

Resolves #657 & #673

## How this PR fixes it

- The `timestamp` of a transaction is formatted as is.
- The exact time is shown on the history list.

## How to test it

Open `rin:0xf2565317F3Ae8Ae9EA98E9Fe1e7FADC77F823cbD/transactions/queue` and observe that the queued transaction have valid "n days ago" labels. The exact time will, however, been shown on the history list.