### PR TITLE
Use replace to overwrite current path in `pages/index.tsx`

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,7 @@ const IndexPage: NextPage = () => {
   const lastSafe = useLastSafe()
 
   useEffect(() => {
-    router.push(
+    router.replace(
       lastSafe
         ? `${AppRoutes.home}?safe=${lastSafe}`
         : chain


### PR DESCRIPTION
Co-authored-by: katspaugh <381895+katspaugh@users.noreply.github.com>

## What it solves

Resolves https://github.com/safe-global/web-core/issues/793

## How this PR fixes it

It removes the intermediate route between the starting and final route, so the back button takes you to the starting route and not the intermediate one

## How to test it

1. Go on any non-homepage route (safe view, apps, etc)
2. Switch the network, it should take you to the home page
3. Click back button in the browser, it should take you to the previous route
