### PR TITLE
fix: align sidebar footer + page headers

### DIFF
--- a/src/components/common/PageHeader/index.tsx
+++ b/src/components/common/PageHeader/index.tsx
@@ -23,7 +23,7 @@ const PageHeader = ({
     <Box
       className={css.container}
       sx={{
-        height: `${199 + nameHeight}.5px`,
+        height: `${199 + nameHeight}px`,
         top: `-${76 + nameHeight}px`,
       }}
     >

--- a/src/components/sidebar/Sidebar/styles.module.css
+++ b/src/components/sidebar/Sidebar/styles.module.css
@@ -13,6 +13,9 @@
 }
 
 .scroll {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   position: relative;
   overflow-y: auto;
   overflow-x: hidden;
@@ -47,7 +50,7 @@
   z-index: 2;
   right: 0;
   transform: translateX(50%);
-  margin-top: 18px;
+  margin-top: 54px;
   border-radius: 50%;
   width: 40px;
   height: 40px;
@@ -76,6 +79,6 @@
   .drawerButton {
     width: 60px;
     height: 60px;
-    margin-top: 40px;
+    margin-top: 44px;
   }
 }


### PR DESCRIPTION
## What it solves

Misalignment of "What's new" and "Need help?" and page headers.

## How this PR fixes it

The sidebar footer is now pinned to the bottom and page headers now match the height of the sidebar header.

## How to test it

Open a Safe and observe the page headers align with the sidebar header and that the sidebar footer is pinned to the bottom of the sidebar.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/194006515-ca4dff10-eb1a-4992-9155-d7c4c342c6ec.png)

![image](https://user-images.githubusercontent.com/20442784/194006734-d78b82cf-b6fe-4bdf-8061-07559bdd2ec7.png)