### PR TITLE
Fix: scroll body when modal is too big

### DIFF
--- a/src/components/common/ModalDialog/index.tsx
+++ b/src/components/common/ModalDialog/index.tsx
@@ -70,7 +70,7 @@ const ModalDialog = ({
   const fullScreen = useMediaQuery(theme.breakpoints.down('sm'))
 
   return (
-    <StyledDialog {...restProps} fullScreen={fullScreen} onClick={(e) => e.stopPropagation()}>
+    <StyledDialog {...restProps} fullScreen={fullScreen} scroll="body" onClick={(e) => e.stopPropagation()}>
       {dialogTitle && (
         <ModalDialogTitle onClose={restProps.onClose} hideChainIndicator={hideChainIndicator}>
           {dialogTitle}


### PR DESCRIPTION
## What it solves

Resolves #744

## How this PR fixes it
Adds scoll=body to the MUI Dialog.

## How to test it
Open a Safe with many owners and try to add a new one.
The whole page should now scroll.