### PR TITLE
fix: remove Beamer top padding

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -88,6 +88,10 @@ input[type='number'] {
   }
 }
 
+body.beamerAnnouncementBarTopActive {
+  padding-top: 0px !important;
+}
+
 #beamerLastPostTitle {
   left: 330px !important;
 }


### PR DESCRIPTION
## What it solves

Resolves #812

## How this PR fixes it

The `padding-top` which Beamer adds to the `body` has been removed. As such, the content does not move down the page when the top bar is present.

## How to test it

Open a Safe on Rinkeby and observe the top bar from Beamer (if it is not there, open the PR deployment in an Icognito/Private Window or set an announcement in the Beamer admin panel). Observe no content shift downwards.

## Screenshots

![beamer-padding](https://user-images.githubusercontent.com/20442784/194279897-c25c352d-b028-40fd-a54c-95fe5648b159.gif)