### PR TITLE
fix: only use address book/known names

### DIFF
--- a/src/components/settings/SafeModules/index.tsx
+++ b/src/components/settings/SafeModules/index.tsx
@@ -14,7 +14,7 @@ const NoModules = () => {
   )
 }
 
-const ModuleDisplay = ({ moduleAddress, chainId, name }: { moduleAddress: string; chainId: string; name: string }) => {
+const ModuleDisplay = ({ moduleAddress, chainId, name }: { moduleAddress: string; chainId: string; name?: string }) => {
   const isGranted = useIsGranted()
 
   return (
@@ -63,7 +63,7 @@ const SafeModules = () => {
                   key={module.value}
                   chainId={safe.chainId}
                   moduleAddress={module.value}
-                  name={module.name || ''}
+                  name={module.name}
                 />
               ))
             )}

--- a/src/components/settings/SafeModules/index.tsx
+++ b/src/components/settings/SafeModules/index.tsx
@@ -5,10 +5,6 @@ import { Paper, Grid, Typography, Box, Link } from '@mui/material'
 import css from './styles.module.css'
 import { RemoveModule } from '@/components/settings/SafeModules/RemoveModule'
 import useIsGranted from '@/hooks/useIsGranted'
-import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
-import { sameAddress } from '@/utils/addresses'
-
-export const DEFAULT_MODULE_NAME = 'Unknown module'
 
 const NoModules = () => {
   return (
@@ -16,14 +12,6 @@ const NoModules = () => {
       No modules enabled
     </Typography>
   )
-}
-
-const getModuleName = (chainId: string, address: string): string => {
-  if (sameAddress(getSpendingLimitModuleAddress(chainId), address)) {
-    return 'Spending limit module'
-  }
-
-  return DEFAULT_MODULE_NAME
 }
 
 const ModuleDisplay = ({ moduleAddress, chainId, name }: { moduleAddress: string; chainId: string; name: string }) => {
@@ -75,7 +63,7 @@ const SafeModules = () => {
                   key={module.value}
                   chainId={safe.chainId}
                   moduleAddress={module.value}
-                  name={module.name || getModuleName(safe.chainId, module.value)}
+                  name={module.name || ''}
                 />
               ))
             )}

--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -87,13 +87,11 @@ const MultiSendTx = ({ info }: { info: MultiSend }): ReactElement => {
 }
 
 const SettingsChangeTx = ({ info }: { info: SettingsChange }): ReactElement => {
-  const UNKNOWN_MODULE = 'Unknown module'
-
   if (
     info.settingsInfo?.type === SettingsInfoType.ENABLE_MODULE ||
     info.settingsInfo?.type === SettingsInfoType.DISABLE_MODULE
   ) {
-    return <>{info.settingsInfo.module.name || UNKNOWN_MODULE}</>
+    return <>{info.settingsInfo.module.name}</>
   }
 
   return <></>

--- a/src/hooks/useTransactionType.ts
+++ b/src/hooks/useTransactionType.ts
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import {
   SettingsInfoType,
   TransactionInfoType,
@@ -8,7 +7,7 @@ import {
 } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import { isCancellationTxInfo, isModuleExecutionInfo, isTxQueued } from '@/utils/transaction-guards'
-import { DEFAULT_MODULE_NAME } from '@/components/settings/SafeModules'
+import useAddressBook from './useAddressBook'
 
 const getTxTo = ({ txInfo }: Pick<TransactionSummary, 'txInfo'>): AddressEx | undefined => {
   switch (txInfo.type) {
@@ -32,8 +31,10 @@ type TxType = {
   text: string
 }
 
-const getTxType = (tx: TransactionSummary): TxType => {
+export const useTransactionType = (tx: TransactionSummary): TxType => {
   const toAddress = getTxTo(tx)
+  const addressBook = useAddressBook()
+  const addressBookName = toAddress?.value ? addressBook[toAddress.value] : undefined
 
   switch (tx.txInfo.type) {
     case TransactionInfoType.CREATION: {
@@ -64,7 +65,7 @@ const getTxType = (tx: TransactionSummary): TxType => {
       if (isModuleExecutionInfo(tx.executionInfo)) {
         return {
           icon: toAddress?.logoUri || '/images/transactions/settings.svg',
-          text: toAddress?.name || DEFAULT_MODULE_NAME,
+          text: toAddress?.name || '',
         }
       }
 
@@ -84,20 +85,14 @@ const getTxType = (tx: TransactionSummary): TxType => {
 
       return {
         icon: toAddress?.logoUri || '/images/transactions/custom.svg',
-        text: toAddress?.name || 'Contract interaction',
+        text: addressBookName || toAddress?.name || 'Contract interaction',
       }
     }
     default: {
       return {
         icon: '/images/transactions/custom.svg',
-        text: 'Contract interaction',
+        text: addressBookName || 'Contract interaction',
       }
     }
   }
-}
-
-export const useTransactionType = (tx: TransactionSummary): TxType => {
-  return useMemo(() => {
-    return getTxType(tx)
-  }, [tx])
 }

--- a/src/hooks/useTransactionType.ts
+++ b/src/hooks/useTransactionType.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import {
   SettingsInfoType,
   TransactionInfoType,
@@ -36,63 +37,65 @@ export const useTransactionType = (tx: TransactionSummary): TxType => {
   const addressBook = useAddressBook()
   const addressBookName = toAddress?.value ? addressBook[toAddress.value] : undefined
 
-  switch (tx.txInfo.type) {
-    case TransactionInfoType.CREATION: {
-      return {
-        icon: toAddress?.logoUri || '/images/transactions/settings.svg',
-        text: 'Safe created',
-      }
-    }
-    case TransactionInfoType.TRANSFER: {
-      const isSendTx = tx.txInfo.direction === TransferDirection.OUTGOING
-
-      return {
-        icon: isSendTx ? '/images/transactions/outgoing.svg' : '/images/transactions/incoming.svg',
-        text: isSendTx ? (isTxQueued(tx.txStatus) ? 'Send' : 'Sent') : 'Received',
-      }
-    }
-    case TransactionInfoType.SETTINGS_CHANGE: {
-      // deleteGuard doesn't exist in Solidity
-      // It is decoded as 'setGuard' with a settingsInfo.type of 'DELETE_GUARD'
-      const isDeleteGuard = tx.txInfo.settingsInfo?.type === SettingsInfoType.DELETE_GUARD
-
-      return {
-        icon: '/images/transactions/settings.svg',
-        text: isDeleteGuard ? 'deleteGuard' : tx.txInfo.dataDecoded.method,
-      }
-    }
-    case TransactionInfoType.CUSTOM: {
-      if (isModuleExecutionInfo(tx.executionInfo)) {
+  return useMemo(() => {
+    switch (tx.txInfo.type) {
+      case TransactionInfoType.CREATION: {
         return {
           icon: toAddress?.logoUri || '/images/transactions/settings.svg',
-          text: toAddress?.name || '',
+          text: 'Safe created',
         }
       }
+      case TransactionInfoType.TRANSFER: {
+        const isSendTx = tx.txInfo.direction === TransferDirection.OUTGOING
 
-      if (isCancellationTxInfo(tx.txInfo)) {
         return {
-          icon: '/images/transactions/circle-cross-red.svg',
-          text: 'On-chain rejection',
+          icon: isSendTx ? '/images/transactions/outgoing.svg' : '/images/transactions/incoming.svg',
+          text: isSendTx ? (isTxQueued(tx.txStatus) ? 'Send' : 'Sent') : 'Received',
         }
       }
+      case TransactionInfoType.SETTINGS_CHANGE: {
+        // deleteGuard doesn't exist in Solidity
+        // It is decoded as 'setGuard' with a settingsInfo.type of 'DELETE_GUARD'
+        const isDeleteGuard = tx.txInfo.settingsInfo?.type === SettingsInfoType.DELETE_GUARD
 
-      if (tx.safeAppInfo) {
         return {
-          icon: tx.safeAppInfo.logoUri,
-          text: tx.safeAppInfo.name,
+          icon: '/images/transactions/settings.svg',
+          text: isDeleteGuard ? 'deleteGuard' : tx.txInfo.dataDecoded.method,
         }
       }
+      case TransactionInfoType.CUSTOM: {
+        if (isModuleExecutionInfo(tx.executionInfo)) {
+          return {
+            icon: toAddress?.logoUri || '/images/transactions/settings.svg',
+            text: toAddress?.name || '',
+          }
+        }
 
-      return {
-        icon: toAddress?.logoUri || '/images/transactions/custom.svg',
-        text: addressBookName || toAddress?.name || 'Contract interaction',
+        if (isCancellationTxInfo(tx.txInfo)) {
+          return {
+            icon: '/images/transactions/circle-cross-red.svg',
+            text: 'On-chain rejection',
+          }
+        }
+
+        if (tx.safeAppInfo) {
+          return {
+            icon: tx.safeAppInfo.logoUri,
+            text: tx.safeAppInfo.name,
+          }
+        }
+
+        return {
+          icon: toAddress?.logoUri || '/images/transactions/custom.svg',
+          text: addressBookName || toAddress?.name || 'Contract interaction',
+        }
+      }
+      default: {
+        return {
+          icon: '/images/transactions/custom.svg',
+          text: addressBookName || 'Contract interaction',
+        }
       }
     }
-    default: {
-      return {
-        icon: '/images/transactions/custom.svg',
-        text: addressBookName || 'Contract interaction',
-      }
-    }
-  }
+  }, [tx, addressBookName, toAddress])
 }


### PR DESCRIPTION
## What it solves

Resolves #749, #775 & #755

## How this PR fixes it

- 749/775: We no longer hardcode any module names, including "Unknown module".
- 755: Contract interactions in the transaction list return the address book entry name if it is present as their type.

## How to test it

- 749/775: Ensure the spending limit or other module is enabled on your Safe and observe that they have no name.
- 755: Interact with a contract then add it's address to your address book. Observe the transaction list type now returns the address book name

## Screenshots

![module name](https://user-images.githubusercontent.com/20442784/193081839-393b7fff-04bd-4a8f-aa95-43c760b22063.gif)

![image](https://user-images.githubusercontent.com/20442784/193081503-427fc45f-6129-4b6f-a7c6-0f9a6686fbaa.png)