### PR TITLE
Fix: support non-EIP-1559 chains

### DIFF
--- a/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
+++ b/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
@@ -18,6 +18,7 @@ type AdvancedParamsFormProps = {
   recommendedNonce?: number
   recommendedGasLimit?: AdvancedParameters['gasLimit']
   isExecution: boolean
+  isEIP1559: boolean
   nonceReadonly?: boolean
 }
 
@@ -146,26 +147,28 @@ const AdvancedParamsForm = ({ params, ...props }: AdvancedParamsFormProps) => {
                   </Grid>
 
                   {/* Gas price */}
-                  <Grid item xs={6}>
-                    <FormControl fullWidth>
-                      <TextField
-                        label={errors.maxPriorityFeePerGas?.message || 'Max priority fee (Gwei)'}
-                        error={!!errors.maxPriorityFeePerGas}
-                        autoComplete="off"
-                        required
-                        {...register(AdvancedField.maxPriorityFeePerGas, {
-                          required: true,
-                          pattern: FLOAT_REGEX,
-                          min: 0,
-                        })}
-                      />
-                    </FormControl>
-                  </Grid>
+                  {props.isEIP1559 && (
+                    <Grid item xs={6}>
+                      <FormControl fullWidth>
+                        <TextField
+                          label={errors.maxPriorityFeePerGas?.message || 'Max priority fee (Gwei)'}
+                          error={!!errors.maxPriorityFeePerGas}
+                          autoComplete="off"
+                          required
+                          {...register(AdvancedField.maxPriorityFeePerGas, {
+                            required: true,
+                            pattern: FLOAT_REGEX,
+                            min: 0,
+                          })}
+                        />
+                      </FormControl>
+                    </Grid>
+                  )}
 
                   <Grid item xs={6}>
                     <FormControl fullWidth>
                       <TextField
-                        label={errors.maxFeePerGas?.message || 'Max fee (Gwei)'}
+                        label={errors.maxFeePerGas?.message || props.isEIP1559 ? 'Max fee (Gwei)' : 'Gas price (Gwei)'}
                         error={!!errors.maxFeePerGas}
                         autoComplete="off"
                         required

--- a/src/components/tx/AdvancedParams/index.tsx
+++ b/src/components/tx/AdvancedParams/index.tsx
@@ -1,5 +1,8 @@
 import GasParams from '@/components/tx/GasParams'
+import { useCurrentChain } from '@/hooks/useChains'
 import { MODALS_EVENTS, trackEvent } from '@/services/analytics'
+import { hasFeature } from '@/utils/chains'
+import { FEATURES } from '@gnosis.pm/safe-react-gateway-sdk'
 import { useState } from 'react'
 import AdvancedParamsForm from './AdvancedParamsForm'
 import { type AdvancedParameters } from './types'
@@ -22,6 +25,8 @@ const AdvancedParams = ({
   onFormSubmit,
 }: Props) => {
   const [isEditing, setIsEditing] = useState<boolean>(false)
+  const chain = useCurrentChain()
+  const isEIP1559 = !!chain && hasFeature(chain, FEATURES.EIP1559)
 
   const onEditOpen = () => {
     setIsEditing(true)
@@ -41,9 +46,10 @@ const AdvancedParams = ({
       recommendedGasLimit={recommendedGasLimit}
       nonceReadonly={nonceReadonly}
       onSubmit={onAdvancedSubmit}
+      isEIP1559={isEIP1559}
     />
   ) : (
-    <GasParams params={params} isExecution={willExecute} onEdit={onEditOpen} />
+    <GasParams params={params} isExecution={willExecute} isEIP1559={isEIP1559} onEdit={onEditOpen} />
   )
 }
 

--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -20,10 +20,11 @@ const GasDetail = ({ name, value, isLoading }: { name: string; value: string; is
 type GasParamsProps = {
   params: AdvancedParameters
   isExecution: boolean
+  isEIP1559: boolean
   onEdit: () => void
 }
 
-const GasParams = ({ params, isExecution, onEdit }: GasParamsProps): ReactElement => {
+const GasParams = ({ params, isExecution, isEIP1559, onEdit }: GasParamsProps): ReactElement => {
   const { nonce, userNonce, safeTxGas, gasLimit, maxFeePerGas, maxPriorityFeePerGas } = params
 
   const onChangeExpand = (_: SyntheticEvent, expanded: boolean) => {
@@ -31,7 +32,6 @@ const GasParams = ({ params, isExecution, onEdit }: GasParamsProps): ReactElemen
   }
 
   const chain = useCurrentChain()
-
   const isLoading = !gasLimit || !maxFeePerGas || !maxPriorityFeePerGas
 
   // Total gas cost
@@ -88,9 +88,14 @@ const GasParams = ({ params, isExecution, onEdit }: GasParamsProps): ReactElemen
 
             <GasDetail isLoading={isLoading} name="Gas limit" value={gasLimitString} />
 
-            <GasDetail isLoading={isLoading} name="Max priority fee (Gwei)" value={maxPrioGasGwei} />
-
-            <GasDetail isLoading={isLoading} name="Max fee (Gwei)" value={maxFeePerGasGwei} />
+            {isEIP1559 ? (
+              <>
+                <GasDetail isLoading={isLoading} name="Max priority fee (Gwei)" value={maxPrioGasGwei} />
+                <GasDetail isLoading={isLoading} name="Max fee (Gwei)" value={maxFeePerGasGwei} />
+              </>
+            ) : (
+              <GasDetail isLoading={isLoading} name="Gas price (Gwei)" value={maxFeePerGasGwei} />
+            )}
           </>
         )}
 

--- a/src/hooks/__tests__/useGasPrice.test.ts
+++ b/src/hooks/__tests__/useGasPrice.test.ts
@@ -7,7 +7,7 @@ jest.mock('../wallets/web3', () => {
   const provider = {
     getFeeData: jest.fn(() =>
       Promise.resolve({
-        gasPrice: BigNumber.from('0x956f'),
+        gasPrice: undefined,
         maxFeePerGas: BigNumber.from('0x956e'),
         maxPriorityFeePerGas: BigNumber.from('0x136f'),
       }),

--- a/src/hooks/useGasPrice.ts
+++ b/src/hooks/useGasPrice.ts
@@ -71,10 +71,12 @@ const useGasPrice = (): {
 
   // Save the previous gas price so that we don't return undefined each time it's polled
   const lastPrice = useRef<BigNumber>()
-  lastPrice.current = gasPrice || feeData?.maxFeePerGas || lastPrice.current
+  // Fallback to feeData.gasPrice for non-EIP-1559 networks
+  lastPrice.current = gasPrice || feeData?.maxFeePerGas || feeData?.gasPrice || lastPrice.current
 
   const lastPrioFee = useRef<BigNumber>()
-  lastPrioFee.current = feeData?.maxPriorityFeePerGas || lastPrioFee.current
+  // Fallback to 0 for non-EIP-1559 networks
+  lastPrioFee.current = feeData ? feeData.maxPriorityFeePerGas || BigNumber.from(0) : lastPrioFee.current
 
   return {
     maxFeePerGas: lastPrice.current,


### PR DESCRIPTION
## What it solves

Resolves #811

## How this PR fixes it

Gas price estimation was relying on EIP-1559 params.
I've added fallbacks for non-EIP-1559 chains + hiding the new gas params if on such a network.

## How to test it
Try to execute a tx on Optimism.

## Screenshots
<img width="627" alt="Screenshot 2022-10-05 at 12 22 33" src="https://user-images.githubusercontent.com/381895/194039519-3c1f3023-d947-4b0a-b194-8282c4622737.png">

<img width="639" alt="Screenshot 2022-10-05 at 12 22 41" src="https://user-images.githubusercontent.com/381895/194039549-39538361-ed5e-4ec2-ac6c-9cc355d161d0.png">
