### PR TITLE
Fix: MUI CSS cache for SSG

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,8 +5,7 @@ import Head from 'next/head'
 import CssBaseline from '@mui/material/CssBaseline'
 import { ThemeProvider } from '@mui/material/styles'
 import { setBaseUrl } from '@gnosis.pm/safe-react-gateway-sdk'
-import { CacheProvider } from '@emotion/react'
-import createCache from '@emotion/cache'
+import { CacheProvider, type EmotionCache } from '@emotion/react'
 import '@/styles/globals.css'
 import { IS_PRODUCTION, GATEWAY_URL } from '@/config/constants'
 import { StoreHydrator } from '@/store'
@@ -30,11 +29,7 @@ import useGtm from '@/services/analytics/useGtm'
 import useBeamer from '@/hooks/useBeamer'
 import ErrorBoundary from '@/components/common/ErrorBoundary'
 import { ContentSecurityPolicy, StrictTransportSecurity } from '@/config/securityHeaders'
-
-const cssCache = createCache({
-  key: 'css',
-  prepend: true,
-})
+import createEmotionCache from '@/utils/createEmotionCache'
 
 const InitApp = (): null => {
   if (!IS_PRODUCTION && !cgwDebugStorage.get()) {
@@ -58,21 +53,26 @@ const InitApp = (): null => {
   return null
 }
 
+// Client-side cache, shared for the whole session of the user in the browser.
+const clientSideEmotionCache = createEmotionCache()
+
 export const AppProviders = ({ children }: { children: ReactNode | ReactNode[] }) => {
   const theme = useLightDarkTheme()
 
   return (
-    <CacheProvider value={cssCache}>
-      <ThemeProvider theme={theme}>
-        <Sentry.ErrorBoundary showDialog fallback={ErrorBoundary}>
-          {children}
-        </Sentry.ErrorBoundary>
-      </ThemeProvider>
-    </CacheProvider>
+    <ThemeProvider theme={theme}>
+      <Sentry.ErrorBoundary showDialog fallback={ErrorBoundary}>
+        {children}
+      </Sentry.ErrorBoundary>
+    </ThemeProvider>
   )
 }
 
-const SafeWebCore = ({ Component, pageProps }: AppProps): ReactElement => {
+interface WebCoreAppProps extends AppProps {
+  emotionCache?: EmotionCache
+}
+
+const WebCoreApp = ({ Component, pageProps, emotionCache = clientSideEmotionCache }: WebCoreAppProps): ReactElement => {
   return (
     <StoreHydrator>
       <Head>
@@ -97,21 +97,23 @@ const SafeWebCore = ({ Component, pageProps }: AppProps): ReactElement => {
         <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#000" />
       </Head>
 
-      <AppProviders>
-        <CssBaseline />
+      <CacheProvider value={emotionCache}>
+        <AppProviders>
+          <CssBaseline />
 
-        <InitApp />
+          <InitApp />
 
-        <PageLayout>
-          <Component {...pageProps} />
-        </PageLayout>
+          <PageLayout>
+            <Component {...pageProps} />
+          </PageLayout>
 
-        <CookieBanner />
+          <CookieBanner />
 
-        <Notifications />
-      </AppProviders>
+          <Notifications />
+        </AppProviders>
+      </CacheProvider>
     </StoreHydrator>
   )
 }
 
-export default SafeWebCore
+export default WebCoreApp

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,61 @@
+/**
+ * This file is needed to embed MUI theme CSS into the pre-built HTML files
+ * @see https://github.com/mui/material-ui/tree/master/examples/nextjs-with-typescript
+ */
+import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document'
+import createEmotionServer from '@emotion/server/create-instance'
+import createEmotionCache from '@/utils/createEmotionCache'
+
+export default class WebCoreDocument extends Document {
+  render() {
+    return (
+      <Html lang="en">
+        <Head>
+          <meta name="emotion-insertion-point" content="" />
+          {(this.props as any).emotionStyleTags}
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+const getInitialProps = async (ctx: DocumentContext) => {
+  const originalRenderPage = ctx.renderPage
+
+  // You can consider sharing the same Emotion cache between all the SSR requests to speed up performance.
+  // However, be aware that it can have global side effects.
+  const cache = createEmotionCache()
+  const { extractCriticalToChunks } = createEmotionServer(cache)
+
+  ctx.renderPage = () =>
+    originalRenderPage({
+      enhanceApp: (App: any) =>
+        function EnhanceApp(props) {
+          return <App emotionCache={cache} {...props} />
+        },
+    })
+
+  const initialProps = await Document.getInitialProps(ctx)
+  // This is important. It prevents Emotion to render invalid HTML.
+  // See https://github.com/mui/material-ui/issues/26561#issuecomment-855286153
+  const emotionStyles = extractCriticalToChunks(initialProps.html)
+  const emotionStyleTags = emotionStyles.styles.map((style) => (
+    <style
+      data-emotion={`${style.key} ${style.ids.join(' ')}`}
+      key={style.key}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: style.css }}
+    />
+  ))
+
+  return {
+    ...initialProps,
+    emotionStyleTags,
+  }
+}
+
+WebCoreDocument.getInitialProps = getInitialProps

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -11,6 +11,7 @@ export default class WebCoreDocument extends Document {
     return (
       <Html lang="en">
         <Head>
+          <title>Safe</title>
           <meta name="emotion-insertion-point" content="" />
           {(this.props as any).emotionStyleTags}
         </Head>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -11,7 +11,6 @@ export default class WebCoreDocument extends Document {
     return (
       <Html lang="en">
         <Head>
-          <title>Safe</title>
           <meta name="emotion-insertion-point" content="" />
           {(this.props as any).emotionStyleTags}
         </Head>

--- a/src/utils/createEmotionCache.ts
+++ b/src/utils/createEmotionCache.ts
@@ -1,0 +1,17 @@
+import createCache from '@emotion/cache'
+
+const isBrowser = typeof document !== 'undefined'
+
+// On the client side, Create a meta tag at the top of the <head> and set it as insertionPoint.
+// This assures that MUI styles are loaded first.
+// It allows developers to easily override MUI styles with other styling solutions, like CSS modules.
+export default function createEmotionCache() {
+  let insertionPoint
+
+  if (isBrowser) {
+    const emotionInsertionPoint = document.querySelector<HTMLMetaElement>('meta[name="emotion-insertion-point"]')
+    insertionPoint = emotionInsertionPoint ?? undefined
+  }
+
+  return createCache({ key: 'mui-style', insertionPoint })
+}


### PR DESCRIPTION
## What it solves

Resolves #680

## How this PR fixes it

I've copied this example: https://github.com/mui/material-ui/tree/master/examples/nextjs-with-typescript

Basically restoring what @yagopv already did once.

The MUI theme CSS is now embedded into the pre-built HTML files.