### PR TITLE
fix: Adjust page header width

### DIFF
--- a/src/components/common/PageHeader/styles.module.css
+++ b/src/components/common/PageHeader/styles.module.css
@@ -7,7 +7,7 @@
   border-bottom: 1px solid var(--color-border-light);
   background-color: var(--color-background-paper);
   z-index: 1;
-  width: 100%;
+  width: calc(100% - var(--space-6));
   position: sticky !important;
 }
 

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -253,18 +253,18 @@ export const dispatchOnChainSigning = async (safeTx: SafeTransaction, provider: 
   const sdkUnchecked = await getUncheckedSafeSDK(provider)
   const safeTxHash = await sdkUnchecked.getTransactionHash(safeTx)
 
-  txDispatch(TxEvent.EXECUTING, { txId, groupKey: safeTxHash })
+  txDispatch(TxEvent.EXECUTING, { groupKey: safeTxHash })
 
   try {
     // With the unchecked signer, the contract call resolves once the tx
     // has been submitted in the wallet not when it has been executed
     await sdkUnchecked.approveTransactionHash(safeTxHash)
   } catch (err) {
-    txDispatch(TxEvent.FAILED, { txId, groupKey: safeTxHash, error: err as Error })
+    txDispatch(TxEvent.FAILED, { groupKey: safeTxHash, error: err as Error })
     throw err
   }
 
-  txDispatch(TxEvent.AWAITING_ON_CHAIN_SIGNATURE, { txId, groupKey: safeTxHash })
+  txDispatch(TxEvent.AWAITING_ON_CHAIN_SIGNATURE, { groupKey: safeTxHash })
 
   return safeTx
 }


### PR DESCRIPTION
## What it solves

Resolves #849 

## How this PR fixes it

Since we are using `box-sizing: content-box` we have to subtract the padding from the total width.

## How to test it

1. Open the Safe
2. Navigate to Tx history, AB and any other page with a page header
3. Observe that the page header content is visible

## Screenshots
<img width="1294" alt="Screenshot 2022-10-06 at 17 21 09" src="https://user-images.githubusercontent.com/5880855/194352787-aae637e0-ea8b-4c2d-a950-0c6d7106478a.png">
