### PR TITLE
fix: handle gas estimation error in createTx

### DIFF
--- a/src/services/tx/__tests__/txSender.test.ts
+++ b/src/services/tx/__tests__/txSender.test.ts
@@ -1,7 +1,7 @@
 import { setSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import Safe from '@gnosis.pm/safe-core-sdk'
 import { type TransactionResult } from '@gnosis.pm/safe-core-sdk-types'
-import { getTransactionDetails } from '@gnosis.pm/safe-react-gateway-sdk'
+import { getTransactionDetails, postSafeGasEstimation } from '@gnosis.pm/safe-react-gateway-sdk'
 import extractTxInfo from '../extractTxInfo'
 import proposeTx from '../proposeTransaction'
 import * as txEvents from '../txEvents'
@@ -107,6 +107,26 @@ describe('txSender', () => {
         data: '0x0',
         nonce: 18,
       }
+      expect(mockSafeSDK.createTransaction).toHaveBeenCalledWith({ safeTransactionData })
+    })
+
+    it('should create a tx with initial txParams if gas estimation fails', async () => {
+      // override postSafeGasEstimation default implementation
+      ;(postSafeGasEstimation as jest.Mock)
+        .mockImplementationOnce(() => Promise.reject(new Error('Failed to retrieve recommended nonce #1')))
+        .mockImplementationOnce(() => Promise.reject(new Error('Failed to retrieve recommended nonce #2')))
+
+      const txParams = {
+        to: '0x123',
+        value: '1',
+        data: '0x0',
+      }
+      await createTx(txParams)
+
+      // Shallow copy of txParams
+      const safeTransactionData = Object.assign({}, txParams)
+
+      // calls SDK createTransaction withouth recommended nonce
       expect(mockSafeSDK.createTransaction).toHaveBeenCalledWith({ safeTransactionData })
     })
   })

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -59,7 +59,8 @@ export const createTx = async (txParams: SafeTransactionDataPartial, nonce?: num
   // Set the recommended nonce and safeTxGas if not provided
   if (nonce === undefined) {
     const chainId = await safeSDK.getChainId()
-    const safeAddress = await safeSDK.getAddress()
+    const safeNonce = await safeSDK.getNonce()
+    const safeAddress = safeSDK.getAddress()
     let estimation: SafeTransactionEstimation
     try {
       estimation = await estimateSafeTxGas(String(chainId), safeAddress, txParams)
@@ -72,7 +73,7 @@ export const createTx = async (txParams: SafeTransactionDataPartial, nonce?: num
         estimation = await estimateSafeTxGas(String(chainId), safeAddress, minTxParams)
       } catch (e) {
         logError(Errors._616, (e as Error).message)
-        estimation = { currentNonce: 0, recommendedNonce: 0, safeTxGas: '0' }
+        estimation = { currentNonce: safeNonce, recommendedNonce: safeNonce, safeTxGas: '0' }
       }
     }
     txParams = { ...txParams, nonce: estimation.recommendedNonce, safeTxGas: Number(estimation.safeTxGas) }

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -57,11 +57,18 @@ export const createTx = async (txParams: SafeTransactionDataPartial, nonce?: num
   // Set the recommended nonce and safeTxGas if not provided
   if (nonce === undefined) {
     const chainId = await safeSDK.getChainId()
+    const safeAddress = await safeSDK.getAddress()
     let estimation: SafeTransactionEstimation
     try {
       estimation = await estimateSafeTxGas(String(chainId), safeSDK.getAddress(), txParams)
     } catch (e) {
-      estimation = { currentNonce: 0, recommendedNonce: 0, safeTxGas: '0' }
+      try {
+        const minTxParams = { ...txParams, data: '0x', to: safeAddress }
+        estimation = await estimateSafeTxGas(String(chainId), safeSDK.getAddress(), minTxParams)
+      } catch (e) {
+        console.error('Error estimating SafeTx gas', e)
+        estimation = { currentNonce: 0, recommendedNonce: 0, safeTxGas: '0' }
+      }
     }
     txParams = { ...txParams, nonce: estimation.recommendedNonce, safeTxGas: Number(estimation.safeTxGas) }
   } else {

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -90,7 +90,7 @@ export const createTx = async (txParams: SafeTransactionDataPartial, nonce?: num
     const recParams = (await getRecommendedTxParams(txParams)) || {}
     txParams = { ...txParams, ...recParams }
   } else {
-    // Othrwise, we use the provided one
+    // Otherwise, we use the provided one
     txParams = { ...txParams, nonce }
   }
 

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -67,10 +67,10 @@ export const createTx = async (txParams: SafeTransactionDataPartial, nonce?: num
     } catch (e) {
       try {
         /* If the initial transaction data causes the estimation to fail
-         we retry the request with an empty transaction to obtain the
+         we retry the request with a cancellation transaction to get the
          recommendedNonce even if the original transaction will likely fail */
-        const minTxParams = { ...txParams, data: EMPTY_DATA, to: safeAddress, value: '0' }
-        estimation = await estimateSafeTxGas(String(chainId), safeAddress, minTxParams)
+        const cancellationTxParams = { ...txParams, data: EMPTY_DATA, to: safeAddress, value: '0' }
+        estimation = await estimateSafeTxGas(String(chainId), safeAddress, cancellationTxParams)
       } catch (e) {
         logError(Errors._616, (e as Error).message)
         estimation = { currentNonce: safeNonce, recommendedNonce: safeNonce, safeTxGas: '0' }

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -27,6 +27,7 @@ import { SpendingLimitTxParams } from '@/components/tx/modals/TokenTransferModal
 import { getSpendingLimitContract } from '@/services/contracts/spendingLimitContracts'
 import EthersAdapter from '@gnosis.pm/safe-ethers-lib'
 import { Errors, logError } from '@/services/exceptions'
+import { EMPTY_DATA } from '@gnosis.pm/safe-core-sdk/dist/src/utils/constants'
 
 const getAndValidateSafeSDK = (): Safe => {
   const safeSDK = getSafeSDK()
@@ -67,7 +68,7 @@ export const createTx = async (txParams: SafeTransactionDataPartial, nonce?: num
         /* If the initial transaction data causes the estimation to fail
          we retry the request with an empty transaction to obtain the
          recommendedNonce even if the original transaction will likely fail */
-        const minTxParams = { ...txParams, data: '0x', to: safeAddress, value: '0' }
+        const minTxParams = { ...txParams, data: EMPTY_DATA, to: safeAddress, value: '0' }
         estimation = await estimateSafeTxGas(String(chainId), safeAddress, minTxParams)
       } catch (e) {
         logError(Errors._616, (e as Error).message)

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -59,7 +59,6 @@ export const createTx = async (txParams: SafeTransactionDataPartial, nonce?: num
   // Set the recommended nonce and safeTxGas if not provided
   if (nonce === undefined) {
     const chainId = await safeSDK.getChainId()
-    const safeNonce = await safeSDK.getNonce()
     const safeAddress = safeSDK.getAddress()
     let estimation: SafeTransactionEstimation
     try {
@@ -73,7 +72,7 @@ export const createTx = async (txParams: SafeTransactionDataPartial, nonce?: num
         estimation = await estimateSafeTxGas(String(chainId), safeAddress, cancellationTxParams)
       } catch (e) {
         logError(Errors._616, (e as Error).message)
-        estimation = { currentNonce: safeNonce, recommendedNonce: safeNonce, safeTxGas: '0' }
+        return safeSDK.createTransaction({ safeTransactionData: txParams })
       }
     }
     txParams = { ...txParams, nonce: estimation.recommendedNonce, safeTxGas: Number(estimation.safeTxGas) }

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -57,7 +57,12 @@ export const createTx = async (txParams: SafeTransactionDataPartial, nonce?: num
   // Set the recommended nonce and safeTxGas if not provided
   if (nonce === undefined) {
     const chainId = await safeSDK.getChainId()
-    const estimation = await estimateSafeTxGas(String(chainId), safeSDK.getAddress(), txParams)
+    let estimation: SafeTransactionEstimation
+    try {
+      estimation = await estimateSafeTxGas(String(chainId), safeSDK.getAddress(), txParams)
+    } catch (e) {
+      estimation = { currentNonce: 0, recommendedNonce: 0, safeTxGas: '0' }
+    }
     txParams = { ...txParams, nonce: estimation.recommendedNonce, safeTxGas: Number(estimation.safeTxGas) }
   } else {
     txParams = { ...txParams, nonce }


### PR DESCRIPTION
## What it solves

Resolves #644

## How this PR fixes it
The SafeTx gas estimation call is now inside of a `try..catch`. Because the estimation failed with the initial param, both `recommendedNonce` and `safeTxGas` were not fetched.
If the estimation fails with the initial params, a second request with '0x' data is issued to be able to retrieve the recommendedNonce for the "Review Modal"

## How to test it
See steps of #644 
The Review Modal is expected to be operable now.

## Screenshots
![Screenshot 2022-09-28 at 13 35 27](https://user-images.githubusercontent.com/32431609/192768975-2d536853-c959-48de-be22-501a41e52d34.png)
