### PR TITLE
fix: remove Address Book entry for edited address

### DIFF
--- a/src/components/address-book/EntryDialog/index.tsx
+++ b/src/components/address-book/EntryDialog/index.tsx
@@ -10,7 +10,7 @@ import ModalDialog from '@/components/common/ModalDialog'
 import NameInput from '@/components/common/NameInput'
 import useChainId from '@/hooks/useChainId'
 import { useAppDispatch } from '@/store'
-import { upsertAddressBookEntry } from '@/store/addressBookSlice'
+import { removeAddressBookEntry, upsertAddressBookEntry } from '@/store/addressBookSlice'
 
 export type AddressEntry = {
   name: string
@@ -41,6 +41,9 @@ const EntryDialog = ({
   const { handleSubmit, formState } = methods
 
   const onSubmit = (data: AddressEntry) => {
+    if (defaultValues.address !== data.address) {
+      dispatch(removeAddressBookEntry({ address: defaultValues.address, chainId: chainId || currentChainId }))
+    }
     dispatch(upsertAddressBookEntry({ ...data, chainId: chainId || currentChainId }))
 
     handleClose()


### PR DESCRIPTION
## What it solves

Resolves #790

## How this PR fixes it
When editing a AB entry and the address is modified, remove the clicked entry.

## How to test it
1. On AB click to edit an entry.
2. Modify the name and the address.
3. Save
4. The clicked entry should be removed
5. The new entry should be in the AB

## Analytics changes
None

## Screenshots
