### PR TITLE
Fix: page headers w/o Safe name

### DIFF
--- a/src/components/common/PageHeader/index.tsx
+++ b/src/components/common/PageHeader/index.tsx
@@ -16,17 +16,15 @@ const PageHeader = ({
 }): ReactElement => {
   const safeAddress = useSafeAddress()
   const addressBook = useAddressBook()
-
   const isNamedSafe = !!addressBook[safeAddress]
+  const nameHeight = isNamedSafe ? 20 : 0
 
   return (
     <Box
       className={css.container}
       sx={{
-        // Doesn't work in module
-        position: 'sticky',
-        top: -96,
-        height: isNamedSafe ? '219px' : '199px',
+        height: `${199 + nameHeight}.5px`,
+        top: `-${76 + nameHeight}px`,
       }}
     >
       <div>

--- a/src/components/common/PageHeader/styles.module.css
+++ b/src/components/common/PageHeader/styles.module.css
@@ -7,4 +7,5 @@
   background-color: var(--color-background-paper);
   z-index: 1;
   width: 100%;
+  position: sticky !important;
 }


### PR DESCRIPTION
## What it solves
<img width="1566" alt="Screenshot 2022-09-28 at 12 04 16" src="https://user-images.githubusercontent.com/381895/192751709-88a71495-5b96-488a-bd4c-3e323ce81743.png">

## How this PR fixes it
Adds the same fixed offset when sticky as is added to the height.

## Screenshots
<img width="1571" alt="Screenshot 2022-09-28 at 12 06 32" src="https://user-images.githubusercontent.com/381895/192752153-b029b052-4ae4-4be4-baa7-85c63d35e111.png">
