### PR TITLE
fix: add Sentry to the CSP allowed domains

### DIFF
--- a/src/config/securityHeaders.ts
+++ b/src/config/securityHeaders.ts
@@ -12,7 +12,7 @@ import { CYPRESS_MNEMONIC, IS_PRODUCTION } from '@/config/constants'
 export const ContentSecurityPolicy = `
  default-src 'self';
  connect-src 'self' *;
- script-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com 'unsafe-inline' https://*.getbeamer.com https://www.googletagmanager.com ${
+ script-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com 'unsafe-inline' https://*.getbeamer.com https://www.googletagmanager.com https://*.ingest.sentry.io ${
    !IS_PRODUCTION || /* TODO: remove after moving cypress to görli and testing in staging again!! */ CYPRESS_MNEMONIC
      ? "'unsafe-eval'"
      : ''


### PR DESCRIPTION
## What it solves

Resolves #827 

## How this PR fixes it
Adds `https://*.ingest.sentry.io` to our CSP allowed src so the Core SDK error is handled without crashing the app.

## How to test it
1. Try to update a 1.0.0 Safe (which will throw an uncatched error)
2. The app should handle the error elegantly and not crash (i.e display our ErrorBoundary component)

## Analytics changes
None

## Screenshots
N/A