### PR TITLE
fix(safe-apps): Remove trailing slash from permissions appUrl comparisons

### DIFF
--- a/src/hooks/safe-apps/permissions/useBrowserPermissions.ts
+++ b/src/hooks/safe-apps/permissions/useBrowserPermissions.ts
@@ -1,7 +1,7 @@
 import { AllowedFeatures, PermissionStatus } from '@/components/safe-apps/types'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import { useCallback } from 'react'
-import { trimTrailingSlash } from '../../../utils/url'
+import { trimTrailingSlash } from '@/utils/url'
 
 const BROWSER_PERMISSIONS = 'BROWSER_PERMISSIONS'
 

--- a/src/hooks/safe-apps/permissions/useBrowserPermissions.ts
+++ b/src/hooks/safe-apps/permissions/useBrowserPermissions.ts
@@ -1,6 +1,7 @@
 import { AllowedFeatures, PermissionStatus } from '@/components/safe-apps/types'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import { useCallback } from 'react'
+import { trimTrailingSlash } from '../../../utils/url'
 
 const BROWSER_PERMISSIONS = 'BROWSER_PERMISSIONS'
 
@@ -24,16 +25,18 @@ const useBrowserPermissions = (): UseBrowserPermissionsReturnType => {
 
   const getPermissions = useCallback(
     (origin: string) => {
-      return permissions[origin] || []
+      return permissions[trimTrailingSlash(origin)] || []
     },
     [permissions],
   )
 
   const updatePermission = useCallback(
     (origin: string, changeset: BrowserPermissionChangeSet) => {
+      const appUrl = trimTrailingSlash(origin)
+
       setPermissions({
         ...permissions,
-        [origin]: permissions[origin].map((p) => {
+        [appUrl]: permissions[appUrl].map((p) => {
           const change = changeset.find((change) => change.feature === p.feature)
 
           if (change) {
@@ -49,7 +52,7 @@ const useBrowserPermissions = (): UseBrowserPermissionsReturnType => {
 
   const removePermissions = useCallback(
     (origin: string) => {
-      delete permissions[origin]
+      delete permissions[trimTrailingSlash(origin)]
       setPermissions({ ...permissions })
     },
     [permissions, setPermissions],
@@ -57,7 +60,7 @@ const useBrowserPermissions = (): UseBrowserPermissionsReturnType => {
 
   const addPermissions = useCallback(
     (origin: string, selectedPermissions: BrowserPermission[]) => {
-      setPermissions({ ...permissions, [origin]: selectedPermissions })
+      setPermissions({ ...permissions, [trimTrailingSlash(origin)]: selectedPermissions })
     },
     [permissions, setPermissions],
   )

--- a/src/hooks/safe-apps/permissions/useSafePermissions.ts
+++ b/src/hooks/safe-apps/permissions/useSafePermissions.ts
@@ -4,6 +4,7 @@ import { Permission, PermissionCaveat, PermissionRequest } from '@gnosis.pm/safe
 
 import { PermissionStatus } from '@/components/safe-apps/types'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
+import { trimTrailingSlash } from '../../../utils/url'
 
 const SAFE_PERMISSIONS = 'SAFE_PERMISSIONS'
 const USER_RESTRICTED = 'userRestricted'
@@ -37,16 +38,18 @@ const useSafePermissions = (): UseSafePermissionsReturnType => {
 
   const getPermissions = useCallback(
     (origin: string) => {
-      return permissions[origin] || []
+      return permissions[trimTrailingSlash(origin)] || []
     },
     [permissions],
   )
 
   const updatePermission = useCallback(
     (origin: string, changeset: SafePermissionChangeSet) => {
+      const appUrl = trimTrailingSlash(origin)
+
       setPermissions({
         ...permissions,
-        [origin]: permissions[origin].map((permission) => {
+        [appUrl]: permissions[appUrl].map((permission) => {
           const change = changeset.find((change) => change.capability === permission.parentCapability)
 
           if (change) {
@@ -72,7 +75,7 @@ const useSafePermissions = (): UseSafePermissionsReturnType => {
 
   const removePermissions = useCallback(
     (origin: string) => {
-      delete permissions[origin]
+      delete permissions[trimTrailingSlash(origin)]
       setPermissions({ ...permissions })
     },
     [permissions, setPermissions],
@@ -80,14 +83,16 @@ const useSafePermissions = (): UseSafePermissionsReturnType => {
 
   const hasPermission = useCallback(
     (origin: string, permission: Methods) => {
-      return permissions[origin]?.some((p) => p.parentCapability === permission && !isUserRestricted(p.caveats))
+      return permissions[trimTrailingSlash(origin)]?.some(
+        (p) => p.parentCapability === permission && !isUserRestricted(p.caveats),
+      )
     },
     [permissions],
   )
 
   const hasCapability = useCallback(
     (origin: string, permission: Methods) => {
-      return permissions[origin]?.some((p) => p.parentCapability === permission)
+      return permissions[trimTrailingSlash(origin)]?.some((p) => p.parentCapability === permission)
     },
     [permissions],
   )

--- a/src/hooks/safe-apps/permissions/useSafePermissions.ts
+++ b/src/hooks/safe-apps/permissions/useSafePermissions.ts
@@ -4,7 +4,7 @@ import { Permission, PermissionCaveat, PermissionRequest } from '@gnosis.pm/safe
 
 import { PermissionStatus } from '@/components/safe-apps/types'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
-import { trimTrailingSlash } from '../../../utils/url'
+import { trimTrailingSlash } from '@/utils/url'
 
 const SAFE_PERMISSIONS = 'SAFE_PERMISSIONS'
 const USER_RESTRICTED = 'userRestricted'


### PR DESCRIPTION
## What it solves
Resolves https://github.com/safe-global/safe-react-apps/issues/500

## How this PR fixes it
We removed the trailingSlash from the comparisons between origins
