### PR TITLE
Fix: set default testnet to Goerli

### DIFF
--- a/src/components/common/SafeTokenWidget/__tests__/SafeTokenWidget.test.tsx
+++ b/src/components/common/SafeTokenWidget/__tests__/SafeTokenWidget.test.tsx
@@ -1,7 +1,7 @@
 import { SAFE_TOKEN_ADDRESSES } from '@/config/constants'
 import * as useBalances from '@/hooks/useBalances'
 import * as nextRouter from 'next/router'
-import * as useChainId from '@/hooks/useChainId'
+import useChainId from '@/hooks/useChainId'
 import { render, waitFor } from '@/tests/test-utils'
 import { SafeAppAccessPolicyTypes, TokenType } from '@gnosis.pm/safe-react-gateway-sdk'
 import { ethers } from 'ethers'
@@ -12,7 +12,13 @@ import * as useSafeApps from '@/hooks/safe-apps/useSafeApps'
 
 const MOCK_CLAIMING_APP_URL = 'https://fake.claiming-app.safe.global'
 
+jest.mock('@/hooks/useChainId')
+
 describe('SafeTokenWidget', () => {
+  beforeAll(() => {
+    ;(useChainId as jest.Mock).mockImplementation(jest.fn(() => '4'))
+  })
+
   const fakeSafeAddress = hexZeroPad('0x1', 20)
   beforeEach(() => {
     jest.restoreAllMocks()
@@ -60,7 +66,7 @@ describe('SafeTokenWidget', () => {
   })
 
   it('Should render nothing for unsupported chains', () => {
-    jest.spyOn(useChainId, 'default').mockImplementation(() => '100')
+    ;(useChainId as jest.Mock).mockImplementationOnce(jest.fn(() => '100'))
 
     jest.spyOn(useBalances, 'default').mockImplementation(() => ({
       balances: {

--- a/src/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
@@ -98,14 +98,14 @@ const RESET_TIME_OPTIONS = [
   { label: '1 month', value: '43200' },
 ]
 
-const RINKEBY_RESET_TIME_OPTIONS = [
+const TEST_RESET_TIME_OPTIONS = [
   { label: '5 minutes', value: '5' },
   { label: '30 minutes', value: '30' },
   { label: '1 hour', value: '60' },
 ]
 
 export const getResetTimeOptions = (chainId = ''): { label: string; value: string }[] => {
-  return chainId !== chains.rin ? RESET_TIME_OPTIONS : RINKEBY_RESET_TIME_OPTIONS
+  return chainId === chains.gor ? TEST_RESET_TIME_OPTIONS : RESET_TIME_OPTIONS
 }
 
 export default SpendingLimits

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,3 +1,5 @@
+import chains from './chains'
+
 export const IS_PRODUCTION = process.env.NEXT_PUBLIC_IS_PRODUCTION
 
 export const GATEWAY_URL_PRODUCTION = process.env.NEXT_PUBLIC_GATEWAY_URL_PRODUCTION || 'https://safe-client.gnosis.io'
@@ -26,8 +28,8 @@ export const CYPRESS_MNEMONIC = process.env.NEXT_PUBLIC_CYPRESS_MNEMONIC || ''
 
 // Safe Token
 export const SAFE_TOKEN_ADDRESSES: { [chainId: string]: string } = {
-  '1': '0x5aFE3855358E112B5647B952709E6165e1c1eEEe',
-  '4': '0xCFf1b0FdE85C102552D1D96084AF148f478F964A',
+  [chains.eth]: '0x5aFE3855358E112B5647B952709E6165e1c1eEEe',
+  [chains.rin]: '0xCFf1b0FdE85C102552D1D96084AF148f478F964A',
 }
 
 // Safe Apps

--- a/src/hooks/__tests__/useChainId.test.ts
+++ b/src/hooks/__tests__/useChainId.test.ts
@@ -21,7 +21,7 @@ describe('useChainId hook', () => {
 
   it('should return the default chainId if no query params', () => {
     const { result } = renderHook(() => useChainId())
-    expect(result.current).toBe('4')
+    expect(result.current).toBe('5')
   })
 
   it('should return the chainId based on the chain query', () => {

--- a/src/hooks/useChainId.ts
+++ b/src/hooks/useChainId.ts
@@ -5,7 +5,7 @@ import { useAppSelector } from '@/store'
 import { selectSession } from '@/store/sessionSlice'
 import { parsePrefixedAddress } from '@/utils/addresses'
 
-const defaultChainId = IS_PRODUCTION ? chains.eth : chains.rin
+const defaultChainId = IS_PRODUCTION ? chains.eth : chains.gor
 
 export const useChainId = (): string => {
   const router = useRouter()

--- a/src/services/tx/__tests__/tokenTransferParams.test.ts
+++ b/src/services/tx/__tests__/tokenTransferParams.test.ts
@@ -49,7 +49,7 @@ describe('Token transfer encoder', () => {
       const from = '0x0000000000000000000000000000000000000001'
       const to = '0x0000000000000000000000000000000000000002'
       const tokenId = '123'
-      const tokenAddress = '0x16baf0de678e52367adc69fd067e5edd1d33e3bf'
+      const tokenAddress = '0x06012c8cf97bead5deae237070f9587f8e7a266d'
       const txParams = createNftTransferParams(from, to, tokenId, tokenAddress)
 
       expect(txParams.to).toBe(tokenAddress)

--- a/src/services/tx/tokenTransferParams.ts
+++ b/src/services/tx/tokenTransferParams.ts
@@ -1,17 +1,13 @@
 import { safeParseUnits } from '@/utils/formatters'
 import { Interface } from '@ethersproject/abi'
 import type { MetaTransactionData } from '@gnosis.pm/safe-core-sdk-types'
-import chains from '@/config/chains'
 import { sameAddress } from '@/utils/addresses'
 
 // CryptoKitties Contract Addresses by network
 // This is an exception made for a popular NFT that's not ERC721 standard-compatible,
 // so we can allow the user to transfer the assets by using `transfer` instead of
 // the standard `safeTransferFrom` method.
-const CryptoKittiesContract = {
-  [chains.eth]: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
-  [chains.rin]: '0x16baf0de678e52367adc69fd067e5edd1d33e3bf',
-}
+const CryptoKittiesContract = '0x06012c8cf97bead5deae237070f9587f8e7a266d'
 
 const encodeERC20TransferData = (to: string, value: string): string => {
   const erc20Abi = ['function transfer(address to, uint256 value)']
@@ -56,10 +52,7 @@ export const createNftTransferParams = (
   let data = encodeERC721TransferData(from, to, tokenId)
 
   // An exception made for CryptoKitties, which is not ERC721 standard-compatible
-  if (
-    sameAddress(tokenAddress, CryptoKittiesContract[chains.eth]) ||
-    sameAddress(tokenAddress, CryptoKittiesContract[chains.rin])
-  ) {
+  if (sameAddress(tokenAddress, CryptoKittiesContract)) {
     data = encodeERC20TransferData(to, tokenId)
   }
 


### PR DESCRIPTION
## What it solves

Rinkeby is deprecated, so we'll use Görli as our default chain on dev.