### PR TITLE
fix: Persist stepper data when going back in create/load safe

### DIFF
--- a/src/components/common/AddressInput/useNameResolver.ts
+++ b/src/components/common/AddressInput/useNameResolver.ts
@@ -15,7 +15,7 @@ const useNameResolver = (
     if (!ethersProvider || !debouncedValue || !isDomain(debouncedValue)) return
 
     return resolveName(ethersProvider, debouncedValue).then((address) => {
-      if (!address) throw Error('Failed to reslove the address')
+      if (!address) throw Error('Failed to resolve the address')
       return { name: debouncedValue, address }
     })
   }, [debouncedValue, ethersProvider])

--- a/src/components/create-safe/steps/ConnectWalletStep.tsx
+++ b/src/components/create-safe/steps/ConnectWalletStep.tsx
@@ -74,7 +74,7 @@ const ConnectWalletStep = ({ onSubmit, onBack }: Props) => {
       <Box padding={3}>
         <Grid container alignItems="center" justifyContent="center" spacing={3}>
           <Grid item>
-            <Button onClick={onBack}>Cancel</Button>
+            <Button onClick={() => onBack()}>Cancel</Button>
           </Grid>
           <Grid item>
             <Button variant="contained" onClick={() => onSubmit(undefined)} disabled={isDisabled}>

--- a/src/components/create-safe/steps/OwnerPolicyStep.tsx
+++ b/src/components/create-safe/steps/OwnerPolicyStep.tsx
@@ -87,6 +87,10 @@ const OwnerPolicyStep = ({ params, onSubmit, setStep, onBack }: Props): ReactEle
     })
   })
 
+  const onFormBack = handleSubmit((data: SafeFormData) => {
+    onBack(data)
+  })
+
   return (
     <Paper>
       <FormProvider {...formMethods}>
@@ -155,7 +159,7 @@ const OwnerPolicyStep = ({ params, onSubmit, setStep, onBack }: Props): ReactEle
 
             <Grid container alignItems="center" justifyContent="center" spacing={3}>
               <Grid item>
-                <Button onClick={onBack}>Back</Button>
+                <Button onClick={onFormBack}>Back</Button>
               </Grid>
 
               <Grid item>

--- a/src/components/create-safe/steps/OwnerRow.tsx
+++ b/src/components/create-safe/steps/OwnerRow.tsx
@@ -44,10 +44,10 @@ export const OwnerRow = ({
       setValue(`${fieldName}.ens`, ens)
     }
 
-    if (name) {
+    if (name && !getValues(`${fieldName}.name`)) {
       setValue(`${fieldName}.name`, name)
     }
-  }, [ens, setValue, index, name, fieldName])
+  }, [ens, setValue, getValues, name, fieldName])
 
   return (
     <Grid container spacing={3} alignItems="center" marginBottom={3} flexWrap={['wrap', undefined, 'nowrap']}>

--- a/src/components/create-safe/steps/ReviewStep.tsx
+++ b/src/components/create-safe/steps/ReviewStep.tsx
@@ -111,7 +111,7 @@ const ReviewStep = ({ params, onSubmit, setStep, onBack }: Props) => {
       <Box padding={3}>
         <Grid container alignItems="center" justifyContent="center" spacing={3}>
           <Grid item>
-            <Button onClick={onBack}>Back</Button>
+            <Button onClick={() => onBack()}>Back</Button>
           </Grid>
           <Grid item>
             <Button variant="contained" onClick={createSafe}>

--- a/src/components/create-safe/steps/SetNameStep.tsx
+++ b/src/components/create-safe/steps/SetNameStep.tsx
@@ -44,6 +44,13 @@ const SetNameStep = ({ params, onSubmit, onBack, setStep }: Props) => {
     }
   })
 
+  const onFormBack = handleSubmit((data: SafeFormData) => {
+    onBack({
+      ...data,
+      name: data.name || fallbackName,
+    })
+  })
+
   return (
     <Paper>
       <FormProvider {...formMethods}>
@@ -74,7 +81,7 @@ const SetNameStep = ({ params, onSubmit, onBack, setStep }: Props) => {
           <Box padding={3}>
             <Grid container alignItems="center" justifyContent="center" spacing={3}>
               <Grid item>
-                <Button onClick={onBack}>Back</Button>
+                <Button onClick={onFormBack}>Back</Button>
               </Grid>
 
               <Grid item>

--- a/src/components/load-safe/steps/SafeOwnersStep.tsx
+++ b/src/components/load-safe/steps/SafeOwnersStep.tsx
@@ -74,7 +74,7 @@ const SafeOwnersStep = ({ params, onSubmit, onBack }: Props): ReactElement => {
             ))}
             <Grid container alignItems="center" justifyContent="center" spacing={3}>
               <Grid item>
-                <Button onClick={onBack}>Back</Button>
+                <Button onClick={() => onBack()}>Back</Button>
               </Grid>
               <Grid item>
                 <Button variant="contained" type="submit" disabled={!formState.isValid}>

--- a/src/components/load-safe/steps/SafeOwnersStep.tsx
+++ b/src/components/load-safe/steps/SafeOwnersStep.tsx
@@ -48,6 +48,10 @@ const SafeOwnersStep = ({ params, onSubmit, onBack }: Props): ReactElement => {
     setValue('owners', owners)
   }, [getValues, safeInfo, setValue])
 
+  const onFormBack = handleSubmit((data: SafeFormData) => {
+    onBack(data)
+  })
+
   return (
     <Paper>
       <FormProvider {...formMethods}>
@@ -74,7 +78,7 @@ const SafeOwnersStep = ({ params, onSubmit, onBack }: Props): ReactElement => {
             ))}
             <Grid container alignItems="center" justifyContent="center" spacing={3}>
               <Grid item>
-                <Button onClick={() => onBack()}>Back</Button>
+                <Button onClick={onFormBack}>Back</Button>
               </Grid>
               <Grid item>
                 <Button variant="contained" type="submit" disabled={!formState.isValid}>

--- a/src/components/load-safe/steps/SafeReviewStep.tsx
+++ b/src/components/load-safe/steps/SafeReviewStep.tsx
@@ -154,7 +154,7 @@ const SafeReviewStep = ({ params, onBack }: Props) => {
       <Box padding={3}>
         <Grid container alignItems="center" justifyContent="center" spacing={3}>
           <Grid item>
-            <Button onClick={onBack}>Back</Button>
+            <Button onClick={() => onBack()}>Back</Button>
           </Grid>
           <Grid item>
             <Button variant="contained" onClick={addSafe}>

--- a/src/components/load-safe/steps/SelectNetworkStep.tsx
+++ b/src/components/load-safe/steps/SelectNetworkStep.tsx
@@ -19,7 +19,7 @@ const SelectNetworkStep = ({ onSubmit, onBack }: Props) => {
       <Box padding={3}>
         <Grid container alignItems="center" justifyContent="center" spacing={3}>
           <Grid item>
-            <Button onClick={onBack}>Cancel</Button>
+            <Button onClick={() => onBack()}>Cancel</Button>
           </Grid>
           <Grid item>
             <Button variant="contained" onClick={() => onSubmit(undefined)}>

--- a/src/components/load-safe/steps/SetAddressStep.tsx
+++ b/src/components/load-safe/steps/SetAddressStep.tsx
@@ -130,7 +130,7 @@ const SetAddressStep = ({ params, onSubmit, onBack }: Props) => {
           <Box padding={3}>
             <Grid container alignItems="center" justifyContent="center" spacing={3}>
               <Grid item>
-                <Button onClick={onBack}>Back</Button>
+                <Button onClick={() => onBack()}>Back</Button>
               </Grid>
               <Grid item>
                 <Button variant="contained" type="submit" disabled={!formState.isValid}>

--- a/src/components/load-safe/steps/SetAddressStep.tsx
+++ b/src/components/load-safe/steps/SetAddressStep.tsx
@@ -69,6 +69,13 @@ const SetAddressStep = ({ params, onSubmit, onBack }: Props) => {
     }
   })
 
+  const onFormBack = handleSubmit((data: SafeFormData) => {
+    onBack({
+      ...data,
+      [FormField.name]: data[FormField.name] || fallbackName,
+    })
+  })
+
   return (
     <FormProvider {...formMethods}>
       <Paper>
@@ -130,7 +137,7 @@ const SetAddressStep = ({ params, onSubmit, onBack }: Props) => {
           <Box padding={3}>
             <Grid container alignItems="center" justifyContent="center" spacing={3}>
               <Grid item>
-                <Button onClick={() => onBack()}>Back</Button>
+                <Button onClick={onFormBack}>Back</Button>
               </Grid>
               <Grid item>
                 <Button variant="contained" type="submit" disabled={!formState.isValid}>

--- a/src/components/tx/TxStepper/index.tsx
+++ b/src/components/tx/TxStepper/index.tsx
@@ -36,7 +36,7 @@ const TxStepper = ({ steps, initialData, initialStep, onClose }: TxStepperProps)
       {steps[activeStep].render(activeStepData, onSubmit, onBack, setStep)}
 
       <DialogActions>
-        <Button color="inherit" onClick={onBack}>
+        <Button color="inherit" onClick={() => onBack()}>
           {firstStep ? 'Cancel' : 'Back'}
         </Button>
       </DialogActions>

--- a/src/components/tx/TxStepper/useTxStepper.ts
+++ b/src/components/tx/TxStepper/useTxStepper.ts
@@ -1,11 +1,12 @@
 import type { ReactElement } from 'react'
 import { useState } from 'react'
 import { trackEvent, MODALS_CATEGORY } from '@/services/analytics'
+import { merge } from 'lodash'
 
 export type StepRenderProps = {
   data: unknown
   onSubmit: (data: unknown) => void
-  onBack: () => void
+  onBack: (data?: unknown) => void
   setStep: (step: number) => void
 }
 
@@ -46,9 +47,20 @@ export const useTxStepper = ({
     trackEvent({ category: eventCategory, action: lastStep ? 'Submit' : 'Next' })
   }
 
-  const handleBack = () => {
+  const handleBack = (data?: unknown) => {
     setActiveStep((prevActiveStep) => prevActiveStep - 1)
     trackEvent({ category: eventCategory, action: firstStep ? 'Cancel' : 'Back' })
+
+    if (data) {
+      updateStepData(data)
+    }
+  }
+
+  const updateStepData = (data: unknown) => {
+    const allData = [...stepData]
+    allData[activeStep] = data
+    allData[activeStep + 1] = merge(allData[activeStep + 1], data)
+    setStepData(allData)
   }
 
   const setStep = (step: number) => {
@@ -65,10 +77,7 @@ export const useTxStepper = ({
       onFinish ? onFinish() : onClose()
       return
     }
-    const allData = [...stepData]
-    allData[activeStep] = data
-    allData[activeStep + 1] = data
-    setStepData(allData)
+    updateStepData(data)
     handleNext()
   }
 


### PR DESCRIPTION
## What it solves

Resolves #768 

## How this PR fixes it

- Extends `useTxStepper` to optionally update step data when going back
- Updates data in create/load safe forms when going back
- Fixes an issue where owner AddressBook names would overwrite a newly typed name in create/load safe forms

## How to test it

1. Open the Safe
2. Create a new Safe
3. Input data in every screen and press back and continue
4. Observe that the data is persisted
5. Load an existing Safe
6. Change data in every screen and press back and continue
7. Observe that the data is persisted
8. Change the name of an existing owner that has an AB entry and press back/continue
9. Observe that the newly typed name is shown instead of the AB name
