### PR TITLE
fix: show explorer icon when replacing owner

### DIFF
--- a/src/components/settings/owner/AddOwnerDialog/DialogSteps/ChooseOwnerStep.tsx
+++ b/src/components/settings/owner/AddOwnerDialog/DialogSteps/ChooseOwnerStep.tsx
@@ -67,7 +67,7 @@ export const ChooseOwnerStep = ({
           {removedOwner && (
             <Box my={2}>
               <Typography mb={1}>Current owner</Typography>
-              <EthHashInfo address={removedOwner.address} showCopyButton shortAddress={false} />
+              <EthHashInfo address={removedOwner.address} showCopyButton shortAddress={false} hasExplorer />
             </Box>
           )}
 

--- a/src/components/settings/owner/AddOwnerDialog/DialogSteps/ReviewOwnerTxStep.tsx
+++ b/src/components/settings/owner/AddOwnerDialog/DialogSteps/ReviewOwnerTxStep.tsx
@@ -96,7 +96,15 @@ export const ReviewOwnerTxStep = ({ data, onSubmit }: { data: ChangeOwnerData; o
             {safe.owners
               .filter((owner) => !removedOwner || !sameAddress(owner.value, removedOwner.address))
               .map((owner) => {
-                return <EthHashInfo key={owner.value} address={owner.value} shortAddress={false} />
+                return (
+                  <EthHashInfo
+                    key={owner.value}
+                    address={owner.value}
+                    shortAddress={false}
+                    showCopyButton
+                    hasExplorer
+                  />
+                )
               })}
           </Box>
           {removedOwner && (
@@ -106,7 +114,7 @@ export const ReviewOwnerTxStep = ({ data, onSubmit }: { data: ChangeOwnerData; o
               </div>
               <Divider />
               <Box bgcolor="error.light" padding={2}>
-                <EthHashInfo address={removedOwner.address} shortAddress={false} />
+                <EthHashInfo address={removedOwner.address} shortAddress={false} showCopyButton hasExplorer />
               </Box>
               <Divider />
             </>
@@ -116,7 +124,7 @@ export const ReviewOwnerTxStep = ({ data, onSubmit }: { data: ChangeOwnerData; o
           </div>
           <Divider />
           <Box padding={2}>
-            <EthHashInfo address={newOwner.address} shortAddress={false} />
+            <EthHashInfo address={newOwner.address} shortAddress={false} showCopyButton hasExplorer />
           </Box>
         </Grid>
       </Grid>

--- a/src/components/settings/owner/RemoveOwnerDialog/DialogSteps/ReviewRemoveOwnerTxStep.tsx
+++ b/src/components/settings/owner/RemoveOwnerDialog/DialogSteps/ReviewRemoveOwnerTxStep.tsx
@@ -74,7 +74,7 @@ export const ReviewRemoveOwnerTxStep = ({
             .map((owner) => (
               <div key={owner.value}>
                 <Box padding={2} key={owner.value}>
-                  <EthHashInfo address={owner.value} shortAddress={false} />
+                  <EthHashInfo address={owner.value} shortAddress={false} showCopyButton hasExplorer />
                 </Box>
                 <Divider />
               </div>
@@ -86,7 +86,7 @@ export const ReviewRemoveOwnerTxStep = ({
               </div>
               <Divider />
               <Box bgcolor="error.light" padding={2}>
-                <EthHashInfo address={removedOwner.address} shortAddress={false} />
+                <EthHashInfo address={removedOwner.address} shortAddress={false} showCopyButton hasExplorer />
               </Box>
               <Divider />
             </>


### PR DESCRIPTION
## What it solves

Resolves #741

## How this PR fixes it

The explorer link is shown next to the address when replacing an owner.

## How to test it

Open the owner replacement modal and observe the explorer link.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/193030829-8f0f5bc0-fa98-437f-8003-1c967493083f.png)