### PR TITLE
feat: show information when no asset value

### DIFF
--- a/src/components/balances/AssetsTable/index.tsx
+++ b/src/components/balances/AssetsTable/index.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactElement } from 'react'
-import { Button, Typography } from '@mui/material'
+import { Button, Tooltip, Typography, SvgIcon } from '@mui/material'
 import type { SafeBalanceResponse } from '@gnosis.pm/safe-react-gateway-sdk'
 import { TokenType } from '@gnosis.pm/safe-react-gateway-sdk'
 import css from './styles.module.css'
@@ -12,6 +12,7 @@ import TokenTransferModal from '@/components/tx/modals/TokenTransferModal'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import Track from '@/components/common/Track'
 import { ASSETS_EVENTS } from '@/services/analytics/events/assets'
+import InfoIcon from '@/public/images/notifications/info.svg'
 
 interface AssetsTableProps {
   items?: SafeBalanceResponse['items']
@@ -45,50 +46,71 @@ const AssetsTable = ({ items }: AssetsTableProps): ReactElement => {
   const [selectedAsset, setSelectedAsset] = useState<string | undefined>()
   const isSafeOwner = useIsSafeOwner()
 
-  const rows = (items || []).map((item) => ({
-    asset: {
-      rawValue: item.tokenInfo.name,
-      content: (
-        <div className={css.token}>
-          <TokenIcon logoUri={item.tokenInfo.logoUri} tokenSymbol={item.tokenInfo.symbol} />
+  const rows = (items || []).map((item) => {
+    const rawFiatValue = parseFloat(item.fiatBalance)
 
-          <Typography>{item.tokenInfo.name}</Typography>
+    return {
+      asset: {
+        rawValue: item.tokenInfo.name,
+        content: (
+          <div className={css.token}>
+            <TokenIcon logoUri={item.tokenInfo.logoUri} tokenSymbol={item.tokenInfo.symbol} />
 
-          {item.tokenInfo.type !== TokenType.NATIVE_TOKEN && <TokenExplorerLink address={item.tokenInfo.address} />}
-        </div>
-      ),
-    },
-    balance: {
-      rawValue: Number(item.balance) / 10 ** item.tokenInfo.decimals,
-      content: (
-        <TokenAmount value={item.balance} decimals={item.tokenInfo.decimals} tokenSymbol={item.tokenInfo.symbol} />
-      ),
-    },
-    value: {
-      rawValue: parseFloat(item.fiatBalance),
-      content: <FiatValue value={item.fiatBalance} />,
-    },
-    actions: {
-      rawValue: '',
-      sticky: true,
-      content: (
-        <>
-          {isSafeOwner && (
-            <Track {...ASSETS_EVENTS.SEND}>
-              <Button
-                variant="contained"
-                color="primary"
-                size="small"
-                onClick={() => setSelectedAsset(item.tokenInfo.address)}
-              >
-                Send
-              </Button>
-            </Track>
-          )}
-        </>
-      ),
-    },
-  }))
+            <Typography>{item.tokenInfo.name}</Typography>
+
+            {item.tokenInfo.type !== TokenType.NATIVE_TOKEN && <TokenExplorerLink address={item.tokenInfo.address} />}
+          </div>
+        ),
+      },
+      balance: {
+        rawValue: Number(item.balance) / 10 ** item.tokenInfo.decimals,
+        content: (
+          <TokenAmount value={item.balance} decimals={item.tokenInfo.decimals} tokenSymbol={item.tokenInfo.symbol} />
+        ),
+      },
+      value: {
+        rawValue: rawFiatValue,
+        content: (
+          <>
+            <FiatValue value={item.fiatBalance} />
+            {rawFiatValue === 0 && (
+              <Tooltip title="Value may be zero due to missing token price information" placement="top" arrow>
+                <span>
+                  <SvgIcon
+                    component={InfoIcon}
+                    inheritViewBox
+                    color="error"
+                    fontSize="small"
+                    sx={{ verticalAlign: 'middle', marginLeft: 0.5 }}
+                  />
+                </span>
+              </Tooltip>
+            )}
+          </>
+        ),
+      },
+      actions: {
+        rawValue: '',
+        sticky: true,
+        content: (
+          <>
+            {isSafeOwner && (
+              <Track {...ASSETS_EVENTS.SEND}>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  size="small"
+                  onClick={() => setSelectedAsset(item.tokenInfo.address)}
+                >
+                  Send
+                </Button>
+              </Track>
+            )}
+          </>
+        ),
+      },
+    }
+  })
 
   return (
     <div className={css.container}>


### PR DESCRIPTION
## What it solves

Resolves #832

## How this PR fixes it

An information icon, with tooltip, is shown when there is no value of an asset.

## How to test it

Open a Safe with assets of no value, e.g. `eth:0x8675B754342754A30A2AeF474D114d8460bca19b` and observe the new icon with tooltip.

## Screenshots

![tooltip](https://user-images.githubusercontent.com/20442784/194247474-ce1a77b6-40eb-4674-9384-421a0215b474.gif)