### PR TITLE
fix: add native currency to filter label

### DIFF
--- a/src/components/transactions/TxFilterForm/index.tsx
+++ b/src/components/transactions/TxFilterForm/index.tsx
@@ -18,6 +18,7 @@ import { validateAmount } from '@/utils/validation'
 import { trackEvent } from '@/services/analytics'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 import { txFilter, useTxFilter, TxFilterType, type TxFilter } from '@/utils/tx-history-filter'
+import { useCurrentChain } from '@/hooks/useChains'
 
 enum TxFilterFormFieldNames {
   FILTER_TYPE = 'type',
@@ -63,6 +64,7 @@ const getInitialFormValues = (filter: TxFilter | null): DefaultValues<TxFilterFo
 
 const TxFilterForm = ({ toggleFilter }: { toggleFilter: () => void }): ReactElement => {
   const [filter, setFilter] = useTxFilter()
+  const chain = useCurrentChain()
 
   const formMethods = useForm<TxFilterFormState>({
     mode: 'onChange',
@@ -190,7 +192,10 @@ const TxFilterForm = ({ toggleFilter }: { toggleFilter: () => void }): ReactElem
                           }}
                           render={({ field, fieldState }) => (
                             <TextField
-                              label={fieldState.error?.message || 'Amount'}
+                              label={
+                                fieldState.error?.message ||
+                                `Amount${isMultisigFilter && chain ? ` (only ${chain.nativeCurrency.symbol})` : ''}`
+                              }
                               error={!!fieldState.error}
                               {...field}
                               fullWidth


### PR DESCRIPTION
## What it solves

Resolves #501

## How this PR fixes it

The outgoing amount filter now shows "Acount (only {{nativeCurrency}})" as a label.

## How to test it

Open the outgoing transaction filter and observe the new label. It should not show on the incoming filter.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/192982095-ff981cd3-363e-4418-9290-444cfcb0ffad.png)

![image](https://user-images.githubusercontent.com/20442784/192982244-77289947-2d93-48ae-b662-7f4fe076dc26.png)