### PR TITLE
Fix: prevent error flashing in SingleTx

### DIFF
--- a/src/components/transactions/SingleTx/SingleTx.test.tsx
+++ b/src/components/transactions/SingleTx/SingleTx.test.tsx
@@ -37,7 +37,9 @@ jest.mock('@gnosis.pm/safe-react-gateway-sdk', () => ({
 
 jest.spyOn(useSafeInfo, 'default').mockImplementation(() => ({
   safeAddress: SAFE_ADDRESS,
-  safe: {} as SafeInfo,
+  safe: {
+    chainId: '5',
+  } as SafeInfo,
   safeError: undefined,
   safeLoading: false,
   safeLoaded: true,

--- a/src/components/transactions/SingleTx/index.tsx
+++ b/src/components/transactions/SingleTx/index.tsx
@@ -20,7 +20,7 @@ const SingleTxGrid = ({ txDetails }: { txDetails: TransactionDetails }): ReactEl
   return (
     <TxListGrid>
       <TxDateLabel item={dateLabel} />
-      <ExpandableTransactionItem item={tx} txDetails={txDetails} testId="single-tx" />
+      <ExpandableTransactionItem item={tx} txDetails={txDetails} />
     </TxListGrid>
   )
 }
@@ -32,17 +32,23 @@ const SingleTx = () => {
   const transactionId = Array.isArray(id) ? id[0] : id
   const { safe, safeAddress } = useSafeInfo()
 
-  const [txDetails, txDetailsError] = useAsync<TransactionDetails>(() => {
-    if (!transactionId) return
+  const [txDetails, txDetailsError] = useAsync<TransactionDetails>(
+    () => {
+      if (!transactionId) return
 
-    return getTransactionDetails(chainId, transactionId).then((details) => {
-      // If the transaction is not related to the current safe, throw an error
-      if (!sameAddress(details.safeAddress, safeAddress)) {
-        return Promise.reject(new Error(`Transaction with this id was not found in this Safe`))
-      }
-      return details
-    })
-  }, [transactionId, safe.txQueuedTag, safe.txHistoryTag, safeAddress])
+      console.log(safeAddress, transactionId)
+
+      return getTransactionDetails(chainId, transactionId).then((details) => {
+        // If the transaction is not related to the current safe, throw an error
+        if (!sameAddress(details.safeAddress, safeAddress)) {
+          return Promise.reject(new Error('Transaction with this id was not found in this Safe'))
+        }
+        return details
+      })
+    },
+    [transactionId, safe.txQueuedTag, safe.txHistoryTag, safeAddress],
+    false,
+  )
 
   if (txDetailsError) {
     return <ErrorMessage error={txDetailsError}>Failed to load transaction</ErrorMessage>

--- a/src/components/transactions/SingleTx/index.tsx
+++ b/src/components/transactions/SingleTx/index.tsx
@@ -36,8 +36,6 @@ const SingleTx = () => {
     () => {
       if (!transactionId) return
 
-      console.log(safeAddress, transactionId)
-
       return getTransactionDetails(chainId, transactionId).then((details) => {
         // If the transaction is not related to the current safe, throw an error
         if (!sameAddress(details.safeAddress, safeAddress)) {

--- a/src/components/transactions/SingleTx/index.tsx
+++ b/src/components/transactions/SingleTx/index.tsx
@@ -1,6 +1,5 @@
 import { CircularProgress } from '@mui/material'
 import ErrorMessage from '@/components/tx/ErrorMessage'
-import useChainId from '@/hooks/useChainId'
 import { useRouter } from 'next/router'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useAsync from '@/hooks/useAsync'
@@ -26,7 +25,6 @@ const SingleTxGrid = ({ txDetails }: { txDetails: TransactionDetails }): ReactEl
 }
 
 const SingleTx = () => {
-  const chainId = useChainId()
   const router = useRouter()
   const { id } = router.query
   const transactionId = Array.isArray(id) ? id[0] : id
@@ -34,9 +32,9 @@ const SingleTx = () => {
 
   const [txDetails, txDetailsError] = useAsync<TransactionDetails>(
     () => {
-      if (!transactionId) return
+      if (!transactionId || !safeAddress) return
 
-      return getTransactionDetails(chainId, transactionId).then((details) => {
+      return getTransactionDetails(safe.chainId, transactionId).then((details) => {
         // If the transaction is not related to the current safe, throw an error
         if (!sameAddress(details.safeAddress, safeAddress)) {
           return Promise.reject(new Error('Transaction with this id was not found in this Safe'))
@@ -44,7 +42,7 @@ const SingleTx = () => {
         return details
       })
     },
-    [transactionId, safe.txQueuedTag, safe.txHistoryTag, safeAddress],
+    [transactionId, safe.chainId, safe.txQueuedTag, safe.txHistoryTag, safeAddress],
     false,
   )
 


### PR DESCRIPTION
## What it solves

Resolves #851

## How this PR fixes it

`query.id` is undefined at first because the router is client-side only. So the page is pre-generated with an error message.

I removed the handling of a missing query.id. It will just show an infinite loader if you open a page w/o the query param. I think it's fine because why would you open it like this?