### PR TITLE
Chore: deploy HTML files w/o extension

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -45,8 +45,13 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
       - name: Deploy to the staging S3
-        # A hack to achieve blue-green deployments: run the sync command twice.
-        # First time to upload new files, second time to upload the new files AND clean up old files.
         run: |
-          aws s3 sync ./out s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current
-          aws s3 sync ./out s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete
+          cd out
+
+          aws s3 sync . s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current
+          aws s3 sync . s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current --delete
+
+          for file in $(find . -name '*.html' | sed 's|^\./||'); do
+              aws s3 cp ${file%} s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current/${file%.*} --content-type 'text/html'
+          done
+

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,7 +3,7 @@ name: Deploy to staging
 on:
   push:
     branches:
-      - staging
+      - main
 
 jobs:
   deploy-staging:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,3 @@ jobs:
       - uses: Maggi64/eslint-plus-action@master
         with:
           npmInstall: false
-
-      - name: Ensure build works
-        run: yarn build

--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -1,26 +1,26 @@
 # Releasing to production
 
-The code is being actively developed on the `main` branch. Pull requests are made against this branch.
+The code is being actively developed on the `dev` branch. Pull requests are made against this branch.
 
-After a release is approved by QA, the code goes to the `staging` branch and is deployed to the staging environment.
+After a release is approved by QA, the code goes to the `main` branch and is deployed to the staging environment.
 
 Schematically:
 ```
-<PR branch> –> main -> staging
+<PR branch> –> dev -> main
 ```
 
 We prepare at least one release every sprint. Sprints are two weeks long.
 
 ### Preparing a release branch
 * Create a code-freeze branch named `release/X.Y.Z`
-  * If it's a regular release, this branch is typically based off of `main`
-  * For hot fixes, it would be `staging` + cherry-picked commits
+  * If it's a regular release, this branch is typically based off of `dev`
+  * For hot fixes, it would be `main` + cherry-picked commits
 * Bump the version in the `package.json`
 * Create a PR with the list of changes
 
 💡 To generate a quick changelog:
 ```
-git log origin/staging..origin/main --pretty=format:'* %s'
+git log origin/main..origin/dev --pretty=format:'* %s'
 ```
 
 ### QA
@@ -32,9 +32,9 @@ git log origin/staging..origin/main --pretty=format:'* %s'
 Wait for all the checks on GitHub to pass.
 * Switch to the main branch and make sure it's up to date:
 ```
-git checkout staging
+git checkout main
 git fetch --all
-git reset --hard origin/staging
+git reset --hard origin/main
 ```
 * Pull from the release branch:
 ```
@@ -52,4 +52,4 @@ git push --tags
 
 * Create a [GitHub release](https://github.com/gnosis/safe-react/releases) for this tag
 * Notify devops on Slack and send them the release link to deploy to production
-* Back-merge `staging` into the `main` branch to keep them in sync
+* Back-merge `main` into the `dev` branch to keep them in sync

--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -1,17 +1,26 @@
 # Releasing to production
 
+The code is being actively developed on the `main` branch. Pull requests are made against this branch.
+
+After a release is approved by QA, the code goes to the `staging` branch and is deployed to the staging environment.
+
+Schematically:
+```
+<PR branch> –> main -> staging
+```
+
 We prepare at least one release every sprint. Sprints are two weeks long.
 
-### Prepare a branch
+### Preparing a release branch
 * Create a code-freeze branch named `release/X.Y.Z`
-  * If it's a regular release, this branch is typically based off of `dev`
-  * For hot fixes, it would be `main` + cherry-picked commits
+  * If it's a regular release, this branch is typically based off of `main`
+  * For hot fixes, it would be `staging` + cherry-picked commits
 * Bump the version in the `package.json`
 * Create a PR with the list of changes
 
 💡 To generate a quick changelog:
 ```
-git log origin/main..origin/dev --pretty=format:'* %s'
+git log origin/staging..origin/main --pretty=format:'* %s'
 ```
 
 ### QA
@@ -23,17 +32,17 @@ git log origin/main..origin/dev --pretty=format:'* %s'
 Wait for all the checks on GitHub to pass.
 * Switch to the main branch and make sure it's up to date:
 ```
-git checkout main
+git checkout staging
 git fetch --all
-git reset --hard origin/main
+git reset --hard origin/staging
 ```
 * Pull from the release branch:
 ```
 git pull origin release/3.15.0
 ```
-* Push to main:
+* Push:
 ```
-git push origin main
+git push
 ```
 * Create and push a new version tag :
 ```
@@ -43,4 +52,4 @@ git push --tags
 
 * Create a [GitHub release](https://github.com/gnosis/safe-react/releases) for this tag
 * Notify devops on Slack and send them the release link to deploy to production
-* Back-merge `main` into the `dev` branch to keep them in sync
+* Back-merge `staging` into the `main` branch to keep them in sync

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "serve": "npx -y http-server out"
   },
   "pre-commit": [
-    "lint",
-    "prettier"
+    "lint"
   ],
   "dependencies": {
     "@date-io/date-fns": "^2.15.0",

--- a/src/hooks/__tests__/usePathRewrite.test.ts
+++ b/src/hooks/__tests__/usePathRewrite.test.ts
@@ -1,5 +1,5 @@
-import usePathRewrite, { use404Rewrite } from '@/hooks/usePathRewrite'
-import { act, renderHook } from '@/tests/test-utils'
+import usePathRewrite from '@/hooks/usePathRewrite'
+import { renderHook } from '@/tests/test-utils'
 
 // mock window history replaceState
 Object.defineProperty(window, 'history', {
@@ -101,30 +101,5 @@ describe('usePathRewrite', () => {
       '',
       '/rin:0x0000000000000000000000000000000000000000/hello?hi=hello&count=1',
     )
-  })
-})
-
-describe('useQueryRewrite', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
-
-  it('should not redirect if there is no Safe address in the path', async () => {
-    const { result } = renderHook(() => use404Rewrite())
-    expect(result.current).toBe(false)
-  })
-
-  it('should redirect if there is a Safe address in the path', async () => {
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: {
-        pathname: '/rin:0x0000000000000000000000000000000000000000/balances',
-      },
-    })
-
-    const { result } = renderHook(() => use404Rewrite())
-    expect(result.current).toBe(true)
-    await act(() => Promise.resolve())
-    expect(result.current).toBe(true)
   })
 })

--- a/src/hooks/usePathRewrite.ts
+++ b/src/hooks/usePathRewrite.ts
@@ -1,12 +1,11 @@
 import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 
 // Next.js needs to know all the static paths in advance when doing SSG (static site generation)
 // @see https://nextjs.org/docs/api-reference/next.config.js/runtime-config-static-paths
 // Since we cannot enumerate all the possible Safe addresses which are part of the path,
 // we need to use the `?safe=` query parameter to pass the Safe address.
 // However, the user should still sees `/rin:0x123.../balances` in the browser URL.
-// These two hooks make it work.
 
 // This hook takes the `?safe=` query parameter and rewrites the URL to put the Safe address into the path
 // Next.js doesn't care because dynamic path params are internally represented as query params anyway.
@@ -41,32 +40,3 @@ const usePathRewrite = () => {
 }
 
 export default usePathRewrite
-
-// This hook is the opposite of the first one. It's called from the 404 page.
-// If we see that this URL wasn't found (i.e. the pass has a dynamic Safe address and no query),
-// we rewrite the URL to put the Safe address into the query.
-// This must and will cause a rendering and route change.
-// Thankfully, this will only happen if you reload the page or open this URL from an external link.
-export const use404Rewrite = (): boolean => {
-  const [redirecting, setRedirecting] = useState<boolean>(true)
-  const router = useRouter()
-
-  useEffect(() => {
-    if (typeof location === 'undefined') return
-    const currentPath = location.pathname
-    const re = /^\/([^/]+?:0x[0-9a-fA-F]{40})/
-    const [, pathSafe] = currentPath.match(re) || []
-
-    if (pathSafe) {
-      const newPath = currentPath.replace(re, '') || '/'
-
-      if (newPath !== currentPath) {
-        router.replace(`${newPath}?safe=${pathSafe}${location.search ? '&' + location.search.slice(1) : ''}`)
-      }
-    } else {
-      setRedirecting(false)
-    }
-  }, [router])
-
-  return redirecting
-}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,10 +1,39 @@
+import { useEffect, useState } from 'react'
 import type { NextPage } from 'next'
-import { use404Rewrite } from '@/hooks/usePathRewrite'
+import { useRouter } from 'next/router'
+
+// Rewrite the URL to put the Safe address into the query.
+const getRedirectUrl = (): string | undefined => {
+  if (typeof location === 'undefined') return
+
+  const { pathname, search } = location
+  const re = /^\/([^/]+?:0x[0-9a-fA-F]{40})/
+  const [, pathSafe] = pathname.match(re) || []
+
+  if (pathSafe) {
+    const newPath = pathname.replace(re, '') || '/'
+
+    if (newPath !== pathname) {
+      return `${newPath}?safe=${pathSafe}${search ? '&' + search.slice(1) : ''}`
+    }
+  }
+}
 
 const Custom404: NextPage = () => {
-  const isRedirecting = use404Rewrite()
+  const router = useRouter()
+  const [isRedirecting, setIsRedirecting] = useState<boolean>(true)
 
-  return <main>{!isRedirecting && <h1>404 - Page Not Found</h1>}</main>
+  useEffect(() => {
+    const redirectUrl = getRedirectUrl()
+
+    if (redirectUrl) {
+      router.replace(redirectUrl)
+    } else {
+      setIsRedirecting(false)
+    }
+  }, [router])
+
+  return <main>{!isRedirecting && <h1>404 - Page not found</h1>}</main>
 }
 
 export default Custom404


### PR DESCRIPTION
## What it solves
Copies HTML files to S3 w/o an extension but with the right content-type, so that URLs like `/welcome` work along with `/welcome.html`.

Also I moved the 404 redirect code to the 404 page itself, I think it makes more sense than a common hook.