### PR TITLE
fix: show <EthHashInfo /> for known tx recipients

### DIFF
--- a/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
+++ b/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
@@ -21,6 +21,8 @@ import { type NftTransferParams } from '.'
 import useCollectibles from '@/hooks/useCollectibles'
 import { SafeCollectibleResponse } from '@gnosis.pm/safe-react-gateway-sdk'
 import ImageFallback from '@/components/common/ImageFallback'
+import useAddressBook from '@/hooks/useAddressBook'
+import EthHashInfo from '@/components/common/EthHashInfo'
 
 enum Field {
   recipient = 'recipient',
@@ -58,6 +60,7 @@ const NftMenuItem = ({ image, name, description }: { image: string; name: string
 )
 
 const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
+  const addressBook = useAddressBook()
   const [pageUrl, setPageUrl] = useState<string>()
   const [combinedNfts, setCombinedNfts] = useState<SafeCollectibleResponse[]>()
   const [nftData, nftError, nftLoading] = useCollectibles(pageUrl)
@@ -77,6 +80,8 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
     setValue,
     formState: { errors },
   } = formMethods
+
+  const recipient = watch(Field.recipient)
 
   // Collections
   const collections = useMemo(() => uniqBy(allNfts, 'address'), [allNfts])
@@ -115,7 +120,13 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
           <SendFromBlock />
 
           <FormControl fullWidth sx={{ mb: 2, mt: 1 }}>
-            <AddressBookInput name={Field.recipient} label="Recipient" />
+            {addressBook[recipient] ? (
+              <Box onClick={() => setValue(Field.recipient, '')}>
+                <EthHashInfo address={recipient} shortAddress={false} hasExplorer showCopyButton />
+              </Box>
+            ) : (
+              <AddressBookInput name={Field.recipient} label="Recipient" />
+            )}
           </FormControl>
 
           <FormControl fullWidth sx={{ mb: 2 }}>

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -81,7 +81,6 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
     formState: { errors },
   } = formMethods
 
-  // Recipient
   const recipient = watch(SendAssetsField.recipient)
 
   // Selected token

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -10,6 +10,7 @@ import {
   Typography,
   TextField,
   DialogContent,
+  Box,
 } from '@mui/material'
 import { type TokenInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 
@@ -22,6 +23,8 @@ import InputValueHelper from '@/components/common/InputValueHelper'
 import SendFromBlock from '../../SendFromBlock'
 import SpendingLimitRow from '@/components/tx/SpendingLimitRow'
 import useSpendingLimit from '@/hooks/useSpendingLimit'
+import EthHashInfo from '@/components/common/EthHashInfo'
+import useAddressBook from '@/hooks/useAddressBook'
 
 export const AutocompleteItem = (item: { tokenInfo: TokenInfo; balance: string }): ReactElement => (
   <Grid container alignItems="center" gap={1}>
@@ -63,6 +66,7 @@ type SendAssetsFormProps = {
 
 const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactElement => {
   const { balances } = useBalances()
+  const addressBook = useAddressBook()
 
   const formMethods = useForm<SendAssetsFormData>({
     defaultValues: { ...formData, [SendAssetsField.type]: SendTxType.multiSig },
@@ -76,6 +80,9 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
     watch,
     formState: { errors },
   } = formMethods
+
+  // Recipient
+  const recipient = watch(SendAssetsField.recipient)
 
   // Selected token
   const tokenAddress = watch(SendAssetsField.tokenAddress)
@@ -105,7 +112,13 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
           <SendFromBlock />
 
           <FormControl fullWidth sx={{ mb: 2, mt: 1 }}>
-            <AddressBookInput name={SendAssetsField.recipient} label="Recipient" />
+            {addressBook[recipient] ? (
+              <Box onClick={() => setValue(SendAssetsField.recipient, '')}>
+                <EthHashInfo address={recipient} shortAddress={false} hasExplorer showCopyButton />
+              </Box>
+            ) : (
+              <AddressBookInput name={SendAssetsField.recipient} label="Recipient" />
+            )}
           </FormControl>
 
           <FormControl fullWidth sx={{ mb: 2 }}>


### PR DESCRIPTION
## What it solves

Resolves #678

## How this PR fixes it
if the selected tx recipient is know show it in a `<EthHashInfo />` component
Clicking on the `<EthHashInfo />` resets the recipient value.

## How to test it
1. Go to "Send funds"
2. Select a recipient address from the list
3. Observe <EthHashInfo /> component with the know address

1. Go to "Send NFT"
2. Select a recipient address from the list
3. Observe <EthHashInfo /> component with the know address

## Screenshots
<img width="622" alt="Screenshot 2022-09-28 at 15 27 22" src="https://user-images.githubusercontent.com/32431609/192790795-d8399128-0565-4dbe-9c24-61d77020e4d9.png">

<img width="624" alt="Screenshot 2022-09-29 at 10 56 06" src="https://user-images.githubusercontent.com/32431609/192987906-e22010e3-0b97-4c8a-bb98-dbaaca80799f.png">
