### PR TITLE
Fix: reset error after ENS resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-gtm-module": "^2.0.11",
-    "react-hook-form": "^7.34.0",
+    "react-hook-form": "^7.36.1",
     "react-papaparse": "^4.0.2",
     "react-qr-reader": "2.2.1",
     "react-redux": "^8.0.2",

--- a/src/components/common/AddressInput/index.test.tsx
+++ b/src/components/common/AddressInput/index.test.tsx
@@ -127,7 +127,7 @@ describe('AddressInput tests', () => {
 
     await act(async () => {
       fireEvent.change(input, { target: { value: 'zero.eth' } })
-      await waitFor(() => expect(input.value).toBe('0x0000000000000000000000000000000000000000'))
+      await waitFor(() => expect(input.value).toBe('rin:0x0000000000000000000000000000000000000000'))
     })
 
     expect(useNameResolver).toHaveBeenCalledWith('zero.eth')

--- a/src/components/common/AddressInput/index.tsx
+++ b/src/components/common/AddressInput/index.tsx
@@ -43,17 +43,17 @@ const AddressInput = ({ name, validate, required = true, ...props }: AddressInpu
   // Update the input value
   const setAddressValue = useCallback(
     (value: string) => {
-      setValue(name, value)
-      // Workaround for a bug in react-hook-form that it restores a cached error state on blur
-      trigger(name)
+      setValue(name, value, { shouldValidate: true })
     },
-    [setValue, trigger, name],
+    [setValue, name],
   )
 
   // On ENS resolution, update the input value
   useEffect(() => {
-    address && setAddressValue(address)
-  }, [address, setAddressValue])
+    if (address) {
+      setAddressValue(`${currentShortName}:${address}`)
+    }
+  }, [address, currentShortName, setAddressValue])
 
   return (
     <Grid container alignItems="center" gap={1}>
@@ -99,6 +99,9 @@ const AddressInput = ({ name, validate, required = true, ...props }: AddressInpu
                 return validatePrefixed(value) || validate?.(parsePrefixedAddress(value).address)
               }
             },
+
+            // Workaround for a bug in react-hook-form that it restores a cached error state on blur
+            onBlur: () => setTimeout(() => trigger(name), 100),
           })}
         />
       </Grid>

--- a/src/components/common/AddressInput/index.tsx
+++ b/src/components/common/AddressInput/index.tsx
@@ -1,7 +1,6 @@
 import { ReactElement, useEffect, useCallback, useRef, useMemo } from 'react'
 import { InputAdornment, TextField, type TextFieldProps, CircularProgress, Grid } from '@mui/material'
-import _get from 'lodash/get'
-import { useFormContext, useWatch, type Validate } from 'react-hook-form'
+import { useFormContext, useWatch, type Validate, get } from 'react-hook-form'
 import { FEATURES } from '@gnosis.pm/safe-react-gateway-sdk'
 import { validatePrefixedAddress } from '@/utils/validation'
 import { useCurrentChain } from '@/hooks/useChains'
@@ -31,7 +30,7 @@ const AddressInput = ({ name, validate, required = true, ...props }: AddressInpu
   const { address, resolverError, resolving } = useNameResolver(isDomainLookupEnabled ? watchedValue : '')
 
   // errors[name] doesn't work with nested field names like 'safe.address', need to use the lodash get
-  const fieldError = resolverError || _get(errors, name)
+  const fieldError = resolverError || get(errors, name)
 
   // Debounce the field error unless there's no error or it's resolving a domain
   let error = useDebounce(fieldError, 500)
@@ -45,6 +44,7 @@ const AddressInput = ({ name, validate, required = true, ...props }: AddressInpu
   const setAddressValue = useCallback(
     (value: string) => {
       setValue(name, value)
+      // Workaround for a bug in react-hook-form that it restores a cached error state on blur
       trigger(name)
     },
     [setValue, trigger, name],

--- a/yarn.lock
+++ b/yarn.lock
@@ -9953,10 +9953,10 @@ react-gtm-module@^2.0.11:
   resolved "https://registry.yarnpkg.com/react-gtm-module/-/react-gtm-module-2.0.11.tgz#14484dac8257acd93614e347c32da9c5ac524206"
   integrity sha512-8gyj4TTxeP7eEyc2QKawEuQoAZdjKvMY4pgWfycGmqGByhs17fR+zEBs0JUDq4US/l+vbTl+6zvUIx27iDo/Vw==
 
-react-hook-form@^7.34.0:
-  version "7.36.0"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.36.0.tgz#27bf64e2a06b994bc64e055b4cc502794b8f6978"
-  integrity sha512-2PmRhTDH90/G1XWbUGpfuFBf7wxj9kYvzPqoZCv4wUGBIfuac0fK3up9sbeoz0ghpLYcFFXRVDKMUXgMutLXTw==
+react-hook-form@^7.36.1:
+  version "7.36.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.36.1.tgz#82a311fe8cbe75e689fd4529f083b7c983da6520"
+  integrity sha512-EbYYkCG2p8ywe7ikOH2l02lAFMrrrslZi1I8fqd8ifDGNAkhomHZQzQsP6ksvzrWBKntRe8b5L5L7Zsd+Gm02Q==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
## What it solves

Resolves #686

## How this PR fixes it

Some sort of bug in RHF caches the error state somewhere. I blamed our code at first, but it doesn't cache the error anywhere. It's not the debounce or anything else on our side. `trigger` seems to help.