### PR TITLE
fix: rename Safe Apps settings route

### DIFF
--- a/scripts/generate-routes.js
+++ b/scripts/generate-routes.js
@@ -13,8 +13,9 @@ const iterate = (folderName, parentRoute, root) => {
 
       // A folder, continue iterating
       if (!isFile(item)) {
-        root[item] = {}
-        iterate(`${folderName}/${item}`, `${parentRoute}/${item}`, root[item])
+        const key = item.replace(/-\w/g, (match) => match.replace(/-/g, '').toUpperCase()) // spending-limit -> spendingLimit
+        root[key] = {}
+        iterate(`${folderName}/${item}`, `${parentRoute}/${item}`, root[key])
         return
       }
 

--- a/src/components/settings/SafeAppsPermissions/index.tsx
+++ b/src/components/settings/SafeAppsPermissions/index.tsx
@@ -97,7 +97,7 @@ const SafeAppsPermissions = (): ReactElement => {
   return (
     <Paper sx={{ padding: 4 }}>
       <Typography variant="h4" fontWeight={700}>
-        Safe Apps Permissions
+        Safe Apps permissions
       </Typography>
       <br />
       {!domains.length && (

--- a/src/components/sidebar/SidebarNavigation/config.tsx
+++ b/src/components/sidebar/SidebarNavigation/config.tsx
@@ -90,6 +90,6 @@ export const settingsNavItems = [
   },
   {
     label: 'Safe Apps permissions',
-    href: AppRoutes.settings['safe-apps'].index,
+    href: AppRoutes.settings.safeApps.index,
   },
 ]

--- a/src/components/sidebar/SidebarNavigation/config.tsx
+++ b/src/components/sidebar/SidebarNavigation/config.tsx
@@ -89,7 +89,7 @@ export const settingsNavItems = [
     href: AppRoutes.settings.spendingLimits,
   },
   {
-    label: 'Safe Apps Permissions',
-    href: AppRoutes.settings.safeAppsPermissions,
+    label: 'Safe Apps permissions',
+    href: AppRoutes.settings.safeApps,
   },
 ]

--- a/src/components/sidebar/SidebarNavigation/config.tsx
+++ b/src/components/sidebar/SidebarNavigation/config.tsx
@@ -90,6 +90,6 @@ export const settingsNavItems = [
   },
   {
     label: 'Safe Apps permissions',
-    href: AppRoutes.settings.safeApps,
+    href: AppRoutes.settings['safe-apps'].index,
   },
 ]

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -17,7 +17,7 @@ export const AppRoutes = {
     modules: '/settings/modules',
     index: '/settings',
     appearance: '/settings/appearance',
-    safeAppsPermissions: '/settings/safe-apps-permissions',
+    safeApps: '/settings/safe-apps',
   },
   share: {
     safeApp: '/share/safe-app',

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -17,7 +17,7 @@ export const AppRoutes = {
     modules: '/settings/modules',
     index: '/settings',
     appearance: '/settings/appearance',
-    'safe-apps': {
+    safeApps: {
       index: '/settings/safe-apps',
     },
   },

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -17,7 +17,9 @@ export const AppRoutes = {
     modules: '/settings/modules',
     index: '/settings',
     appearance: '/settings/appearance',
-    safeApps: '/settings/safe-apps',
+    'safe-apps': {
+      index: '/settings/safe-apps',
+    },
   },
   share: {
     safeApp: '/share/safe-app',

--- a/src/pages/settings/safe-apps/index.tsx
+++ b/src/pages/settings/safe-apps/index.tsx
@@ -8,7 +8,7 @@ const SafeAppsPermissionsPage: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe – Settings – Safe Apps Permissions</title>
+        <title>Safe – Settings – Safe Apps permissions</title>
       </Head>
 
       <SettingsHeader />


### PR DESCRIPTION
## What it solves

Adjusting the Safe Apps settings route

## How this PR fixes it

The Safe Apps settings router has been renamed to `/settings/safe-apps` and the title adjusted to match our lowercase styling.

## How to test it

Open the Safe Apps permissions settings and observe the title be "Safe Apps permissions" and route `/settings/safe-apps`

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/194292197-6ce9e649-c742-4ff4-aedc-0a6ce14e75b8.png)