### PR TITLE
fix: replacement tx error

### DIFF
--- a/src/components/create-safe/status/usePendingSafeCreation.ts
+++ b/src/components/create-safe/status/usePendingSafeCreation.ts
@@ -1,6 +1,6 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { backOff } from 'exponential-backoff'
-import { didRevert } from '@/utils/ethers-utils'
+import { didRevert, EthersError } from '@/utils/ethers-utils'
 import { SafeCreationStatus } from '@/components/create-safe/status/useSafeCreation'
 import { useEffect } from 'react'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
@@ -8,8 +8,6 @@ import { getSafeInfo, SafeInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { getProxyFactoryContractInstance } from '@/services/contracts/safeContracts'
 import useChainId from '@/hooks/useChainId'
 import { ErrorCode } from '@ethersproject/logger'
-
-type EthersError = Error & { code: ErrorCode; reason: string }
 
 export const pollSafeInfo = async (chainId: string, safeAddress: string): Promise<SafeInfo> => {
   // exponential delay between attempts for around 4 min

--- a/src/components/create-safe/status/useSafeCreation.test.ts
+++ b/src/components/create-safe/status/useSafeCreation.test.ts
@@ -166,10 +166,6 @@ describe('monitorSafeCreationTx', () => {
   })
 
   it('returns TIMEOUT if transaction couldnt be found within the timout limit', async () => {
-    const mockEthersError = {
-      ...new Error(),
-      code: 'TRANSACTION_REPLACED',
-    }
     waitForTxSpy.mockImplementationOnce(() => Promise.reject(new Error()))
 
     const result = await checkSafeCreationTx(provider, '0x0', '4')

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -17,7 +17,7 @@ import extractTxInfo from '@/services/tx/extractTxInfo'
 import proposeTx from './proposeTransaction'
 import { txDispatch, TxEvent } from './txEvents'
 import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
-import { didRevert } from '@/utils/ethers-utils'
+import { didRevert, EthersError } from '@/utils/ethers-utils'
 import Safe, { RemoveOwnerTxParams } from '@gnosis.pm/safe-core-sdk'
 import { AddOwnerTxParams, SwapOwnerTxParams } from '@gnosis.pm/safe-core-sdk/dist/src/Safe'
 import MultiSendCallOnlyEthersContract from '@gnosis.pm/safe-ethers-lib/dist/src/contracts/MultiSendCallOnly/MultiSendCallOnlyEthersContract'
@@ -26,6 +26,7 @@ import { ContractTransaction, ethers } from 'ethers'
 import { SpendingLimitTxParams } from '@/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx'
 import { getSpendingLimitContract } from '@/services/contracts/spendingLimitContracts'
 import EthersAdapter from '@gnosis.pm/safe-ethers-lib'
+import { ErrorCode } from '@ethersproject/logger'
 
 const getAndValidateSafeSDK = (): Safe => {
   const safeSDK = getSafeSDK()
@@ -262,7 +263,14 @@ export const dispatchTxExecution = async (
         txDispatch(TxEvent.PROCESSED, { txId, receipt })
       }
     })
-    .catch((error) => {
+    .catch((err) => {
+      const error = err as EthersError
+
+      // Meaning the transaction was "repriced" or "replaced"
+      if (error.code === ErrorCode.TRANSACTION_REPLACED && error.reason !== 'cancelled') {
+        // TxEvent.SUCCESS is handled by txHistoryMiddleware
+        return
+      }
       txDispatch(TxEvent.FAILED, { txId, error: error as Error })
     })
 

--- a/src/utils/ethers-utils.ts
+++ b/src/utils/ethers-utils.ts
@@ -15,5 +15,5 @@ export const didRevert = (receipt: TransactionReceipt): boolean => {
 }
 
 export const didReprice = (error: EthersError): boolean => {
-  return error.code === ErrorCode.TRANSACTION_REPLACED && error.reason === EthersTxReplacedReason.repriced
+  return error.reason === EthersTxReplacedReason.repriced
 }

--- a/src/utils/ethers-utils.ts
+++ b/src/utils/ethers-utils.ts
@@ -1,8 +1,19 @@
 import type { TransactionReceipt } from '@ethersproject/abstract-provider/lib'
 import { ErrorCode } from '@ethersproject/logger'
 
-export type EthersError = Error & { code: ErrorCode; reason: string }
+// https://docs.ethers.io/v5/api/providers/types/#providers-TransactionResponse
+export enum EthersTxReplacedReason {
+  repriced = 'repriced',
+  cancelled = 'cancelled',
+  replaced = 'replaced',
+}
+
+export type EthersError = Error & { code: ErrorCode; reason: EthersTxReplacedReason; receipt: TransactionReceipt }
 
 export const didRevert = (receipt: TransactionReceipt): boolean => {
   return receipt.status === 0
+}
+
+export const didReprice = (error: EthersError): boolean => {
+  return error.code === ErrorCode.TRANSACTION_REPLACED && error.reason === EthersTxReplacedReason.repriced
 }

--- a/src/utils/ethers-utils.ts
+++ b/src/utils/ethers-utils.ts
@@ -1,4 +1,7 @@
 import type { TransactionReceipt } from '@ethersproject/abstract-provider/lib'
+import { ErrorCode } from '@ethersproject/logger'
+
+export type EthersError = Error & { code: ErrorCode; reason: string }
 
 export const didRevert = (receipt: TransactionReceipt): boolean => {
   return receipt.status === 0


### PR DESCRIPTION
## What it solves
Do not dispatch a replacement transaction as an error

Partially resolves #620 

## How this PR fixes it
`ethers` throws an error upon speeding up a transaction. The error is handled now and does not dispatch a FAILED event.

