### PR TITLE
fix: Adjust spacing between paginated tx pages

### DIFF
--- a/src/components/transactions/TxList/index.tsx
+++ b/src/components/transactions/TxList/index.tsx
@@ -5,17 +5,14 @@ import type { TransactionListPage } from '@gnosis.pm/safe-react-gateway-sdk'
 import TxListItem from '../TxListItem'
 import GroupedTxListItems from '@/components/transactions/GroupedTxListItems'
 import { groupConflictingTxs } from '@/utils/tx-list'
+import css from './styles.module.css'
 
 type TxListProps = {
   items: TransactionListPage['results']
 }
 
 export const TxListGrid = ({ children }: { children: ReactElement | ReactElement[] }): ReactElement => {
-  return (
-    <Box display="flex" flexDirection="column" gap="6px">
-      {children}
-    </Box>
-  )
+  return <Box className={css.container}>{children}</Box>
 }
 
 const TxList = ({ items }: TxListProps): ReactElement => {

--- a/src/components/transactions/TxList/styles.module.css
+++ b/src/components/transactions/TxList/styles.module.css
@@ -1,0 +1,10 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.container:first-child {
+  margin-top: 0;
+}


### PR DESCRIPTION
## What it solves

Resolves #846 

## How this PR fixes it

Adds top spacing to each tx page

## How to test it

1. Open the Safe
2. Navigate to the tx history
3. Scroll down to load a new page of transactions
4. Observe transactions having enough space between each other

## Screenshots
<img width="806" alt="Screenshot 2022-10-06 at 12 51 58" src="https://user-images.githubusercontent.com/5880855/194295116-baa1ba8c-f56b-464d-907b-22f86386adde.png">
