### PR TITLE
fix: display specific error message for wrong chain and non-owner wallets

### DIFF
--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -166,7 +166,9 @@ const SignOrExecuteForm = ({
     setAdvancedParams(data)
   }
 
-  const submitDisabled = !isSubmittable || isEstimating || !tx || disableSubmit
+  const walletIsWrongChain = currentChain?.chainId != wallet?.chainId
+  const walletIsNoOwner = !safe.owners.some((owner) => owner.value === wallet?.address)
+  const submitDisabled = !isSubmittable || isEstimating || !tx || walletIsWrongChain || walletIsNoOwner || disableSubmit
 
   return (
     <form onSubmit={handleSubmit}>
@@ -192,6 +194,14 @@ const SignOrExecuteForm = ({
           canExecute={canExecute}
           disabled={submitDisabled}
         />
+
+        {walletIsWrongChain && <ErrorMessage>Your wallet is connected to the wrong chain.</ErrorMessage>}
+
+        {walletIsNoOwner && (
+          <ErrorMessage>
+            You are currently not an owner of this Safe and won&apos;t be able to submit this transaction.
+          </ErrorMessage>
+        )}
 
         {(error || (willExecute && gasLimitError)) && (
           <ErrorMessage error={error || gasLimitError}>

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -166,9 +166,8 @@ const SignOrExecuteForm = ({
     setAdvancedParams(data)
   }
 
-  const walletIsWrongChain = currentChain?.chainId != wallet?.chainId
-  const walletIsNoOwner = !safe.owners.some((owner) => owner.value === wallet?.address)
-  const submitDisabled = !isSubmittable || isEstimating || !tx || walletIsWrongChain || walletIsNoOwner || disableSubmit
+  const isWalletAllowed = willExecute || safe.owners.some((owner) => owner.value === wallet?.address)
+  const submitDisabled = !isSubmittable || isEstimating || !tx || disableSubmit || isWrongChain || !isWalletAllowed
 
   return (
     <form onSubmit={handleSubmit}>
@@ -195,9 +194,9 @@ const SignOrExecuteForm = ({
           disabled={submitDisabled}
         />
 
-        {walletIsWrongChain && <ErrorMessage>Your wallet is connected to the wrong chain.</ErrorMessage>}
+        {isWrongChain && <ErrorMessage>Your wallet is connected to the wrong chain.</ErrorMessage>}
 
-        {walletIsNoOwner && (
+        {!isWalletAllowed && (
           <ErrorMessage>
             You are currently not an owner of this Safe and won&apos;t be able to submit this transaction.
           </ErrorMessage>


### PR DESCRIPTION
## What it solves

This PR displays a specific error message in the transaction modal if the connected wallet is connected to the wrong chain or if it is not an owner of the wallet. 

Resolves #769, #722

## How this PR fixes it

If the connected wallet is connected to the wrong chain or is not an owner, an explicit error message that explains the problem is displayed above the generic `This transaction will most likely fail.` message. Additionally, it disables the submit button in these cases. I used the error messages from #769 and #722.

## How to test it

1. Create a transaction in the transaction builder
2. Switch the connected wallet to a different chain or connect an unrelated address
3. Open the transaction overlay via the `Send Batch` button

## Screenshots
![Screenshot 2022-10-07 at 16 08 36](https://user-images.githubusercontent.com/13310795/194573502-cda5bf6b-d5ef-474f-87e8-f4c3a9d34c24.png)
![Screenshot 2022-10-07 at 16 09 14](https://user-images.githubusercontent.com/13310795/194573526-d63350f0-0e22-4ef5-b6e4-8d2d1bdf4195.png)
