### PR TITLE
fix: dashboard + address book smoke tests

### DIFF
--- a/cypress/e2e/smoke/address_book.cy.js
+++ b/cypress/e2e/smoke/address_book.cy.js
@@ -32,7 +32,7 @@ describe('Address book', () => {
       cy.get('input[name="name"]').type(NAME)
       cy.get('input[name="address"]').type(ENS_NAME)
       // cy.wait(5000)
-      cy.contains('Save').click()
+      cy.contains('button', 'Save').click()
 
       cy.contains(NAME).should('exist')
       cy.contains(ADDRESS).should('exist')
@@ -44,7 +44,7 @@ describe('Address book', () => {
 
       // Give the entry a new name
       cy.get('input[name="name"]').clear().type(EDITED_NAME)
-      cy.contains('Save').click()
+      cy.contains('button', 'Save').click()
 
       // Previous name should have been replaced by the edited one
       cy.get(NAME).should('not.exist')

--- a/cypress/e2e/smoke/dashboard.cy.js
+++ b/cypress/e2e/smoke/dashboard.cy.js
@@ -7,10 +7,6 @@ describe('Dashboard', () => {
     cy.contains('button', 'Accept selection').click()
   })
 
-  it('should display the dashboard title', () => {
-    cy.contains('main p', 'Dashboard')
-  })
-
   it('should display the overview widget', () => {
     cy.contains('main', SAFE).should('exist')
     cy.contains('main', '1/1')


### PR DESCRIPTION
## What it solves

Resolves dashboard/address book smoke tests

## How this PR fixes it

- A legacy dashboard test was removed.
- The address book selectors were improved.

## How to test it

Observe the E2E tests pass on the CI, or that `address_book.cy.js` and `dashboard.cy.js` pass locally