### PR TITLE
fix: show `Tab` scroll buttons on mobile

### DIFF
--- a/src/components/common/NavTabs/index.tsx
+++ b/src/components/common/NavTabs/index.tsx
@@ -8,7 +8,7 @@ const NavTabs = ({ tabs }: { tabs: NavItem[] }) => {
   const activeTab = tabs.map((tab) => tab.href).indexOf(router.pathname)
 
   return (
-    <Tabs value={activeTab}>
+    <Tabs value={activeTab} variant="scrollable" allowScrollButtonsMobile>
       {tabs.map((tab, idx) => {
         return (
           <Link key={tab.href} href={{ pathname: tab.href, query: { safe: router.query.safe } }} passHref>


### PR DESCRIPTION
## What it solves

Resolves #763

## How this PR fixes it

[`Tab` scroll buttons](https://mui.com/material-ui/react-tabs/#scrollable-tabs) are now shown on mobile.

## How to test it

Open the Safe on mobile (or set the resolution to that of a mobile device) and observe the scroll buttons.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/194055495-13c3991c-ecf8-46ed-b861-538f2661a1d3.png)