### PR TITLE
fix: rank Claiming App first on dashboard

### DIFF
--- a/src/components/common/SafeTokenWidget/__tests__/SafeTokenWidget.test.tsx
+++ b/src/components/common/SafeTokenWidget/__tests__/SafeTokenWidget.test.tsx
@@ -41,7 +41,7 @@ describe('SafeTokenWidget', () => {
               name: '$SAFE Claiming App',
               description: '',
               iconUrl: '',
-              tags: '',
+              tags: ['safe-claiming-app'],
               accessControl: {
                 type: SafeAppAccessPolicyTypes.NoRestrictions,
               },

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -1,5 +1,4 @@
-import { cgwDebugStorage } from '@/components/sidebar/DebugToggle'
-import { IS_PRODUCTION, SAFE_TOKEN_ADDRESSES } from '@/config/constants'
+import { SafeAppsTag, SAFE_TOKEN_ADDRESSES } from '@/config/constants'
 import { AppRoutes } from '@/config/routes'
 import { useSafeApps } from '@/hooks/safe-apps/useSafeApps'
 import useBalances from '@/hooks/useBalances'
@@ -18,9 +17,6 @@ import SafeTokenIcon from './safe_token.svg'
 
 import css from './styles.module.css'
 
-const isStaging = !IS_PRODUCTION && !cgwDebugStorage.get()
-const CLAIMING_APP_ID = isStaging ? 61 : 95
-
 export const getSafeTokenAddress = (chainId: string): string => {
   return SAFE_TOKEN_ADDRESSES[chainId]
 }
@@ -32,7 +28,7 @@ const SafeTokenWidget = () => {
   const apps = useSafeApps()
 
   const claimingApp = useMemo(
-    () => apps.allSafeApps.find((appData) => appData.id === CLAIMING_APP_ID),
+    () => apps.allSafeApps.find((appData) => appData.tags.includes(SafeAppsTag.SAFE_CLAIMING_APP)),
     [apps.allSafeApps],
   )
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -53,4 +53,5 @@ export const TENDERLY_ORG_NAME = process.env.NEXT_PUBLIC_TENDERLY_ORG_NAME || ''
 export enum SafeAppsTag {
   TX_BUILDER = 'transaction-builder',
   DASHBOARD_FEATURED = 'dashboard-widgets',
+  SAFE_CLAIMING_APP = 'safe-claiming-app',
 }

--- a/src/hooks/safe-apps/useRankedSafeApps.ts
+++ b/src/hooks/safe-apps/useRankedSafeApps.ts
@@ -13,9 +13,10 @@ const useRankedSafeApps = (safeApps: SafeAppData[], pinnedSafeApps: SafeAppData[
     const mostUsedApps = rankSafeApps(safeApps)
     const rankedPinnedApps = rankSafeApps(pinnedSafeApps)
     const randomApps = safeApps.slice().sort(() => Math.random() - 0.5)
+    const safeClaimingApp = safeApps?.filter((app) => app.tags?.includes(SafeAppsTag.SAFE_CLAIMING_APP)) || []
 
-    const allRankedApps = rankedPinnedApps
-      .concat(pinnedSafeApps, mostUsedApps, randomApps)
+    const allRankedApps = safeClaimingApp
+      .concat(rankedPinnedApps, pinnedSafeApps, mostUsedApps, randomApps)
       // Filter out Featured Apps because they are in their own section
       .filter((app) => !app.tags.includes(SafeAppsTag.DASHBOARD_FEATURED))
 


### PR DESCRIPTION
## What it solves

Resolves #829

## How this PR fixes it

The Claiming App is now positioned first in the dashboard featured apps.

Note: the Claiming App now has a `"safe-claiming-app"` tag and is instead found by this instead of it's `id` (which changes depending on environment).

## How to test it

Open the dashboard on a network that supports the Claiming App and observe it in first position. If necessary, add the `"safe-claiming-app"` to a network temporarily.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/194530603-6e4f74ee-b165-4884-86b7-4262c248f449.png)