### PR TITLE
Style share btn overlapping text

### DIFF
--- a/src/components/transactions/TxDetails/TxData/Rejection/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/Rejection/index.tsx
@@ -19,7 +19,7 @@ const RejectionTxInfo = ({ nonce, isTxExecuted }: Props) => {
 
   return (
     <>
-      <Typography>{message}</Typography>
+      <Typography mr={2}>{message}</Typography>
       {!isTxExecuted && (
         <Box mt={2} sx={{ width: 'fit-content' }}>
           <Link

--- a/src/components/transactions/TxDetails/TxData/Rejection/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/Rejection/index.tsx
@@ -21,8 +21,7 @@ const RejectionTxInfo = ({ nonce, isTxExecuted }: Props) => {
     <>
       <Typography>{message}</Typography>
       {!isTxExecuted && (
-        <>
-          <br />
+        <Box mt={2} sx={{ width: 'fit-content' }}>
           <Link
             href="https://help.gnosis-safe.io/en/articles/4738501-why-do-i-need-to-pay-for-cancelling-a-transaction"
             target="_blank"
@@ -36,7 +35,7 @@ const RejectionTxInfo = ({ nonce, isTxExecuted }: Props) => {
               <LinkIcon />
             </Box>
           </Link>
-        </>
+        </Box>
       )}
     </>
   )


### PR DESCRIPTION
## What it solves

Resolves #663

## How this PR fixes it
Assigns some margin right to the copy

## How to test it
1. Expand a "On-chain rejection" transaction
2. Observe the copy that goes like "_This is an on-chain rejection that didn't send any funds. (...)_" to never stay under the Share button in different viewport widths

## Analytics changes
None

## Screenshots
<img width="658" alt="Screenshot 2022-09-29 at 11 17 31" src="https://user-images.githubusercontent.com/32431609/192993393-a9ae62c6-38b3-4982-9cf6-0e390642801c.png">
