### PR TITLE
Fix: reconnect wallet only if unlocked

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -8,7 +8,7 @@ import 'whatwg-fetch'
 
 jest.mock('@web3-onboard/coinbase', () => jest.fn())
 jest.mock('@web3-onboard/fortmatic', () => jest.fn())
-jest.mock('@web3-onboard/injected-wallets', () => jest.fn())
+jest.mock('@web3-onboard/injected-wallets', () => ({ ProviderLabel: { MetaMask: 'MetaMask' } }))
 jest.mock('@web3-onboard/keystone/dist/index', () => jest.fn())
 jest.mock('@web3-onboard/ledger', () => jest.fn())
 jest.mock('@web3-onboard/portis', () => jest.fn())

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -53,7 +53,7 @@ const SafeTokenWidget = () => {
       <Tooltip title={url ? `Open ${claimingApp?.name}` : ''}>
         <span>
           <Track {...OVERVIEW_EVENTS.SAFE_TOKEN_WIDGET}>
-            <Link href={url || '#'} passHref>
+            <Link href={url || ''} passHref>
               <ButtonBase
                 aria-describedby={'safe-token-widget'}
                 sx={{ alignSelf: 'stretch' }}

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -7,6 +7,9 @@ declare global {
     ethereum?: {
       autoRefreshOnNetworkChange: boolean
       isMetaMask: boolean
+      _metamask: {
+        isUnlocked: () => Promise<boolean>
+      }
     }
     beamer_config?: BeamerConfig
     Beamer?: BeamerMethods

--- a/src/hooks/wallets/wallets.ts
+++ b/src/hooks/wallets/wallets.ts
@@ -11,7 +11,7 @@ import type { ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import coinbaseModule from '@web3-onboard/coinbase'
 import fortmaticModule from '@web3-onboard/fortmatic'
-import injectedWalletModule from '@web3-onboard/injected-wallets'
+import injectedWalletModule, { ProviderLabel } from '@web3-onboard/injected-wallets'
 import keystoneModule from '@web3-onboard/keystone/dist/index'
 import ledgerModule from '@web3-onboard/ledger'
 import portisModule from '@web3-onboard/portis'
@@ -70,7 +70,7 @@ export const getAllWallets = (): WalletInit[] => {
 }
 
 export const getRecommendedInjectedWallets = (): RecommendedInjectedWallets[] => {
-  return [{ name: 'MetaMask', url: 'https://metamask.io' }]
+  return [{ name: ProviderLabel.MetaMask, url: 'https://metamask.io' }]
 }
 
 export const isWalletSupported = (disabledWallets: string[], walletLabel: string): boolean => {

--- a/src/services/pairing/connector.ts
+++ b/src/services/pairing/connector.ts
@@ -5,8 +5,13 @@ import packageJson from '../../../package.json'
 import { IS_PRODUCTION } from '@/config/constants'
 import ExternalStore from '@/services/ExternalStore'
 import PairingIcon from '@/public/images/safe-logo-green.png'
+import local from '../local-storage/local'
 
 export const PAIRING_MODULE_STORAGE_ID = 'pairingConnector'
+
+export const hasStoredPairingSession = (): boolean => {
+  return Boolean(local.getItem(PAIRING_MODULE_STORAGE_ID))
+}
 
 export const getClientMeta = () => {
   const host = location.origin

--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -1,3 +1,4 @@
+import { ProviderLabel } from '@web3-onboard/injected-wallets'
 import { hasStoredPairingSession } from '@/services/pairing/connector'
 import { PAIRING_MODULE_LABEL } from '@/services/pairing/module'
 
@@ -23,7 +24,7 @@ export const isWalletRejection = (err: Error & { code?: number }): boolean => {
 }
 
 const WalletNames = {
-  METAMASK: 'MetaMask',
+  METAMASK: ProviderLabel.MetaMask,
   WALLET_CONNECT: 'WalletConnect',
   SAFE_MOBILE_PAIRING: PAIRING_MODULE_LABEL,
 }

--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -1,3 +1,6 @@
+import { hasStoredPairingSession } from '@/services/pairing/connector'
+import { PAIRING_MODULE_LABEL } from '@/services/pairing/module'
+
 const isKeystoneError = (err: unknown): boolean => {
   if (err instanceof Error) {
     return err.message?.startsWith('#ktek_error')
@@ -17,4 +20,32 @@ const isMMRejection = (err: Error & { code?: number }): boolean => {
 
 export const isWalletRejection = (err: Error & { code?: number }): boolean => {
   return isMMRejection(err) || isWCRejection(err) || isKeystoneError(err)
+}
+
+const WalletNames = {
+  METAMASK: 'MetaMask',
+  WALLET_CONNECT: 'WalletConnect',
+  SAFE_MOBILE_PAIRING: PAIRING_MODULE_LABEL,
+}
+
+/* Check if the wallet is unlocked. */
+export const isWalletUnlocked = async (walletName: string): Promise<boolean> => {
+  if (typeof window === 'undefined') return false
+
+  // Only MetaMask exposes a method to check if the wallet is unlocked
+  if (walletName === WalletNames.METAMASK) {
+    return window.ethereum?._metamask?.isUnlocked() || false
+  }
+
+  // Wallet connect creates a localStorage entry when connected and removes it when disconnected
+  if (walletName === WalletNames.WALLET_CONNECT) {
+    return window.localStorage.getItem('walletconnect') !== null
+  }
+
+  // Our own Safe mobile pairing module
+  if (walletName === WalletNames.SAFE_MOBILE_PAIRING && hasStoredPairingSession()) {
+    return hasStoredPairingSession()
+  }
+
+  return false
 }


### PR DESCRIPTION
## What it solves

Resolves #615

## How this PR fixes it
Avoid attempting to reconnect if the wallet is not verifiably unlocked.

## How to test it
MetaMask:
* Connect to MM
* Refresh the page – it should auto-connect again
* Lock MM
<img width="398" alt="Screenshot 2022-09-27 at 12 03 31" src="https://user-images.githubusercontent.com/381895/192497437-bd5e312c-e44b-45cc-b527-0e5f93f755a2.png">

* Refresh the page
* It should _not_ reconnect

WalletConnect/Safe mobile pairing:
* Connect
* Refresh the page – it should auto-connect again
* Initiate a disconnect from the WC side (not via our app!)
* Refresh the page
* It should _not_ reconnect

## Analytics changes
None.