### PR TITLE
style: make `button` element inherit parent font globally

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -32,6 +32,10 @@ a {
   text-decoration: none;
 }
 
+button {
+  font: inherit;
+}
+
 * {
   box-sizing: border-box;
 }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -162,13 +162,6 @@ const initTheme = (darkMode: boolean) => {
           sizeLarge: { fontSize: '16px' },
         },
       },
-      MuiLink: {
-        styleOverrides: {
-          button: ({ theme }) => ({
-            fontFamily: theme.typography.fontFamily,
-          }),
-        },
-      },
       MuiAccordion: {
         styleOverrides: {
           root: ({ theme }) => ({

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -162,6 +162,13 @@ const initTheme = (darkMode: boolean) => {
           sizeLarge: { fontSize: '16px' },
         },
       },
+      MuiLink: {
+        styleOverrides: {
+          button: ({ theme }) => ({
+            fontFamily: theme.typography.fontFamily,
+          }),
+        },
+      },
       MuiAccordion: {
         styleOverrides: {
           root: ({ theme }) => ({


### PR DESCRIPTION
## What it solves

Resolves #668

## How this PR fixes it
Sets a global style for `button` in order to keep the agent stylesheet from overwriting the font property

## How to test it
1. Go to the Tx Signers in the history list.
2. The "Hide All" button shall have `DM Sans,sans-serif` font-family

## Screenshots
<img width="762" alt="Screenshot 2022-09-28 at 16 43 32" src="https://user-images.githubusercontent.com/32431609/192809570-b7e98ac1-3307-4000-8e5c-49e346e5be32.png">
