### PR TITLE
test: fix e2e test for tx simulation

### DIFF
--- a/cypress/e2e/tx_simulation.cy.js
+++ b/cypress/e2e/tx_simulation.cy.js
@@ -6,24 +6,24 @@ describe('Tx Simulation', () => {
     cy.connectE2EWallet()
 
     // Open the Safe used for testing
-    cy.visit(`/${TEST_SAFE}`)
-    cy.contains('a', 'Accept selection').click()
+    cy.visit(`/${TEST_SAFE}/home`, { failOnStatusCode: false })
+    cy.contains('button', 'Accept selection').click()
 
     // Open Send Funds Modal
-    cy.contains('New Transaction').click()
-    cy.contains('Send funds').click()
+    cy.contains('New transaction').click()
+    cy.contains('Send tokens').click()
 
     // Choose recipient
-    cy.get('#address-book-input').should('be.visible')
-    cy.get('#address-book-input').type(RECIPIENT_ADDRESS, { force: true })
+    cy.get('input[name="recipient"]').should('be.visible')
+    cy.get('input[name="recipient"]').type(RECIPIENT_ADDRESS, { force: true })
 
     // Select asset and amount
-    cy.contains('Select an asset*').click()
+    cy.get('input[name="tokenAddress"]').parent().click()
     cy.get('ul[role="listbox"]').contains('Gnosis').click()
-    cy.contains('Send max').click()
+    cy.contains('Max').click()
 
     // go to review step
-    cy.contains('Review').click()
+    cy.contains('Next').click()
   })
   it('should initially have a successful simulation', () => {
     // Simulate
@@ -35,9 +35,9 @@ describe('Tx Simulation', () => {
 
   it('should show unexpected error for a very low gas limit', () => {
     // Set Gas Limit to too low
-    cy.contains('Estimated fee price').click()
+    cy.contains('Estimated fee').click()
     cy.contains('Edit').click()
-    cy.get('input[placeholder="Gas limit"]').clear().type('69')
+    cy.get('input[name="gasLimit"]').clear().type('21000')
     cy.contains('Confirm').click()
 
     // Simulate
@@ -49,9 +49,9 @@ describe('Tx Simulation', () => {
 
   it('should simulate with failed transaction for a slightly too low gas limit', () => {
     // Set Gas Limit to too low
-    cy.contains('Estimated fee price').click()
+    cy.contains('Estimated fee').click()
     cy.contains('Edit').click()
-    cy.get('input[placeholder="Gas limit"]').clear().type('75000')
+    cy.get('input[name="gasLimit"]').clear().type('75000')
     cy.contains('Confirm').click()
 
     // Simulate

--- a/src/components/tx/TxSimulation/index.tsx
+++ b/src/components/tx/TxSimulation/index.tsx
@@ -1,5 +1,6 @@
 import { AccordionSummary, Accordion, Button, Typography, CircularProgress, Skeleton } from '@mui/material'
 import type { ReactElement } from 'react'
+import { useEffect } from 'react'
 
 import Track from '@/components/common/Track'
 import { useCurrentChain } from '@/hooks/useChains'
@@ -42,6 +43,11 @@ const TxSimulationBlock = ({ transactions, canExecute, disabled, gasLimit }: TxS
       gasLimit,
     } as SimulationTxParams)
   }
+
+  // Reset simulation if gas limit changes
+  useEffect(() => {
+    resetSimulation()
+  }, [gasLimit, resetSimulation])
 
   const isSimulationFinished =
     simulationRequestStatus === FETCH_STATUS.ERROR || simulationRequestStatus === FETCH_STATUS.SUCCESS

--- a/src/config/securityHeaders.ts
+++ b/src/config/securityHeaders.ts
@@ -1,4 +1,4 @@
-import { IS_PRODUCTION } from '@/config/constants'
+import { CYPRESS_MNEMONIC, IS_PRODUCTION } from '@/config/constants'
 
 /**
  * CSP Header notes:
@@ -13,7 +13,9 @@ export const ContentSecurityPolicy = `
  default-src 'self';
  connect-src 'self' *;
  script-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com 'unsafe-inline' https://*.getbeamer.com https://www.googletagmanager.com ${
-   !IS_PRODUCTION ? "'unsafe-eval'" : ''
+   !IS_PRODUCTION || /* TODO: remove after moving cypress to görli and testing in staging again!! */ CYPRESS_MNEMONIC
+     ? "'unsafe-eval'"
+     : ''
  };
  frame-src *;
  style-src 'self' 'unsafe-inline' https://*.getbeamer.com https://*.googleapis.com;

--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -48,5 +48,9 @@ export const isWalletUnlocked = async (walletName: string): Promise<boolean> => 
     return hasStoredPairingSession()
   }
 
+  if (walletName === 'E2E Wallet') {
+    return Boolean(window.Cypress)
+  }
+
   return false
 }


### PR DESCRIPTION
- fix selectors for web-core
- fix simulation issue after changing the gas limit
- fix E2E Test wallet injection

## What it solves
It changes a issue where simulations do not reset when the gas limit parameter is changed.

Resolves #817 

## How to test it
The e2e tests:
1. set IS_PRODUCTION to true using .env variables
2. Use the correct CYPRESS_MNEMONIC
3. run the tx simulation e2e tests

The simulation issue:
1. Simulate a executable tx
4. change the gas limit to something else
5. the simulation result gets closed automatically and shows the simulate button again

## Analytics changes
none

