### PR TITLE
Fix: add safe nonce tooltip

### DIFF
--- a/src/pages/settings/setup.tsx
+++ b/src/pages/settings/setup.tsx
@@ -35,7 +35,10 @@ const Setup: NextPage = () => {
             <Grid item lg={4} xs={12}>
               <Typography variant="h4" fontWeight={700}>
                 Safe nonce
-                <Tooltip placement="top" title="For security reasons, transactions made with Safe need to be executed in order. The nonce shows you which transaction will be executed next. You can find the nonce for a transaction in the transaction details.">
+                <Tooltip
+                  placement="top"
+                  title="For security reasons, transactions made with Safe need to be executed in order. The nonce shows you which transaction will be executed next. You can find the nonce for a transaction in the transaction details."
+                >
                   <InfoIcon fontSize="small" sx={{ verticalAlign: 'middle', ml: 0.5 }} />
                 </Tooltip>
               </Typography>

--- a/src/pages/settings/setup.tsx
+++ b/src/pages/settings/setup.tsx
@@ -1,6 +1,7 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
-import { Grid, Paper, Typography } from '@mui/material'
+import { Box, Grid, Paper, Tooltip, Typography } from '@mui/material'
+import InfoIcon from '@mui/icons-material/Info'
 import { ContractVersion } from '@/components/settings/ContractVersion'
 import { OwnerList } from '@/components/settings/owner/OwnerList'
 import { RequiredConfirmation } from '@/components/settings/RequiredConfirmations'
@@ -34,8 +35,17 @@ const Setup: NextPage = () => {
             <Grid item lg={4} xs={12}>
               <Typography variant="h4" fontWeight={700}>
                 Safe nonce
+                <Tooltip title="For security reasons, transactions made with Safe need to be executed in order. The nonce shows you which transaction will be executed next. You can find the nonce for a transaction in the transaction details.">
+                  <InfoIcon fontSize="small" sx={{ verticalAlign: 'middle', ml: 0.5 }} />
+                </Tooltip>
               </Typography>
-              <Typography paddingTop={1}>Current nonce: {nonce}</Typography>
+
+              <Box pt={1}>
+                <Typography color="text.secondary" component="span">
+                  Current nonce:
+                </Typography>{' '}
+                {nonce}
+              </Box>
             </Grid>
 
             <Grid item xs>

--- a/src/pages/settings/setup.tsx
+++ b/src/pages/settings/setup.tsx
@@ -35,7 +35,7 @@ const Setup: NextPage = () => {
             <Grid item lg={4} xs={12}>
               <Typography variant="h4" fontWeight={700}>
                 Safe nonce
-                <Tooltip title="For security reasons, transactions made with Safe need to be executed in order. The nonce shows you which transaction will be executed next. You can find the nonce for a transaction in the transaction details.">
+                <Tooltip placement="top" title="For security reasons, transactions made with Safe need to be executed in order. The nonce shows you which transaction will be executed next. You can find the nonce for a transaction in the transaction details.">
                   <InfoIcon fontSize="small" sx={{ verticalAlign: 'middle', ml: 0.5 }} />
                 </Tooltip>
               </Typography>


### PR DESCRIPTION
## What it solves

Resolves #736

## How this PR fixes it

Adds a tooltip to the Safe nonce in settings.

<img width="349" alt="Screenshot 2022-09-29 at 12 08 03" src="https://user-images.githubusercontent.com/381895/193004221-0743355a-387d-4989-ad65-0fe899851a7f.png">