### PR TITLE
fix: links to featured apps

### DIFF
--- a/src/components/dashboard/FeaturedApps/FeaturedApps.tsx
+++ b/src/components/dashboard/FeaturedApps/FeaturedApps.tsx
@@ -2,8 +2,10 @@ import { ReactElement, useMemo } from 'react'
 import styled from '@emotion/styled'
 import { Box, Grid, Typography } from '@mui/material'
 import { Card, WidgetBody, WidgetContainer } from '../styled'
-import useChainId from '@/hooks/useChainId'
+import { useRouter } from 'next/router'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
+import Link from 'next/link'
+import { AppRoutes } from '@/config/routes'
 
 export const FEATURED_APPS_TAG = 'dashboard-widgets'
 
@@ -24,14 +26,9 @@ const StyledGridItem = styled(Grid)`
   min-width: 300px;
 `
 
-const getSafeAppUrl = (appUrl: string, chainId: string) => {
-  const origin = typeof window !== 'undefined' ? window.location.origin : ''
-  return `${origin}/share/safe-app?appUrl=${encodeURIComponent(appUrl)}&chainId=${chainId}`
-}
-
 export const FeaturedApps = (): ReactElement | null => {
   const [allApps = [], , isLoading] = useRemoteSafeApps()
-  const chainId = useChainId()
+  const router = useRouter()
   const featuredApps = useMemo(() => allApps.filter((app) => app.tags?.includes(FEATURED_APPS_TAG)), [allApps])
 
   if (!featuredApps.length && !isLoading) return null
@@ -46,25 +43,27 @@ export const FeaturedApps = (): ReactElement | null => {
           <StyledGrid container>
             {featuredApps.map((app) => (
               <StyledGridItem item xs md key={app.id}>
-                <StyledLink href={getSafeAppUrl(app.url, chainId)} target="_blank">
-                  <Card>
-                    <Grid container alignItems="center" spacing={3}>
-                      <Grid item xs={12} md={3}>
-                        <StyledImage src={app.iconUrl} alt={app.name} />
-                      </Grid>
+                <Link passHref href={{ pathname: AppRoutes.apps, query: { ...router.query, appUrl: app.url } }}>
+                  <StyledLink>
+                    <Card>
+                      <Grid container alignItems="center" spacing={3}>
+                        <Grid item xs={12} md={3}>
+                          <StyledImage src={app.iconUrl} alt={app.name} />
+                        </Grid>
 
-                      <Grid item xs={12} md={9}>
-                        <Box mb={1.01}>
-                          <Typography fontSize="lg">{app.description}</Typography>
-                        </Box>
+                        <Grid item xs={12} md={9}>
+                          <Box mb={1.01}>
+                            <Typography fontSize="lg">{app.description}</Typography>
+                          </Box>
 
-                        <Typography color="primary.main" fontWeight="bold">
-                          Use {app.name}
-                        </Typography>
+                          <Typography color="primary.main" fontWeight="bold">
+                            Use {app.name}
+                          </Typography>
+                        </Grid>
                       </Grid>
-                    </Grid>
-                  </Card>
-                </StyledLink>
+                    </Card>
+                  </StyledLink>
+                </Link>
               </StyledGridItem>
             ))}
           </StyledGrid>


### PR DESCRIPTION
## What it solves

Resolves #654

## How this PR fixes it

The links to the features apps on the dashboard have been updated to use the `next/link` component, appending the `app.url` to the `query` object.

## How to test it

Open the Safe and observe the WalletConnect and Transaction Builder apps successfully open from the dashboard.