### PR TITLE
style: place Beamer tooltip to the right after Sidebar

### DIFF
--- a/src/services/beamer/index.ts
+++ b/src/services/beamer/index.ts
@@ -25,6 +25,7 @@ export const loadBeamer = async (): Promise<void> => {
     selector: BEAMER_SELECTOR,
     display: 'left',
     bounce: false,
+    display_position: 'right',
   }
 
   scriptRef = document.createElement('script')

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -87,3 +87,7 @@ input[type='number'] {
     background: var(--color-background-paper);
   }
 }
+
+#beamerLastPostTitle {
+  left: 330px !important;
+}


### PR DESCRIPTION
## What it solves

Resolves #730

## How this PR fixes it
Changes the tooltip to "right" in Beamer's config
Offsets the tooltip past the Sidebar

## How to test it
1. Unselect Beamer's cookies
2. Accept Beamer's cookies
3. Observe the tooltip is rightfully placed

## Analytics changes
N/A

## Screenshots
<img width="628" alt="Screenshot 2022-09-29 at 13 20 01" src="https://user-images.githubusercontent.com/32431609/193019213-b0b43efb-d79d-43b6-a282-ee48f561754a.png">
