### PR TITLE
fix: don't show wallet nonce when signing

### DIFF
--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -78,12 +78,14 @@ const GasParams = ({ params, isExecution, onEdit }: GasParamsProps): ReactElemen
       <AccordionDetails>
         {nonce !== undefined && <GasDetail isLoading={false} name="Safe transaction nonce" value={nonce.toString()} />}
 
-        {userNonce !== undefined && <GasDetail isLoading={false} name="Wallet nonce" value={userNonce.toString()} />}
-
         {!!safeTxGas && <GasDetail isLoading={false} name="safeTxGas" value={safeTxGas.toString()} />}
 
         {isExecution && (
           <>
+            {userNonce !== undefined && (
+              <GasDetail isLoading={false} name="Wallet nonce" value={userNonce.toString()} />
+            )}
+
             <GasDetail isLoading={isLoading} name="Gas limit" value={gasLimitString} />
 
             <GasDetail isLoading={isLoading} name="Max priority fee (Gwei)" value={maxPrioGasGwei} />


### PR DESCRIPTION
## What it solves

Resolves #653

## How this PR fixes it

When signing a transaction, the wallet nonce is no longer shown.

## How to test it

- Create a transaction on a 1+/n Safe and observe that the wallet nonce is no longer shown/is editable in the advanced parameters.
- Create an executable transaction and observe that the wallet nonce remains and is editable.

## Screenshots

### 1+/n

![image](https://user-images.githubusercontent.com/20442784/192477428-0c50fa4b-bdf0-4d3b-9829-3bb642936b82.png)

![image](https://user-images.githubusercontent.com/20442784/192477442-6d747dc6-dd6c-4ffc-9978-c9e09755b0de.png)

### Executable

![image](https://user-images.githubusercontent.com/20442784/192477493-e6c6ba7d-1e32-4f20-aaa1-5602c5fd80af.png)

![image](https://user-images.githubusercontent.com/20442784/192477509-bb363cef-2b8b-463f-bfb4-6d514633559d.png)