### PR TITLE
style: transaction stepper colours

### DIFF
--- a/src/components/transactions/TxSigners/index.tsx
+++ b/src/components/transactions/TxSigners/index.tsx
@@ -58,7 +58,7 @@ const StyledStep = ({ $bold, $state, sx, ...rest }: StyledStepProps & StepProps)
     sx={({ palette }) => ({
       '.MuiStepLabel-label': {
         fontWeight: `${$bold ? 'bold' : 'normal'} !important`,
-        color: `${getStepColor($state, palette)} !important`,
+        color: palette.text.primary,
         fontSize: '16px !important',
       },
       '.MuiStepLabel-iconContainer': {


### PR DESCRIPTION
## What it solves

Resolves transaction stepper colours

## How this PR fixes it

The step labels of the transaction stepper now match that of the [Figma designs](https://www.figma.com/file/ptTs6lDBeUuLNySroJ5PiF/Web-Master-File?node-id=508%3A15613).

## How to test it

Open the transaction details and observe the correct colours in the stepper.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/194854745-4d7db3b9-550e-4a70-9d7d-f64c5140e73d.png)
![image](https://user-images.githubusercontent.com/20442784/194854768-7956a223-1eab-4f56-ad62-a2418afec9bd.png)
![image](https://user-images.githubusercontent.com/20442784/194854829-8a1d6c4c-9826-4e62-8ad7-b744525879b7.png)