### PR TITLE
Fix: don't display EIP-1559 params for non-EIP-1559 chains

### DIFF
--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -32,11 +32,11 @@ const GasParams = ({ params, isExecution, isEIP1559, onEdit }: GasParamsProps): 
   }
 
   const chain = useCurrentChain()
-  const isLoading = !gasLimit || !maxFeePerGas || !maxPriorityFeePerGas
+  const isLoading = !gasLimit || !maxFeePerGas
 
   // Total gas cost
   const totalFee = !isLoading
-    ? formatVisualAmount(maxFeePerGas.add(maxPriorityFeePerGas).mul(gasLimit), chain?.nativeCurrency.decimals)
+    ? formatVisualAmount(maxFeePerGas.mul(gasLimit), chain?.nativeCurrency.decimals)
     : '> 0.001'
 
   // Individual gas params

--- a/src/hooks/__tests__/useGasPrice.test.ts
+++ b/src/hooks/__tests__/useGasPrice.test.ts
@@ -81,9 +81,6 @@ describe('useGasPrice', () => {
 
     expect(fetch).toHaveBeenCalledWith('https://api.etherscan.io/api?module=gastracker&action=gasoracle')
 
-    expect(result.current.gasPriceLoading).toBe(false)
-    expect(result.current.gasPriceError).toBe(undefined)
-
     // assert the gas price is correct
     expect(result.current.maxFeePerGas?.toString()).toBe('47000000000')
 
@@ -121,9 +118,6 @@ describe('useGasPrice', () => {
     expect(fetch).toHaveBeenCalledWith('https://api.etherscan.io/api?module=gastracker&action=gasoracle')
     expect(fetch).toHaveBeenCalledWith('https://ethgasstation.info/json/ethgasAPI.json')
 
-    expect(result.current.gasPriceLoading).toBe(false)
-    expect(result.current.gasPriceError).toBe(undefined)
-
     // assert the gas price is correct
     expect(result.current.maxFeePerGas?.toString()).toBe('60000000000')
 
@@ -150,9 +144,6 @@ describe('useGasPrice', () => {
 
     expect(fetch).toHaveBeenCalledWith('https://api.etherscan.io/api?module=gastracker&action=gasoracle')
     expect(fetch).toHaveBeenCalledWith('https://ethgasstation.info/json/ethgasAPI.json')
-
-    expect(result.current.gasPriceLoading).toBe(false)
-    expect(result.current.gasPriceError).toBe(undefined)
 
     // assert the gas price is correct
     expect(result.current.maxFeePerGas?.toString()).toBe('24000000000')

--- a/src/hooks/__tests__/useGasPrice.test.ts
+++ b/src/hooks/__tests__/useGasPrice.test.ts
@@ -53,12 +53,6 @@ describe('useGasPrice', () => {
   beforeEach(() => {
     jest.useFakeTimers()
     jest.clearAllMocks()
-
-    // Mock fetch
-    Object.defineProperty(window, 'fetch', {
-      writable: true,
-      value: jest.fn(() => Promise.reject()),
-    })
   })
 
   it('should return the fetched gas price from the first oracle', async () => {
@@ -100,11 +94,10 @@ describe('useGasPrice', () => {
 
   it('should return the fetched gas price from the second oracle if the first one fails', async () => {
     // Mock fetch
-    Object.defineProperty(window, 'fetch', {
-      writable: true,
-      value: jest
+    jest.spyOn(window, 'fetch').mockImplementation(
+      jest
         .fn()
-        .mockImplementationOnce(() => Promise.reject())
+        .mockImplementationOnce(() => Promise.reject(new Error('Failed to fetch')))
         .mockImplementationOnce(() =>
           Promise.resolve({
             ok: true,
@@ -116,7 +109,7 @@ describe('useGasPrice', () => {
               }),
           }),
         ),
-    })
+    )
 
     // render the hook
     const { result } = renderHook(() => useGasPrice())
@@ -141,10 +134,12 @@ describe('useGasPrice', () => {
 
   it('should fallback to a fixed gas price if the oracles fail', async () => {
     // Mock fetch
-    Object.defineProperty(window, 'fetch', {
-      writable: true,
-      value: jest.fn(() => Promise.reject()),
-    })
+    jest.spyOn(window, 'fetch').mockImplementation(
+      jest
+        .fn()
+        .mockImplementationOnce(() => Promise.reject(new Error('Failed to fetch')))
+        .mockImplementationOnce(() => Promise.reject(new Error('Failed to fetch'))),
+    )
 
     // render the hook
     const { result } = renderHook(() => useGasPrice())

--- a/src/hooks/__tests__/useGasPrice.test.ts
+++ b/src/hooks/__tests__/useGasPrice.test.ts
@@ -1,7 +1,6 @@
 import { BigNumber } from 'ethers'
-import type { JsonRpcProvider } from '@ethersproject/providers'
 import { act, renderHook } from '@/tests/test-utils'
-import useGasPrice, { _getFeeData } from '@/hooks/useGasPrice'
+import useGasPrice from '@/hooks/useGasPrice'
 
 // mock useWeb3Readonly
 jest.mock('../wallets/web3', () => {
@@ -215,30 +214,5 @@ describe('useGasPrice', () => {
     })
 
     expect(result2.current.maxFeePerGas?.toString()).toBe('22000000000')
-  })
-
-  describe('getFeeData', () => {
-    const provider = {
-      getFeeData: () =>
-        Promise.resolve({
-          gasPrice: BigNumber.from(21000000000),
-          maxFeePerGas: BigNumber.from(20000000000),
-          maxPriorityFeePerGas: BigNumber.from(1000000000),
-        }),
-    } as unknown as JsonRpcProvider
-
-    it('should return the correct fee data', async () => {
-      const feeData = await _getFeeData(provider, true)
-
-      expect(feeData.maxFeePerGas?.toString()).toEqual('20000000000')
-      expect(feeData.maxPriorityFeePerGas?.toString()).toEqual('1000000000')
-    })
-
-    it('should return the fee data for non-EIP-1559 chains', async () => {
-      const feeData = await _getFeeData(provider, false)
-
-      expect(feeData.maxFeePerGas?.toString()).toEqual('21000000000')
-      expect(feeData.maxPriorityFeePerGas?.toString()).toEqual('0')
-    })
   })
 })

--- a/src/hooks/useGasPrice.ts
+++ b/src/hooks/useGasPrice.ts
@@ -10,6 +10,7 @@ import { useCurrentChain } from './useChains'
 import useIntervalCounter from './useIntervalCounter'
 import { useWeb3ReadOnly } from '../hooks/wallets/web3'
 import { hasFeature } from '@/utils/chains'
+import { Errors, logError } from '@/services/exceptions'
 
 // Updat gas fees every 20 seconds
 const REFRESH_DELAY = 20e3
@@ -42,7 +43,7 @@ const getGasPrice = async (gasPriceConfigs: GasPrice): Promise<BigNumber | undef
         return await fetchGasOracle(config)
       } catch (err) {
         error = err as Error
-        console.error('Error fetching gas price from oracle', err)
+        logError(Errors._611, error.message)
         // Continue to the next oracle
         continue
       }


### PR DESCRIPTION
## What it solves

Resolves #855

## How this PR fixes it

Adds a check in GasParams and AdvancedParamsForm to show the old `gas price` if the chain is configured as not supporting EIP-1559.

## How to test it
* Make a tx on Arbitrum (no EIP-1559) – the gas price should be around 0.1 Gwei.
* Make a tx on Mainnet – it should have max priority fee set to 1.5 Gwei.

## Screenshots
<img width="628" alt="Screenshot 2022-10-07 at 13 28 37" src="https://user-images.githubusercontent.com/381895/194543882-c9ca6e05-91aa-4eff-b5a2-403a13694d92.png">
