### PR TITLE
Fix: safe not found style

### DIFF
--- a/src/components/common/SafeLoadingError/index.tsx
+++ b/src/components/common/SafeLoadingError/index.tsx
@@ -14,7 +14,7 @@ const SafeLoadingError = ({ children }: { children: ReactNode }): ReactElement =
       img={<img src="/images/common/error.png" alt="A vault with a red icon in the bottom right corner" />}
       text="This Safe couldn't be loaded"
     >
-      <Button variant="contained" color="primary" size="large" href={AppRoutes.welcome}>
+      <Button variant="contained" color="primary" size="large" href={AppRoutes.welcome} sx={{ mt: 2 }}>
         Go to the main page
       </Button>
     </PagePlaceholder>


### PR DESCRIPTION
## What it solves
Merely adds a margin to fix this:
<img width="244" alt="Screenshot 2022-10-02 at 19 43 35" src="https://user-images.githubusercontent.com/381895/193468250-337c6c1d-01c6-4442-a297-4b6afb711886.png">

## How to test
https://fix-not-found.web-core.pages.dev/0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6/home