### PR TITLE
fix: reduce page header height

### DIFF
--- a/src/components/address-book/AddressBookHeader/index.tsx
+++ b/src/components/address-book/AddressBookHeader/index.tsx
@@ -22,9 +22,8 @@ const AddressBookHeader = ({ handleOpenModal }: Props): ReactElement => {
   return (
     <PageHeader
       title="Address book"
-      subtitle="Save frequent contacts for easy transacting"
       action={
-        <Box display="flex" justifyContent="flex-end" pb={2}>
+        <Box display="flex" justifyContent="flex-end" alignItems="center" pb={1}>
           <Track {...ADDRESS_BOOK_EVENTS.IMPORT_BUTTON}>
             <Button
               onClick={handleOpenModal(ModalType.IMPORT)}

--- a/src/components/address-book/AddressBookHeader/index.tsx
+++ b/src/components/address-book/AddressBookHeader/index.tsx
@@ -22,6 +22,7 @@ const AddressBookHeader = ({ handleOpenModal }: Props): ReactElement => {
   return (
     <PageHeader
       title="Address book"
+      noBorder
       action={
         <Box display="flex" justifyContent="flex-end" alignItems="center" pb={1}>
           <Track {...ADDRESS_BOOK_EVENTS.IMPORT_BUTTON}>

--- a/src/components/balances/AssetsHeader/index.tsx
+++ b/src/components/balances/AssetsHeader/index.tsx
@@ -10,7 +10,6 @@ const AssetsHeader = ({ currencySelect = false }: { currencySelect?: boolean }):
   return (
     <PageHeader
       title="Assets"
-      sx={{ borderBottom: ({ palette }) => `1px solid ${palette.border.light}` }}
       action={
         <Box display="flex" justifyContent="space-between" alignItems="center">
           <NavTabs tabs={balancesNavItems} />

--- a/src/components/balances/AssetsHeader/index.tsx
+++ b/src/components/balances/AssetsHeader/index.tsx
@@ -10,9 +10,9 @@ const AssetsHeader = ({ currencySelect = false }: { currencySelect?: boolean }):
   return (
     <PageHeader
       title="Assets"
-      subtitle="See all your tokens and NFTs in one place"
+      sx={{ borderBottom: ({ palette }) => `1px solid ${palette.border.light}` }}
       action={
-        <Box display="flex" justifyContent="space-between">
+        <Box display="flex" justifyContent="space-between" alignItems="center">
           <NavTabs tabs={balancesNavItems} />
           {currencySelect && <CurrencySelect />}
         </Box>

--- a/src/components/common/NavTabs/styles.module.css
+++ b/src/components/common/NavTabs/styles.module.css
@@ -30,5 +30,5 @@
 
 .label {
   text-transform: none;
-  padding-bottom: 8px;
+  padding-bottom: 6px;
 }

--- a/src/components/common/NavTabs/styles.module.css
+++ b/src/components/common/NavTabs/styles.module.css
@@ -21,11 +21,10 @@
 
 .tab {
   opacity: 1;
-  padding-left: var(--space-3);
-  padding-right: var(--space-3);
-  margin-right: var(--space-2);
+  padding: 0 var(--space-2);
   position: relative;
   z-index: 2;
+  min-width: 0;
 }
 
 .label {

--- a/src/components/common/PageHeader/index.tsx
+++ b/src/components/common/PageHeader/index.tsx
@@ -19,7 +19,7 @@ const PageHeader = ({
         borderBottom: noBorder ? undefined : ({ palette }) => `1px solid ${palette.border.light}`,
       }}
     >
-      <Typography variant="h3" fontWeight={700} gutterBottom>
+      <Typography variant="h3" className={css.title}>
         {title}
       </Typography>
       {action}

--- a/src/components/common/PageHeader/index.tsx
+++ b/src/components/common/PageHeader/index.tsx
@@ -1,5 +1,4 @@
 import { Box, Typography } from '@mui/material'
-import type { BoxProps } from '@mui/material'
 import type { ReactElement } from 'react'
 
 import css from './styles.module.css'
@@ -7,22 +6,21 @@ import css from './styles.module.css'
 const PageHeader = ({
   title,
   action,
-  sx = {},
+  noBorder,
 }: {
   title: string
   action?: ReactElement
-  sx?: BoxProps['sx']
+  noBorder?: boolean
 }): ReactElement => {
   return (
     <Box
       className={css.container}
       sx={{
-        height: '88px',
         top: '-12px',
-        ...sx,
+        borderBottom: !noBorder ? ({ palette }) => `1px solid ${palette.border.light}` : undefined,
       }}
     >
-      <Typography variant="h3" fontWeight={700}>
+      <Typography variant="h3" fontWeight={700} gutterBottom>
         {title}
       </Typography>
       {action}

--- a/src/components/common/PageHeader/index.tsx
+++ b/src/components/common/PageHeader/index.tsx
@@ -1,42 +1,30 @@
-import useAddressBook from '@/hooks/useAddressBook'
-import useSafeAddress from '@/hooks/useSafeAddress'
 import { Box, Typography } from '@mui/material'
+import type { BoxProps } from '@mui/material'
 import type { ReactElement } from 'react'
 
 import css from './styles.module.css'
 
-const SIDEBAR_HEADER_HEIGHT = 158
-
 const PageHeader = ({
   title,
-  subtitle,
   action,
+  sx = {},
 }: {
   title: string
-  subtitle: string | ReactElement
   action?: ReactElement
+  sx?: BoxProps['sx']
 }): ReactElement => {
-  const safeAddress = useSafeAddress()
-  const addressBook = useAddressBook()
-  const isNamedSafe = !!addressBook[safeAddress]
-  const nameHeight = isNamedSafe ? 20 : 0
-
   return (
     <Box
       className={css.container}
       sx={{
-        height: `${SIDEBAR_HEADER_HEIGHT + nameHeight}px`,
-        top: `-${76 + nameHeight}px`,
+        height: '88px',
+        top: '-12px',
+        ...sx,
       }}
     >
-      <div>
-        <Typography variant="h3" fontWeight={700} gutterBottom>
-          {title}
-        </Typography>
-        <Typography variant="h5" fontWeight={400} color="primary.light">
-          {subtitle}
-        </Typography>
-      </div>
+      <Typography variant="h3" fontWeight={700}>
+        {title}
+      </Typography>
       {action}
     </Box>
   )

--- a/src/components/common/PageHeader/index.tsx
+++ b/src/components/common/PageHeader/index.tsx
@@ -16,8 +16,7 @@ const PageHeader = ({
     <Box
       className={css.container}
       sx={{
-        top: '-12px',
-        borderBottom: !noBorder ? ({ palette }) => `1px solid ${palette.border.light}` : undefined,
+        borderBottom: noBorder ? undefined : ({ palette }) => `1px solid ${palette.border.light}`,
       }}
     >
       <Typography variant="h3" fontWeight={700} gutterBottom>

--- a/src/components/common/PageHeader/styles.module.css
+++ b/src/components/common/PageHeader/styles.module.css
@@ -10,3 +10,8 @@
   position: sticky !important;
   top: -12px;
 }
+
+.title {
+  padding-bottom: 12px;
+  font-weight: 700;
+}

--- a/src/components/common/PageHeader/styles.module.css
+++ b/src/components/common/PageHeader/styles.module.css
@@ -1,19 +1,11 @@
 .container {
-  padding: var(--space-5) var(--space-3) 0;
+  padding: var(--space-4) var(--space-3) 0;
   box-sizing: content-box;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  border-bottom: 1px solid var(--color-border-light);
-  background-color: var(--color-background-paper);
+  background-color: var(--color-background-main);
   z-index: 1;
   width: calc(100% - var(--space-6));
   position: sticky !important;
-}
-
-/* Retina display */
-@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
-  .container {
-    padding-bottom: 0.5px;
-  }
 }

--- a/src/components/common/PageHeader/styles.module.css
+++ b/src/components/common/PageHeader/styles.module.css
@@ -8,4 +8,5 @@
   z-index: 1;
   width: calc(100% - var(--space-6));
   position: sticky !important;
+  top: -12px;
 }

--- a/src/components/safe-apps/SafeAppsHeader/index.tsx
+++ b/src/components/safe-apps/SafeAppsHeader/index.tsx
@@ -16,9 +16,8 @@ const SafeAppsHeader = ({ searchQuery, onSearchQueryChange }: Props): ReactEleme
   return (
     <PageHeader
       title="Safe Apps"
-      subtitle="Explore endless possibilities to manage your assets"
       action={
-        <Grid container sx={{ pb: 2 }}>
+        <Grid container sx={{ pb: 1 }}>
           <Grid item xs={12} sm={12} md={6} xl={4.5}>
             <TextField
               placeholder="Search"

--- a/src/components/safe-apps/SafeAppsHeader/index.tsx
+++ b/src/components/safe-apps/SafeAppsHeader/index.tsx
@@ -16,6 +16,7 @@ const SafeAppsHeader = ({ searchQuery, onSearchQueryChange }: Props): ReactEleme
   return (
     <PageHeader
       title="Safe Apps"
+      noBorder
       action={
         <Grid container sx={{ pb: 1 }}>
           <Grid item xs={12} sm={12} md={6} xl={4.5}>

--- a/src/components/settings/SettingsHeader/index.tsx
+++ b/src/components/settings/SettingsHeader/index.tsx
@@ -5,13 +5,7 @@ import PageHeader from '@/components/common/PageHeader'
 import { settingsNavItems } from '@/components/sidebar/SidebarNavigation/config'
 
 const SettingsHeader = (): ReactElement => {
-  return (
-    <PageHeader
-      title="Settings"
-      action={<NavTabs tabs={settingsNavItems} />}
-      sx={{ borderBottom: ({ palette }) => `1px solid ${palette.border.light}` }}
-    />
-  )
+  return <PageHeader title="Settings" action={<NavTabs tabs={settingsNavItems} />} />
 }
 
 export default SettingsHeader

--- a/src/components/settings/SettingsHeader/index.tsx
+++ b/src/components/settings/SettingsHeader/index.tsx
@@ -8,8 +8,8 @@ const SettingsHeader = (): ReactElement => {
   return (
     <PageHeader
       title="Settings"
-      subtitle="Customize and manage your Safe"
       action={<NavTabs tabs={settingsNavItems} />}
+      sx={{ borderBottom: ({ palette }) => `1px solid ${palette.border.light}` }}
     />
   )
 }

--- a/src/components/sidebar/Sidebar/index.tsx
+++ b/src/components/sidebar/Sidebar/index.tsx
@@ -26,9 +26,7 @@ const Sidebar = (): ReactElement => {
   return (
     <div className={css.container}>
       <div className={css.scroll}>
-        <div className={css.chain}>
-          <ChainIndicator />
-        </div>
+        <ChainIndicator />
 
         <IconButton className={css.drawerButton} onClick={onDrawerToggle}>
           <ChevronRight />

--- a/src/components/sidebar/Sidebar/styles.module.css
+++ b/src/components/sidebar/Sidebar/styles.module.css
@@ -33,10 +33,6 @@
   border-right: 1px solid var(--color-border-light);
 }
 
-.chain > * {
-  padding: 3px;
-}
-
 .noSafeHeader {
   display: flex;
   justify-content: center;

--- a/src/components/sidebar/SidebarHeader/index.tsx
+++ b/src/components/sidebar/SidebarHeader/index.tsx
@@ -60,52 +60,54 @@ const SafeHeader = (): ReactElement => {
 
   return (
     <div className={css.container}>
-      <div className={css.safe}>
-        <div>
-          {safeLoading ? (
-            <Skeleton variant="circular" width={40} height={40} />
-          ) : (
-            <SafeIcon address={safeAddress} threshold={threshold} owners={owners?.length} />
-          )}
-        </div>
+      <div className={css.info}>
+        <div className={css.safe}>
+          <div>
+            {safeLoading ? (
+              <Skeleton variant="circular" width={40} height={40} />
+            ) : (
+              <SafeIcon address={safeAddress} threshold={threshold} owners={owners?.length} />
+            )}
+          </div>
 
-        <div className={css.address}>
-          {safeLoading ? (
-            <Typography variant="body2">
-              <Skeleton variant="text" width={86} />
+          <div className={css.address}>
+            {safeLoading ? (
+              <Typography variant="body2">
+                <Skeleton variant="text" width={86} />
+              </Typography>
+            ) : (
+              <EthHashInfo address={safeAddress} shortAddress showAvatar={false} />
+            )}
+
+            <Typography variant="body2" fontWeight={700}>
+              {fiatTotal || <Skeleton variant="text" width={60} />}
             </Typography>
-          ) : (
-            <EthHashInfo address={safeAddress} shortAddress showAvatar={false} />
-          )}
-
-          <Typography variant="body1" fontWeight={700}>
-            {fiatTotal || <Skeleton variant="text" width={60} />}
-          </Typography>
+          </div>
         </div>
-      </div>
 
-      <div className={css.iconButtons}>
-        <Track {...OVERVIEW_EVENTS.SHOW_QR}>
-          <QrCodeButton>
-            <HeaderIconButton title="Open QR code">
-              <SvgIcon component={QrIcon} inheritViewBox color="primary" />
-            </HeaderIconButton>
-          </QrCodeButton>
-        </Track>
+        <div className={css.iconButtons}>
+          <Track {...OVERVIEW_EVENTS.SHOW_QR}>
+            <QrCodeButton>
+              <HeaderIconButton title="Open QR code">
+                <SvgIcon component={QrIcon} inheritViewBox color="primary" />
+              </HeaderIconButton>
+            </QrCodeButton>
+          </Track>
 
-        <Track {...OVERVIEW_EVENTS.COPY_ADDRESS}>
-          <CopyButton text={addressCopyText} className={css.iconButton}>
-            <SvgIcon component={CopyIcon} inheritViewBox color="primary" />
-          </CopyButton>
-        </Track>
+          <Track {...OVERVIEW_EVENTS.COPY_ADDRESS}>
+            <CopyButton text={addressCopyText} className={css.iconButton}>
+              <SvgIcon component={CopyIcon} inheritViewBox color="primary" />
+            </CopyButton>
+          </Track>
 
-        <Track {...OVERVIEW_EVENTS.OPEN_EXPLORER}>
-          <a target="_blank" rel="noreferrer" href={blockExplorerLink?.href || '#'}>
-            <HeaderIconButton title={blockExplorerLink?.title || ''}>
-              <SvgIcon component={LinkIcon} inheritViewBox />
-            </HeaderIconButton>
-          </a>
-        </Track>
+          <Track {...OVERVIEW_EVENTS.OPEN_EXPLORER}>
+            <a target="_blank" rel="noreferrer" href={blockExplorerLink?.href || '#'}>
+              <HeaderIconButton title={blockExplorerLink?.title || ''}>
+                <SvgIcon component={LinkIcon} inheritViewBox />
+              </HeaderIconButton>
+            </a>
+          </Track>
+        </div>
       </div>
 
       <NewTxButton />

--- a/src/components/sidebar/SidebarHeader/styles.module.css
+++ b/src/components/sidebar/SidebarHeader/styles.module.css
@@ -1,5 +1,9 @@
 .container {
-  padding: var(--space-2);
+  padding: var(--space-2) var(--space-1);
+}
+
+.info {
+  padding: 0 var(--space-1);
 }
 
 .safe {
@@ -10,7 +14,7 @@
 }
 
 .iconButtons {
-  margin-top: 8px;
+  margin-top: 10px;
   margin-bottom: 16px;
   display: flex;
   gap: 8px;
@@ -36,4 +40,5 @@
   width: 100%;
   overflow: hidden;
   white-space: nowrap;
+  font-size: 14px;
 }

--- a/src/components/sidebar/SidebarNavigation/index.tsx
+++ b/src/components/sidebar/SidebarNavigation/index.tsx
@@ -25,17 +25,22 @@ const Navigation = (): ReactElement => {
 
   return (
     <SidebarList>
-      {navItems.map((item) => (
-        <ListItem key={item.href} disablePadding selected={router.pathname === item.href}>
-          <SidebarListItemButton
-            selected={router.pathname === item.href}
-            href={{ pathname: item.href, query: { safe: router.query.safe } }}
-          >
-            {item.icon && <SidebarListItemIcon badge={item.badge}>{item.icon}</SidebarListItemIcon>}
-            <SidebarListItemText bold>{item.label}</SidebarListItemText>
-          </SidebarListItemButton>
-        </ListItem>
-      ))}
+      {navItems.map((item) => {
+        const subdirectory = item.href.split('/')[1]
+        const isSelected = router.pathname.includes(subdirectory)
+
+        return (
+          <ListItem key={item.href} disablePadding selected={isSelected}>
+            <SidebarListItemButton
+              selected={isSelected}
+              href={{ pathname: item.href, query: { safe: router.query.safe } }}
+            >
+              {item.icon && <SidebarListItemIcon badge={item.badge}>{item.icon}</SidebarListItemIcon>}
+              <SidebarListItemText bold>{item.label}</SidebarListItemText>
+            </SidebarListItemButton>
+          </ListItem>
+        )
+      })}
     </SidebarList>
   )
 }

--- a/src/components/transactions/TxHeader/index.tsx
+++ b/src/components/transactions/TxHeader/index.tsx
@@ -6,8 +6,8 @@ const TxHeader = ({ action }: { action?: ReactElement }): ReactElement => {
   return (
     <PageHeader
       title="Transactions"
-      subtitle="Confirm queued transactions and view all those in the past"
       action={action}
+      sx={{ borderBottom: ({ palette }) => `1px solid ${palette.border.light}` }}
     />
   )
 }

--- a/src/components/transactions/TxHeader/index.tsx
+++ b/src/components/transactions/TxHeader/index.tsx
@@ -3,13 +3,7 @@ import type { ReactElement } from 'react'
 import PageHeader from '@/components/common/PageHeader'
 
 const TxHeader = ({ action }: { action?: ReactElement }): ReactElement => {
-  return (
-    <PageHeader
-      title="Transactions"
-      action={action}
-      sx={{ borderBottom: ({ palette }) => `1px solid ${palette.border.light}` }}
-    />
-  )
+  return <PageHeader title="Transactions" action={action} />
 }
 
 export default TxHeader

--- a/src/pages/transactions/history.tsx
+++ b/src/pages/transactions/history.tsx
@@ -31,15 +31,9 @@ const History: NextPage = () => {
 
       <TxHeader
         action={
-          <Box display="flex" justifyContent="space-between">
+          <Box display="flex" justifyContent="space-between" alignItems="center">
             <NavTabs tabs={transactionNavItems} />
-            <Button
-              variant="contained"
-              onClick={toggleFilter}
-              size="small"
-              endIcon={<ExpandIcon />}
-              sx={{ height: '36px' }}
-            >
+            <Button variant="outlined" onClick={toggleFilter} size="small" endIcon={<ExpandIcon />}>
               {filter?.type ?? 'Filter'}
             </Button>
           </Box>

--- a/src/pages/transactions/queue.tsx
+++ b/src/pages/transactions/queue.tsx
@@ -19,7 +19,7 @@ const Queue: NextPage = () => {
       <BatchExecuteHoverProvider>
         <TxHeader
           action={
-            <Box display="flex" justifyContent="space-between">
+            <Box display="flex" justifyContent="space-between" alignItems="center">
               <NavTabs tabs={transactionNavItems} />
               <BatchExecuteButton />
             </Box>

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -423,12 +423,12 @@ const initTheme = (darkMode: boolean) => {
         styleOverrides: {
           root: ({ theme }) => ({
             borderRadius: 4,
-            backgroundColor: theme.palette.background.main,
+            backgroundColor: theme.palette.background.paper,
             border: '1px solid transparent',
             transition: 'border-color 0.2s',
 
             '&:hover, &:focus, &.Mui-focused': {
-              backgroundColor: theme.palette.background.main,
+              backgroundColor: theme.palette.background.paper,
               borderColor: theme.palette.primary.main,
             },
           }),


### PR DESCRIPTION
## What it solves

Smaller page headers.

## How this PR fixes it

The page header height has been reduced in accordance with [the designs](https://www.figma.com/file/ptTs6lDBeUuLNySroJ5PiF/Web-Master-File?node-id=1137%3A50534). The sidebar "header" was also tweaked to incorporate the new design.

It follows [this visual rule as described by @liliiaorlenko](https://5afe.slack.com/archives/C03DAGWJCR5/p1665138752632389):

![image](https://user-images.githubusercontent.com/20442784/194562530-9e587c4d-e0bc-49d4-ab4b-cc05db61c62a.png)

Note: the address book search is not included in this PR. An issue exists for it [here](https://github.com/safe-global/web-core/issues/835).

## How to test it

Open the Safe and navigate between sections. Observe the correct page header designs.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/194561736-1ce8bde0-aefb-4ccf-b215-7dc218e40b83.png)

![image](https://user-images.githubusercontent.com/20442784/194561787-86ddb76a-b6d5-4a00-a6c3-f9c56964b933.png)
![image](https://user-images.githubusercontent.com/20442784/194561842-3bd46cbf-5453-43b1-ab14-9cb0367f113e.png)
![image](https://user-images.githubusercontent.com/20442784/194562315-ef09b2a6-06b5-41d2-9f5c-478f93387eba.png)

![image](https://user-images.githubusercontent.com/20442784/194562149-da0f7597-6762-4f4a-9416-15ea76be928e.png)

![image](https://user-images.githubusercontent.com/20442784/194562199-fda496a4-c55d-4bf0-909e-c906d53631d4.png)
![image](https://user-images.githubusercontent.com/20442784/194562254-82ddcf26-1f74-4d64-813d-eade1d38e756.png)

![image](https://user-images.githubusercontent.com/20442784/194562364-341caea3-1ed2-4be6-9a5a-7a9dd56a0e9c.png)