### PR TITLE
Fix: page placeholder style

### DIFF
--- a/src/components/common/PagePlaceholder/styles.module.css
+++ b/src/components/common/PagePlaceholder/styles.module.css
@@ -7,3 +7,10 @@
   text-align: center;
   flex: 1;
 }
+
+.container svg,
+.container img {
+  min-height: 200px;
+  max-height: 100%;
+  width: auto;
+}

--- a/src/components/common/PagePlaceholder/styles.module.css
+++ b/src/components/common/PagePlaceholder/styles.module.css
@@ -1,16 +1,9 @@
 .container {
-  height: 100%;
+  padding-top: 10vh;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   text-align: center;
   flex: 1;
-}
-
-.container svg,
-.container img {
-  min-height: 200px;
-  max-height: 100%;
-  width: auto;
 }

--- a/src/components/dashboard/PendingTxs/PendingTxsList.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxsList.tsx
@@ -2,14 +2,13 @@ import { ReactElement, useMemo } from 'react'
 import { useRouter } from 'next/router'
 import uniqBy from 'lodash/uniqBy'
 import styled from '@emotion/styled'
-import { Skeleton, Typography } from '@mui/material'
+import { Box, Skeleton, Typography } from '@mui/material'
 import { Transaction } from '@gnosis.pm/safe-react-gateway-sdk'
 import { Card, ViewAllLink, WidgetBody, WidgetContainer } from '../styled'
 import PendingTxListItem from './PendingTxListItem'
 import { isMultisigExecutionInfo, isTransactionListItem } from '@/utils/transaction-guards'
 import useTxQueue from '@/hooks/useTxQueue'
 import { AppRoutes } from '@/config/routes'
-import PagePlaceholder from '@/components/common/PagePlaceholder'
 import NoTransactionsIcon from '@/public/images/no-transactions.svg'
 import { getQueuedTransactionCount } from '@/utils/transactions'
 
@@ -33,7 +32,13 @@ const StyledWidgetTitle = styled.div`
 const EmptyState = () => {
   return (
     <Card>
-      <PagePlaceholder img={<NoTransactionsIcon />} text="This Safe has no queued transactions" />
+      <Box display="flex" flexDirection="column" alignItems="center" justifyContent="center" height="100%" gap={2}>
+        <NoTransactionsIcon />
+
+        <Typography variant="body1" color="primary.light">
+          This Safe has no queued transactions
+        </Typography>
+      </Box>
     </Card>
   )
 }


### PR DESCRIPTION
## What it solves

We lost the image size after the illustrations were updated.

<img width="1331" alt="Screenshot 2022-09-28 at 18 28 01" src="https://user-images.githubusercontent.com/381895/192834716-fdf3bf7f-1804-46cb-9bd9-f10a15043cee.png">