### PR TITLE
fix(safe-apps): Use classes for dark mode in network error icon

### DIFF
--- a/public/images/apps/network-error.svg
+++ b/public/images/apps/network-error.svg
@@ -4,14 +4,14 @@
     height="90"
     viewBox="0 0 90 90">
     <g fill="none" fillRule="evenodd">
-      <circle cx="45" cy="45" r="45" fill="#E8E7E6" />
+      <circle cx="45" cy="45" r="45" class="illustration-main-fill" />
       <path
-        fill="#B2B5B2"
+        class="illustration-background-fill"
         fillRule="nonzero"
         d="M26.24 62c-.57 0-1.13-.15-1.623-.437a3.254 3.254 0 0 1-1.18-4.44l18.76-32.501a3.234 3.234 0 0 1 5.606 0l18.761 32.501c.286.495.436 1.057.436 1.628A3.244 3.244 0 0 1 63.76 62H26.24z"
       />
       <path
-        fill="#E8E7E6"
+        class="illustration-main-fill"
         fillRule="nonzero"
         d="M47 49h-4V36h4zM47 55h-4v-4h4z"
       />
@@ -19,9 +19,8 @@
         cx="78"
         cy="78"
         r="11"
-        fill="#FFC05F"
+        class="illustration-light-fill"
         fillRule="nonzero"
-        stroke="#F6F7F8"
         strokeWidth="4"
       />
     </g>

--- a/src/components/safe-apps/SafeAppsErrorBoundary/SafeAppsLoadError.tsx
+++ b/src/components/safe-apps/SafeAppsErrorBoundary/SafeAppsLoadError.tsx
@@ -1,8 +1,10 @@
 import Typography from '@mui/material/Typography'
 import Link from '@mui/material/Link'
 import Button from '@mui/material/Button'
+import SvgIcon from '@mui/material/SvgIcon'
 import OpenInNew from '@mui/icons-material/OpenInNew'
 import { SAFE_APPS_SUPPORT_CHAT_URL } from '@/config/constants'
+import NetworkError from '@/public/images/apps/network-error.svg'
 
 import css from './styles.module.css'
 
@@ -16,7 +18,7 @@ const SafeAppsLoadError = ({ onBackToApps }: SafeAppsLoadErrorProps): React.Reac
       <div className={css.content}>
         <Typography variant="h1">Safe App could not be loaded</Typography>
 
-        <img src="/images/apps/network-error.svg" alt="Safe Apps load error" className={css.image} />
+        <SvgIcon component={NetworkError} inheritViewBox className={css.image} />
 
         <div>
           <Typography component="span">In case the problem persists, please reach out to us via </Typography>

--- a/src/components/safe-apps/SafeAppsErrorBoundary/styles.module.css
+++ b/src/components/safe-apps/SafeAppsErrorBoundary/styles.module.css
@@ -38,4 +38,6 @@
 .image {
   margin-top: 15px;
   margin-bottom: 15px;
+  width: 64px;
+  height: 64px;
 }


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/web-core/issues/707

## How this PR fixes it
Use classes for dark mode instead same image for both
