### PR TITLE
fix: add debug toggle for dark mode

### DIFF
--- a/src/components/sidebar/DebugToggle/index.tsx
+++ b/src/components/sidebar/DebugToggle/index.tsx
@@ -2,16 +2,22 @@ import { type ChangeEvent, type ReactElement } from 'react'
 import { Box, FormControlLabel, Switch } from '@mui/material'
 import { localItem } from '@/services/local-storage/local'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
+import { setDarkMode } from '@/store/settingsSlice'
+import { useDarkMode } from '@/hooks/useDarkMode'
+import { useAppDispatch } from '@/store'
 
 const LS_KEY = 'debugProdCgw'
 
 export const cgwDebugStorage = localItem<boolean>(LS_KEY)
 
 const DebugToggle = (): ReactElement => {
-  const [enabled, setEnabled] = useLocalStorage<boolean>(LS_KEY, false)
+  const dispatch = useAppDispatch()
+  const isDarkMode = useDarkMode()
+
+  const [isProdGateway, setIsProdGateway] = useLocalStorage<boolean>(LS_KEY, false)
 
   const onToggle = (event: ChangeEvent<HTMLInputElement>) => {
-    setEnabled(event.target.checked)
+    setIsProdGateway(event.target.checked)
 
     setTimeout(() => {
       location.reload()
@@ -20,7 +26,11 @@ const DebugToggle = (): ReactElement => {
 
   return (
     <Box py={2} ml={2}>
-      <FormControlLabel control={<Switch checked={enabled} onChange={onToggle} />} label="Use prod CGW" />
+      <FormControlLabel
+        control={<Switch checked={isDarkMode} onChange={(_, checked) => dispatch(setDarkMode(checked))} />}
+        label="Dark mode"
+      />
+      <FormControlLabel control={<Switch checked={isProdGateway} onChange={onToggle} />} label="Use prod CGW" />
     </Box>
   )
 }


### PR DESCRIPTION
## What it solves

Dark mode debug toggle

## How this PR fixes it

Another debug toggle in the sidebar for dark mode has been added.

## How to test it

Switch the new toggle and observe the theme change.

## Screenshots

![dark mode debug toggle](https://user-images.githubusercontent.com/20442784/194056367-41123c4b-e19e-4bd4-9634-76800cce2116.gif)