### PR TITLE
Fix: don't auto-remove pinned apps

### DIFF
--- a/src/hooks/safe-apps/usePinnedSafeApps.ts
+++ b/src/hooks/safe-apps/usePinnedSafeApps.ts
@@ -1,23 +1,24 @@
-import { useState, useEffect } from 'react'
-import local from '@/services/local-storage/local'
+import { useCallback, useMemo } from 'react'
+import { useAppDispatch, useAppSelector } from '@/store'
+import { selectPinned, setPinned } from '@/store/safeAppsSlice'
 
 type ReturnType = {
   pinnedSafeAppIds: Set<number>
   updatePinnedSafeApps: (newPinnedSafeAppIds: Set<number>) => void
 }
 
-const pinnedSafeAppsIdsKey = 'pinnedSafeAppsIds'
+// Return the pinned app ids across all chains
+export const usePinnedSafeApps = (): ReturnType => {
+  const pinned = useAppSelector(selectPinned)
+  const pinnedSafeAppIds = useMemo(() => new Set(pinned), [pinned])
+  const dispatch = useAppDispatch()
 
-const usePinnedSafeApps = (): ReturnType => {
-  const [pinnedSafeAppIds, updatePinnedSafeApps] = useState<Set<number>>(
-    () => new Set(local.getItem<number[]>(pinnedSafeAppsIdsKey) || []),
+  const updatePinnedSafeApps = useCallback(
+    (pinned: Set<number>) => {
+      dispatch(setPinned(Array.from(pinned)))
+    },
+    [dispatch],
   )
-
-  useEffect(() => {
-    local.setItem(pinnedSafeAppsIdsKey, Array.from(pinnedSafeAppIds))
-  }, [pinnedSafeAppIds])
 
   return { pinnedSafeAppIds, updatePinnedSafeApps }
 }
-
-export { usePinnedSafeApps }

--- a/src/hooks/safe-apps/useSafeApps.ts
+++ b/src/hooks/safe-apps/useSafeApps.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useCallback } from 'react'
+import { useMemo, useCallback } from 'react'
 import type { SafeAppData } from '@gnosis.pm/safe-react-gateway-sdk'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
 import { useCustomSafeApps } from '@/hooks/safe-apps/useCustomSafeApps'
@@ -22,31 +22,12 @@ type ReturnType = {
   removeCustomApp: (appId: number) => void
 }
 
-const useDeadPinnedSafeAppsRemover = (
-  remoteSafeApps: SafeAppData[],
-  pinnedSafeAppIds: Set<number>,
-  updateCallback: (newIds: Set<number>) => void,
-) => {
-  useEffect(() => {
-    if (remoteSafeApps.length > 0 && pinnedSafeAppIds.size > 0) {
-      const filteredPinnedAppsIds = Array.from(pinnedSafeAppIds).filter((pinnedAppId) =>
-        remoteSafeApps.some((app) => app.id === pinnedAppId),
-      )
-      if (filteredPinnedAppsIds.length !== pinnedSafeAppIds.size) {
-        updateCallback(new Set(filteredPinnedAppsIds))
-      }
-    }
-  }, [remoteSafeApps, pinnedSafeAppIds, updateCallback])
-}
-
 const useSafeApps = (): ReturnType => {
   const [remoteSafeApps = [], remoteSafeAppsError, remoteSafeAppsLoading] = useRemoteSafeApps()
   const { customSafeApps, loading: customSafeAppsLoading, updateCustomSafeApps } = useCustomSafeApps()
   const { pinnedSafeAppIds, updatePinnedSafeApps } = usePinnedSafeApps()
   const { removePermissions: removeSafePermissions } = useSafePermissions()
   const { removePermissions: removeBrowserPermissions } = useBrowserPermissions()
-
-  useDeadPinnedSafeAppsRemover(remoteSafeApps, pinnedSafeAppIds, updatePinnedSafeApps)
 
   const allSafeApps = useMemo(
     () => remoteSafeApps.concat(customSafeApps).sort((a, b) => a.name.localeCompare(b.name)),

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -6,6 +6,8 @@ import {
   type AnyAction,
 } from '@reduxjs/toolkit'
 import { useDispatch, useSelector, type TypedUseSelectorHook } from 'react-redux'
+import { IS_PRODUCTION } from '@/config/constants'
+import { createStoreHydrator, HYDRATE_ACTION } from './storeHydrator'
 import { chainsSlice } from './chainsSlice'
 import { safeInfoSlice } from './safeInfoSlice'
 import { balancesSlice } from './balancesSlice'
@@ -20,9 +22,8 @@ import { addedSafesMiddleware, addedSafesSlice } from './addedSafesSlice'
 import { settingsSlice } from './settingsSlice'
 import { cookiesSlice } from './cookiesSlice'
 import { popupSlice } from './popupSlice'
-import { spendingLimitSlice } from '@/store/spendingLimitsSlice'
-import { IS_PRODUCTION } from '@/config/constants'
-import { createStoreHydrator, HYDRATE_ACTION } from './storeHydrator'
+import { spendingLimitSlice } from './spendingLimitsSlice'
+import { safeAppsSlice } from './safeAppsSlice'
 
 const rootReducer = combineReducers({
   [chainsSlice.name]: chainsSlice.reducer,
@@ -39,6 +40,7 @@ const rootReducer = combineReducers({
   [cookiesSlice.name]: cookiesSlice.reducer,
   [popupSlice.name]: popupSlice.reducer,
   [spendingLimitSlice.name]: spendingLimitSlice.reducer,
+  [safeAppsSlice.name]: safeAppsSlice.reducer,
 })
 
 const persistedSlices: (keyof PreloadedState<RootState>)[] = [
@@ -48,6 +50,7 @@ const persistedSlices: (keyof PreloadedState<RootState>)[] = [
   addedSafesSlice.name,
   settingsSlice.name,
   cookiesSlice.name,
+  safeAppsSlice.name,
 ]
 
 const middleware = [persistState(persistedSlices), txHistoryMiddleware, txQueueMiddleware, addedSafesMiddleware]

--- a/src/store/safeAppsSlice.ts
+++ b/src/store/safeAppsSlice.ts
@@ -1,0 +1,27 @@
+import type { PayloadAction } from '@reduxjs/toolkit'
+import { createSlice } from '@reduxjs/toolkit'
+import type { RootState } from '@/store'
+
+export type SafeAppsState = {
+  pinned: number[]
+}
+
+const initialState: SafeAppsState = {
+  pinned: [],
+}
+
+export const safeAppsSlice = createSlice({
+  name: 'safeApps',
+  initialState,
+  reducers: {
+    setPinned: (state, { payload }: PayloadAction<SafeAppsState['pinned']>) => {
+      state.pinned = payload
+    },
+  },
+})
+
+export const { setPinned } = safeAppsSlice.actions
+
+export const selectPinned = (state: RootState): SafeAppsState['pinned'] => {
+  return state[safeAppsSlice.name].pinned || initialState.pinned
+}


### PR DESCRIPTION
## What it solves

Resolves #814 

## How this PR fixes it

The pinned ids are still "global" across chains, because apps also exist on multiple chains.

However, `useDeadPinnedSafeAppsRemover` was removing them if they the app doesn't exist on the current chain.
I've removed that hook. The consequence is that pinned ids might potentially linger even if the app was removed, but they shouldn't do harm?

## How to test it
* Pin a few apps
* Switch to another chain, switch back
* The pinned apps should be intact