### PR TITLE
fix: add missing `required` prop to relevant fields

### DIFF
--- a/src/components/common/AddressInput/index.tsx
+++ b/src/components/common/AddressInput/index.tsx
@@ -83,6 +83,7 @@ const AddressInput = ({ name, validate, required = true, ...props }: AddressInpu
             ...(props.InputLabelProps || {}),
             shrink: !!watchedValue || props.focused,
           }}
+          required={required}
           {...register(name, {
             required,
 

--- a/src/components/common/NameInput/index.tsx
+++ b/src/components/common/NameInput/index.tsx
@@ -23,6 +23,7 @@ const NameInput = ({
       label={<>{fieldError?.type === 'maxLength' ? 'Maximum 50 symbols' : fieldError?.message || props.label}</>}
       error={Boolean(fieldError)}
       fullWidth
+      required={required}
       {...register(name, { maxLength: 50, required })}
     />
   )

--- a/src/components/create-safe/steps/OwnerPolicyStep.tsx
+++ b/src/components/create-safe/steps/OwnerPolicyStep.tsx
@@ -114,7 +114,7 @@ const OwnerPolicyStep = ({ params, onSubmit, setStep, onBack }: Props): ReactEle
 
             <Box display="flex" alignItems="center" gap={2}>
               <FormControl>
-                <Select {...register('threshold')} defaultValue={defaultThreshold}>
+                <Select {...register('threshold')} defaultValue={defaultThreshold} required>
                   {fields.map((field, index) => (
                     <MenuItem key={field.id} value={index + 1}>
                       {index + 1}

--- a/src/components/settings/SpendingLimits/NewSpendingLimit/steps/SpendingLimitForm.tsx
+++ b/src/components/settings/SpendingLimits/NewSpendingLimit/steps/SpendingLimitForm.tsx
@@ -89,6 +89,7 @@ export const SpendingLimitForm = ({ data, onSubmit }: Props) => {
               label={errors.tokenAddress?.message || 'Select an asset'}
               defaultValue={data?.tokenAddress || ''}
               error={!!errors.tokenAddress}
+              required
               {...register('tokenAddress', {
                 required: true,
                 onChange: () => setValue('amount', ''),
@@ -107,6 +108,7 @@ export const SpendingLimitForm = ({ data, onSubmit }: Props) => {
               label={errors.amount?.message || 'Amount'}
               error={!!errors.amount}
               autoComplete="off"
+              required
               {...register('amount', {
                 required: true,
                 validate: (val) =>

--- a/src/components/settings/owner/AddOwnerDialog/DialogSteps/SetThresholdStep.tsx
+++ b/src/components/settings/owner/AddOwnerDialog/DialogSteps/SetThresholdStep.tsx
@@ -33,7 +33,7 @@ export const SetThresholdStep = ({
 
         <Grid container direction="row" alignItems="center" gap={1} pt={1}>
           <Grid item xs={1.5}>
-            <Select value={selectedThreshold} onChange={handleChange} fullWidth>
+            <Select value={selectedThreshold} onChange={handleChange} fullWidth required>
               {safe.owners.map((_, idx) => (
                 <MenuItem key={idx + 1} value={idx + 1}>
                   {idx + 1}

--- a/src/components/settings/owner/ChangeThresholdDialog/index.tsx
+++ b/src/components/settings/owner/ChangeThresholdDialog/index.tsx
@@ -75,7 +75,7 @@ const ChangeThresholdStep = ({ data, onSubmit }: { data: ChangeThresholdData; on
 
         <Grid container direction="row" gap={1} alignItems="center" mb={2}>
           <Grid item xs={2}>
-            <Select value={selectedThreshold ?? data.threshold} onChange={handleChange} fullWidth>
+            <Select value={selectedThreshold ?? data.threshold} onChange={handleChange} fullWidth required>
               {safe.owners.map((_, idx) => (
                 <MenuItem key={idx + 1} value={idx + 1}>
                   {idx + 1}

--- a/src/components/settings/owner/RemoveOwnerDialog/DialogSteps/SetThresholdStep.tsx
+++ b/src/components/settings/owner/RemoveOwnerDialog/DialogSteps/SetThresholdStep.tsx
@@ -33,7 +33,7 @@ export const SetThresholdStep = ({
 
         <Grid container direction="row" alignItems="center" gap={1} mt={1}>
           <Grid item xs={1.5}>
-            <Select value={selectedThreshold} onChange={handleChange} fullWidth>
+            <Select value={selectedThreshold} onChange={handleChange} fullWidth required>
               {safe.owners.slice(1).map((_, idx) => (
                 <MenuItem key={idx + 1} value={idx + 1}>
                   {idx + 1}

--- a/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
+++ b/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
@@ -112,6 +112,7 @@ const AdvancedParamsForm = ({ params, ...props }: AdvancedParamsFormProps) => {
                       autoComplete="off"
                       type="number"
                       disabled={props.nonceReadonly}
+                      required
                       {...register(AdvancedField.safeTxGas, { required: true, min: 0 })}
                     />
                   </FormControl>
@@ -151,6 +152,7 @@ const AdvancedParamsForm = ({ params, ...props }: AdvancedParamsFormProps) => {
                         label={errors.maxPriorityFeePerGas?.message || 'Max priority fee (Gwei)'}
                         error={!!errors.maxPriorityFeePerGas}
                         autoComplete="off"
+                        required
                         {...register(AdvancedField.maxPriorityFeePerGas, {
                           required: true,
                           pattern: FLOAT_REGEX,
@@ -166,6 +168,7 @@ const AdvancedParamsForm = ({ params, ...props }: AdvancedParamsFormProps) => {
                         label={errors.maxFeePerGas?.message || 'Max fee (Gwei)'}
                         error={!!errors.maxFeePerGas}
                         autoComplete="off"
+                        required
                         {...register(AdvancedField.maxFeePerGas, { required: true, pattern: FLOAT_REGEX, min: 0 })}
                       />
                     </FormControl>

--- a/src/components/tx/AdvancedParams/GasLimitInput.tsx
+++ b/src/components/tx/AdvancedParams/GasLimitInput.tsx
@@ -49,6 +49,7 @@ const GasLimitInput = ({ recommendedGasLimit }: { recommendedGasLimit?: string }
           shrink: currentGasLimit !== undefined,
         }}
         type="number"
+        required
         {...register(AdvancedField.gasLimit, { required: true, min: BASE_TX_GAS })}
       />
     </FormControl>

--- a/src/components/tx/NonceForm/index.tsx
+++ b/src/components/tx/NonceForm/index.tsx
@@ -51,6 +51,7 @@ const NonceForm = ({ name, nonce, recommendedNonce, readonly }: NonceFormProps):
       InputLabelProps={{
         shrink: currentNonce !== undefined,
       }}
+      required
       {...register(name, {
         required: true,
         valueAsNumber: true,

--- a/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
+++ b/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
@@ -126,6 +126,7 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
               render={({ field }) => (
                 <Select
                   {...field}
+                  required
                   labelId="asset-label"
                   label={errors.tokenAddress?.message || 'Select an NFT collection'}
                   error={!!errors.tokenAddress}
@@ -163,6 +164,7 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
               render={({ field }) => (
                 <Select
                   {...field}
+                  required
                   labelId="asset-label"
                   label={errors.tokenId?.message || 'Select an NFT'}
                   error={!!errors.tokenId}

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -115,6 +115,7 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
               label={errors.tokenAddress?.message || 'Select an asset'}
               defaultValue={formData?.tokenAddress || ''}
               error={!!errors.tokenAddress}
+              required
               {...register(SendAssetsField.tokenAddress, {
                 required: true,
                 onChange: () => setValue(SendAssetsField.amount, ''),
@@ -148,6 +149,7 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
               InputLabelProps={{
                 shrink: !!watch(SendAssetsField.amount),
               }}
+              required
               {...register(SendAssetsField.amount, {
                 required: true,
                 validate: (val) => {


### PR DESCRIPTION
## What it solves

Resolves #742

## How this PR fixes it

Fields that are required now append an asterisk to their label:

- Asset/amount when creating a spending limit
- Gas limit/nonce/safeTxGas (on older Safes) when editing transaction parameters
- Collection/asset when sending an NFT
- Asset/amount when sending an asset

## How to test it

View the aforementioned fields and observe the asterisk.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/193047974-6eabb88d-1530-4714-9769-aba1e12973cb.png)
![image](https://user-images.githubusercontent.com/20442784/193045334-bd68189a-4d24-4519-a53c-32c17768a3bc.png)
![image](https://user-images.githubusercontent.com/20442784/193048068-a133bef7-3f82-4330-8135-795911db1a67.png)
![image](https://user-images.githubusercontent.com/20442784/193048118-fc379b70-182e-4c3a-a0eb-2c91e8a77fa7.png)