### PR TITLE
fix: change colour of tx  guard modal title

### DIFF
--- a/src/components/settings/TransactionGuards/RemoveGuard/steps/ReviewRemoveGuard.tsx
+++ b/src/components/settings/TransactionGuards/RemoveGuard/steps/ReviewRemoveGuard.tsx
@@ -32,7 +32,7 @@ export const ReviewRemoveGuard = ({ data, onSubmit }: { data: RemoveGuardData; o
 
   return (
     <SignOrExecuteForm safeTx={safeTx} isExecutable={safe.threshold === 1} onSubmit={onFormSubmit} error={safeTxError}>
-      <Typography sx={({ palette }) => ({ color: palette.secondary.light })}>Transaction guard</Typography>
+      <Typography sx={({ palette }) => ({ color: palette.primary.light })}>Transaction guard</Typography>
       <EthHashInfo address={data.address} showCopyButton hasExplorer shortAddress={false} />
       <Typography my={2}>
         Once the transaction guard has been removed, checks by the transaction guard will not be conducted before or


### PR DESCRIPTION
## What it solves

Resolves #754

## How this PR fixes it

The transaction removal modal title colour is now `primary.light`.

## How to test it

Open the transaction guard removal modal and observe the correct title colour.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/193037360-97376200-6014-43c0-8fc1-56d7b5f9cbe5.png)