### PR TITLE
refactor: slow loading warning timeout constant name

### DIFF
--- a/src/components/safe-apps/AppFrame/useAppIsLoading.ts
+++ b/src/components/safe-apps/AppFrame/useAppIsLoading.ts
@@ -1,8 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 
-import { SAFE_APPS_POLLING_INTERVAL } from '@/config/constants'
-
 const APP_LOAD_ERROR_TIMEOUT = 30000
+const APP_SLOW_LOADING_WARNING_TIMEOUT = 15_000
 const APP_LOAD_ERROR = 'There was an error loading the Safe App. There might be a problem with the App provider.'
 
 type UseAppIsLoadingReturnType = {
@@ -30,7 +29,7 @@ const useAppIsLoading = (): UseAppIsLoadingReturnType => {
     if (appIsLoading) {
       timer.current = window.setTimeout(() => {
         setIsLoadingSlow(true)
-      }, SAFE_APPS_POLLING_INTERVAL)
+      }, APP_SLOW_LOADING_WARNING_TIMEOUT)
       errorTimer.current = window.setTimeout(() => {
         setAppLoadError(() => {
           throw Error(APP_LOAD_ERROR)

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -34,7 +34,6 @@ export const SAFE_TOKEN_ADDRESSES: { [chainId: string]: string } = {
 
 // Safe Apps
 export const SAFE_APPS_INFURA_TOKEN = process.env.NEXT_PUBLIC_SAFE_APPS_INFURA_TOKEN || INFURA_TOKEN
-export const SAFE_APPS_POLLING_INTERVAL = 15_000
 export const SAFE_APPS_THIRD_PARTY_COOKIES_CHECK_URL = 'https://third-party-cookies-check.gnosis-safe.com'
 export const SAFE_APPS_SUPPORT_CHAT_URL = 'https://chat.gnosis-safe.io'
 export const SAFE_APPS_DEMO_SAFE_MAINNET = 'eth:0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7'


### PR DESCRIPTION
## What it solves

Resolves a thing from the discussion [here](https://github.com/safe-global/web-core/pull/808#discussion_r987615060)

## How this PR fixes it

It gives a better name to a constant that defines the number of seconds to elapse before we show a warning that the app takes a long time to load
