### PR TITLE
fix: Use unchecked signer when executing transactions

### DIFF
--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -113,7 +113,7 @@ const SignOrExecuteForm = ({
 
   // Execute transaction
   const onExecute = async (): Promise<string> => {
-    const [connectedWallet, createdTx] = assertSubmittable()
+    const [connectedWallet, createdTx, provider] = assertSubmittable()
 
     // If no txId was provided, it's an immediate execution of a new tx
     let id = txId
@@ -124,7 +124,7 @@ const SignOrExecuteForm = ({
 
     const txOptions = getTxOptions(advancedParams, currentChain)
 
-    await dispatchTxExecution(id, createdTx, txOptions)
+    await dispatchTxExecution(id, createdTx, provider, txOptions)
 
     return id
   }

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -104,7 +104,7 @@ const SignOrExecuteForm = ({
     const shouldEthSign = shouldUseEthSignMethod(connectedWallet)
     const smartContractWallet = await isSmartContractWallet(connectedWallet)
     const signedTx = smartContractWallet
-      ? await dispatchOnChainSigning(createdTx, provider, txId)
+      ? await dispatchOnChainSigning(createdTx, provider)
       : await dispatchTxSigning(createdTx, shouldEthSign, txId)
 
     const proposedTx = await dispatchTxProposal(safe.chainId, safeAddress, connectedWallet.address, signedTx, txId)

--- a/src/services/tx/__tests__/txSender.test.ts
+++ b/src/services/tx/__tests__/txSender.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../txSender'
 import { ErrorCode } from '@ethersproject/logger'
 import { waitFor } from '@/tests/test-utils'
+import { Web3Provider } from '@ethersproject/providers'
 
 // Mock getTransactionDetails
 jest.mock('@gnosis.pm/safe-react-gateway-sdk', () => ({
@@ -57,6 +58,7 @@ const mockSafeSDK = {
       },
     }),
   ),
+  connect: jest.fn(() => Promise.resolve(mockSafeSDK)),
   getChainId: jest.fn(() => Promise.resolve(4)),
   getAddress: jest.fn(() => '0x0000000000000000000000000000000000000123'),
   getTransactionHash: jest.fn(() => Promise.resolve('0x1234567890')),
@@ -233,6 +235,8 @@ describe('txSender', () => {
   })
 
   describe('dispatchTxExecution', () => {
+    const mockProvider: Web3Provider = new Web3Provider(jest.fn())
+
     it('should execute a tx', async () => {
       const txId = 'tx_id_123'
 
@@ -243,7 +247,7 @@ describe('txSender', () => {
         nonce: 1,
       })
 
-      await dispatchTxExecution(txId, safeTx)
+      await dispatchTxExecution(txId, safeTx, mockProvider)
 
       expect(mockSafeSDK.executeTransaction).toHaveBeenCalled()
       expect(txEvents.txDispatch).toHaveBeenCalledWith('EXECUTING', { txId })
@@ -263,7 +267,7 @@ describe('txSender', () => {
         nonce: 1,
       })
 
-      await expect(dispatchTxExecution(txId, safeTx)).rejects.toThrow('error')
+      await expect(dispatchTxExecution(txId, safeTx, mockProvider)).rejects.toThrow('error')
 
       expect(mockSafeSDK.executeTransaction).toHaveBeenCalled()
       expect(txEvents.txDispatch).toHaveBeenCalledWith('EXECUTING', { txId })
@@ -288,7 +292,7 @@ describe('txSender', () => {
         nonce: 1,
       })
 
-      await dispatchTxExecution(txId, safeTx)
+      await dispatchTxExecution(txId, safeTx, mockProvider)
 
       expect(mockSafeSDK.executeTransaction).toHaveBeenCalled()
       expect(txEvents.txDispatch).toHaveBeenCalledWith('EXECUTING', { txId })
@@ -318,7 +322,7 @@ describe('txSender', () => {
         nonce: 1,
       })
 
-      await dispatchTxExecution(txId, safeTx)
+      await dispatchTxExecution(txId, safeTx, mockProvider)
 
       expect(mockSafeSDK.executeTransaction).toHaveBeenCalled()
       expect(txEvents.txDispatch).toHaveBeenCalledWith('EXECUTING', { txId })
@@ -350,7 +354,7 @@ describe('txSender', () => {
         nonce: 1,
       })
 
-      await dispatchTxExecution(txId, safeTx)
+      await dispatchTxExecution(txId, safeTx, mockProvider)
 
       expect(mockSafeSDK.executeTransaction).toHaveBeenCalled()
       expect(txEvents.txDispatch).toHaveBeenCalledWith('EXECUTING', { txId })

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -220,7 +220,7 @@ export const dispatchTxSigning = async (
 /**
  * On-Chain sign a transaction
  */
-export const dispatchOnChainSigning = async (safeTx: SafeTransaction, provider: Web3Provider, txId?: string) => {
+export const dispatchOnChainSigning = async (safeTx: SafeTransaction, provider: Web3Provider) => {
   const sdkUnchecked = await getUncheckedSafeSDK(provider)
   const safeTxHash = await sdkUnchecked.getTransactionHash(safeTx)
 

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -35,6 +35,24 @@ const getAndValidateSafeSDK = (): Safe => {
   return safeSDK
 }
 
+/**
+ * https://docs.ethers.io/v5/api/providers/jsonrpc-provider/#UncheckedJsonRpcSigner
+ * This resolves the promise sooner when executing a tx and mocks
+ * most of the values of transactionResponse which is needed when
+ * dealing with smart-contract wallet owners
+ */
+const getUncheckedSafeSDK = (provider: Web3Provider): Promise<Safe> => {
+  const sdk = getAndValidateSafeSDK()
+
+  const signer = provider.getSigner()
+  const ethAdapter = new EthersAdapter({
+    ethers,
+    signer: signer.connectUnchecked(),
+  })
+
+  return sdk.connect({ ethAdapter })
+}
+
 const estimateSafeTxGas = async (
   chainId: string,
   safeAddress: string,
@@ -203,21 +221,14 @@ export const dispatchTxSigning = async (
  * On-Chain sign a transaction
  */
 export const dispatchOnChainSigning = async (safeTx: SafeTransaction, provider: Web3Provider, txId?: string) => {
-  const sdk = getAndValidateSafeSDK()
-  const safeTxHash = await sdk.getTransactionHash(safeTx)
-
-  const signer = provider.getSigner()
-  const ethersAdapter = new EthersAdapter({
-    ethers,
-    signer: signer.connectUnchecked(),
-  })
+  const sdkUnchecked = await getUncheckedSafeSDK(provider)
+  const safeTxHash = await sdkUnchecked.getTransactionHash(safeTx)
 
   txDispatch(TxEvent.EXECUTING, { groupKey: safeTxHash })
 
   try {
     // With the unchecked signer, the contract call resolves once the tx
     // has been submitted in the wallet not when it has been executed
-    const sdkUnchecked = await sdk.connect({ ethAdapter: ethersAdapter })
     await sdkUnchecked.approveTransactionHash(safeTxHash)
   } catch (err) {
     txDispatch(TxEvent.FAILED, { groupKey: safeTxHash, error: err as Error })
@@ -235,16 +246,17 @@ export const dispatchOnChainSigning = async (safeTx: SafeTransaction, provider: 
 export const dispatchTxExecution = async (
   txId: string,
   safeTx: SafeTransaction,
+  provider: Web3Provider,
   txOptions?: TransactionOptions,
 ): Promise<string> => {
-  const sdk = getAndValidateSafeSDK()
+  const sdkUnchecked = await getUncheckedSafeSDK(provider)
 
   txDispatch(TxEvent.EXECUTING, { txId })
 
   // Execute the tx
   let result: TransactionResult | undefined
   try {
-    result = await sdk.executeTransaction(safeTx, txOptions)
+    result = await sdkUnchecked.executeTransaction(safeTx, txOptions)
   } catch (error) {
     txDispatch(TxEvent.FAILED, { txId, error: error as Error })
     throw error


### PR DESCRIPTION
## What it solves

Resolves #658 

## How this PR fixes it

An unchecked signer is used when executing a transaction. This resolves the promise as soon as the tx is submitted in the wallet both for smart-contract wallet owners and EOA owners.

The main difference is that `transactionResponse` now returns [mocked values](https://docs.ethers.io/v5/api/providers/jsonrpc-provider/#UncheckedJsonRpcSigner) (except for txHash). Since we only call `.wait()` on it and are not accessing any other properties I implemented this as a general solution instead of only doing it for executions done with smart-contract wallet owner.

## How to test it

- Follow the steps described in #658 
- Test tx executions with EOA and hardware wallets
- Observe that in all cases, the tx modal closes as soon as the tx is submitted in the wallet

## Screenshots
Left: `transactionResponse` of a tx that is being executed with a `JsonRpcSigner`
Right: `transactionResponse` of a tx that is being executed  with a `JsonRpcUncheckedSigner`
<img width="1503" alt="Screenshot 2022-09-29 at 12 41 59" src="https://user-images.githubusercontent.com/5880855/193011864-133c44cf-17b0-4274-a9a8-33dff029c80b.png">
