### PR TITLE
Fix: overflowing address name

### DIFF
--- a/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -57,7 +57,7 @@ const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
               {wallet.label} @ {chainInfo?.chainName}
             </Typography>
 
-            <Typography variant="caption" fontWeight="bold" className={css.address}>
+            <Typography variant="caption" fontWeight="bold">
               {wallet.ens || (
                 <EthHashInfo
                   prefix={chainInfo?.shortName}
@@ -94,7 +94,9 @@ const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
         <Paper className={css.popoverContainer}>
           <Identicon address={wallet.address} />
 
-          <Typography variant="h5">{addressBook[wallet.address] || wallet.ens}</Typography>
+          <Typography variant="h5" className={css.addressName}>
+            {addressBook[wallet.address] || wallet.ens}
+          </Typography>
 
           <Box bgcolor="border.background" px={2} py={1} fontSize={14}>
             <EthHashInfo address={wallet.address} showAvatar={false} showName={false} hasExplorer showCopyButton />

--- a/src/components/common/ConnectWallet/styles.module.css
+++ b/src/components/common/ConnectWallet/styles.module.css
@@ -21,6 +21,13 @@
   border: 1px solid var(--color-border-light);
 }
 
+.addressName {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
 .imageContainer {
   position: relative;
   font-size: 16px;


### PR DESCRIPTION
## What it solves

<img width="488" alt="Screenshot 2022-09-28 at 10 27 41" src="https://user-images.githubusercontent.com/381895/192734660-664d260a-bcb0-433d-85e4-ed994ee1d443.png">

## How this PR fixes it
Adds no wrap + ellipsis.

## Screenshots
<img width="293" alt="Screenshot 2022-09-28 at 10 48 57" src="https://user-images.githubusercontent.com/381895/192734739-c281f536-155e-4c5f-8367-ad3766620a85.png">
