### PR TITLE
fix: fixed redirection to the safe app on safe creation

### DIFF
--- a/src/components/common/NetworkSelector/index.tsx
+++ b/src/components/common/NetworkSelector/index.tsx
@@ -29,6 +29,7 @@ const NetworkSelector = (): ReactElement => {
       pathname: shouldKeepPath ? router.pathname : '/',
       query: {
         chain: newShortName,
+        safeViewRedirectURL: router.query?.safeViewRedirectURL,
       },
     })
   }

--- a/src/components/safe-apps/SafeAppLandingPage/AppActions.tsx
+++ b/src/components/safe-apps/SafeAppLandingPage/AppActions.tsx
@@ -42,7 +42,7 @@ const AppActions = ({ wallet, onConnectWallet, safes, chain, appUrl }: Props): R
       break
     case shouldCreateSafe:
       const redirect = encodeURIComponent(`${AppRoutes.apps}?appUrl=${appUrl}`)
-      const createSafeHrefWithRedirect = `${AppRoutes.open}?safeViewRedirectURL=${redirect}`
+      const createSafeHrefWithRedirect = `${AppRoutes.open}?chain=${chain.shortName}&safeViewRedirectURL=${redirect}`
       button = (
         <Button variant="contained" sx={{ width: CTA_BUTTON_WIDTH }} href={createSafeHrefWithRedirect}>
           Create new Safe


### PR DESCRIPTION
## What it solves

Resolves #696 

## How this PR fixes it

Switching chain using the network selector keeps the Safe App link in the URL.

In the `NetworkSelector` component:

```
[....]

    return router.push({
      pathname: shouldKeepPath ? router.pathname : '/',
      query: {
        chain: newShortName,
        safeViewRedirectURL: router.query?.safeViewRedirectURL,
      },
    })
```

## How to test it

1. open a share a safe app link
2. Connect your wallet (with an address that is not an owner of a safes to make sure that the Crate Safe Button is present)
3. Use the network selector
4. Complete the Safe Creation
5. You are redirected to the Safe App with your new Safe! 😃 

