### PR TITLE
fix: Use fallback image for safe app icons in tx modal

### DIFF
--- a/src/components/safe-apps/SafeAppsModalLabel/index.tsx
+++ b/src/components/safe-apps/SafeAppsModalLabel/index.tsx
@@ -2,6 +2,7 @@ import type { SafeAppData } from '@gnosis.pm/safe-react-gateway-sdk'
 import { Typography, Box } from '@mui/material'
 
 import css from './styles.module.css'
+import ImageFallback from '@/components/common/ImageFallback'
 
 const APP_LOGO_FALLBACK_IMAGE = '/images/apps/apps-icon.svg'
 
@@ -12,7 +13,14 @@ const SafeAppsModalLabel = ({ app }: { app?: SafeAppData }) => {
 
   return (
     <Box display="flex" alignItems="center">
-      <img src={app.iconUrl || APP_LOGO_FALLBACK_IMAGE} alt={app.name} className={css.modalLabel} />
+      <ImageFallback
+        src={app.iconUrl}
+        fallbackSrc={APP_LOGO_FALLBACK_IMAGE}
+        alt={app.name}
+        className={css.modalLabel}
+        width={24}
+        height={24}
+      />
       <Typography variant="h4">{app.name}</Typography>
     </Box>
   )


### PR DESCRIPTION
## What it solves

Resolves #838 

## How this PR fixes it

Some safe app manifests have a broken `iconUrl`, e.g. the protocol prefix is missing. In that case we display the default safe app icon within the tx modal.

## How to test it

1. Open a safe app with a broken `iconUrl` e.g. ENS safe app
2. Create a transaction
3. Observe the default safe app icon being displayed

## Screenshots
<img width="641" alt="Screenshot 2022-10-06 at 16 23 32" src="https://user-images.githubusercontent.com/5880855/194338569-384420e9-367e-432d-8f82-a17468abcac2.png">
