### PR TITLE
fix: open `NewTxModal` from address book

### DIFF
--- a/src/components/address-book/AddressBookTable/index.tsx
+++ b/src/components/address-book/AddressBookTable/index.tsx
@@ -10,7 +10,7 @@ import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
 import RemoveDialog from '@/components/address-book/RemoveDialog'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
-import TokenTransferModal from '@/components/tx/modals/TokenTransferModal'
+import NewTxModal from '@/components/tx/modals/NewTxModal'
 import css from './styles.module.css'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import AddressBookHeader from '../AddressBookHeader'
@@ -118,12 +118,7 @@ const AddressBookTable = () => {
       {open[ModalType.REMOVE] && <RemoveDialog handleClose={handleClose} address={defaultValues?.address || ''} />}
 
       {/* Send funds modal */}
-      {selectedAddress && (
-        <TokenTransferModal
-          onClose={() => setSelectedAddress(undefined)}
-          initialData={[{ recipient: selectedAddress }]}
-        />
-      )}
+      {selectedAddress && <NewTxModal onClose={() => setSelectedAddress(undefined)} recipient={selectedAddress} />}
     </>
   )
 }

--- a/src/components/tx/modals/NewTxModal/index.tsx
+++ b/src/components/tx/modals/NewTxModal/index.tsx
@@ -4,14 +4,15 @@ import ModalDialog from '@/components/common/ModalDialog'
 import TokenTransferModal from '../TokenTransferModal'
 import AssetsIcon from '@/public/images/sidebar/assets.svg'
 import NftIcon from '@/public/images/nft.svg'
-import NftTransferModal from '../NftTransferModal'
+import NftTransferModal, { NftTransferParams } from '../NftTransferModal'
 import { trackEvent, MODALS_EVENTS } from '@/services/analytics'
+import { SendAssetsField } from '../TokenTransferModal/SendAssetsForm'
 
 const TxButton = (props: ButtonProps) => (
   <Button variant="contained" sx={{ '& svg path': { fill: 'currentColor' } }} fullWidth {...props} />
 )
 
-const NewTxModal = ({ onClose }: { onClose: () => void }): ReactElement => {
+const NewTxModal = ({ onClose, recipient }: { onClose: () => void; recipient?: string }): ReactElement => {
   const [tokenModalOpen, setTokenModalOpen] = useState<boolean>(false)
   const [nftsModalOpen, setNftModalOpen] = useState<boolean>(false)
 
@@ -42,9 +43,11 @@ const NewTxModal = ({ onClose }: { onClose: () => void }): ReactElement => {
         </DialogContent>
       </ModalDialog>
 
-      {tokenModalOpen && <TokenTransferModal onClose={onClose} />}
+      {tokenModalOpen && (
+        <TokenTransferModal onClose={onClose} initialData={[{ [SendAssetsField.recipient]: recipient }]} />
+      )}
 
-      {nftsModalOpen && <NftTransferModal onClose={onClose} />}
+      {nftsModalOpen && <NftTransferModal onClose={onClose} initialData={[{ recipient } as NftTransferParams]} />}
     </>
   )
 }

--- a/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
+++ b/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
@@ -68,14 +68,14 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
   const [pageUrl, setPageUrl] = useState<string>()
   const [combinedNfts, setCombinedNfts] = useState<SafeCollectibleResponse[]>()
   const [nftData, nftError, nftLoading] = useCollectibles(pageUrl)
-  const allNfts = useMemo(() => combinedNfts ?? (params ? [params.token] : []), [combinedNfts, params])
+  const allNfts = useMemo(() => combinedNfts ?? (params?.token ? [params.token] : []), [combinedNfts, params?.token])
   const disabled = nftLoading && !allNfts.length
 
   const formMethods = useForm<FormData>({
     defaultValues: {
       [Field.recipient]: params?.recipient || '',
-      [Field.tokenAddress]: params?.token.address || '',
-      [Field.tokenId]: params?.token.id || '',
+      [Field.tokenAddress]: params?.token?.address || '',
+      [Field.tokenId]: params?.token?.id || '',
     },
   })
   const {


### PR DESCRIPTION
## What it solves

Resolves #677

## How this PR fixes it

The `NewTxModal` is now opened when clicking "Send" in the address book. The `recipient` is passed to either the `TokenTransferModal` or `NftTransferModal` respectively.

## How to test it

Open the address book and click "Send". Observe the modal allowing either token or NFT transfer. Clicking either of them assigns the recipient as the chosen contact.

## Screenshots

![funds](https://user-images.githubusercontent.com/20442784/192484916-5b63d51c-7b98-4914-aa01-2f02822faba5.gif)

![nfts](https://user-images.githubusercontent.com/20442784/192484896-f370cca0-9ddb-4519-9a37-d6f6ade83edf.gif)