### PR TITLE
Fix: auto-choose to WalletConnect on mobile

### DIFF
--- a/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -59,7 +59,9 @@ const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
             </Typography>
 
             <Typography variant="caption" fontWeight="bold">
-              {wallet.ens || (
+              {wallet.ens ? (
+                <div>{wallet.ens}</div>
+              ) : (
                 <EthHashInfo
                   prefix={chainInfo?.shortName}
                   address={wallet.address}

--- a/src/components/common/ConnectWallet/WalletDetails.tsx
+++ b/src/components/common/ConnectWallet/WalletDetails.tsx
@@ -1,13 +1,23 @@
-import { Button, Typography } from '@mui/material'
+import { Button, Typography, useMediaQuery } from '@mui/material'
 import type { ReactElement } from 'react'
-
+import { useTheme } from '@mui/material/styles'
 import useOnboard, { connectWallet } from '@/hooks/wallets/useOnboard'
 import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
 import KeyholeIcon from '@/components/common/icons/KeyholeIcon'
 import { trackEvent } from '@/services/analytics'
+import { WalletNames } from '@/utils/wallets'
 
 const WalletDetails = ({ onConnect }: { onConnect?: () => void }): ReactElement => {
   const onboard = useOnboard()
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
+
+  // On mobile, automatically choose WalletConnect
+  const options = isMobile
+    ? {
+        autoSelect: WalletNames.WALLET_CONNECT,
+      }
+    : undefined
 
   const handleConnect = async () => {
     if (!onboard) return
@@ -16,7 +26,7 @@ const WalletDetails = ({ onConnect }: { onConnect?: () => void }): ReactElement 
     trackEvent(OVERVIEW_EVENTS.OPEN_ONBOARD)
 
     onConnect?.()
-    connectWallet(onboard)
+    connectWallet(onboard, options)
   }
 
   return (

--- a/src/components/common/ConnectWallet/WalletDetails.tsx
+++ b/src/components/common/ConnectWallet/WalletDetails.tsx
@@ -1,23 +1,13 @@
-import { Button, Typography, useMediaQuery } from '@mui/material'
+import { Button, Typography } from '@mui/material'
 import type { ReactElement } from 'react'
-import { useTheme } from '@mui/material/styles'
+
 import useOnboard, { connectWallet } from '@/hooks/wallets/useOnboard'
 import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
 import KeyholeIcon from '@/components/common/icons/KeyholeIcon'
 import { trackEvent } from '@/services/analytics'
-import { WalletNames } from '@/utils/wallets'
 
 const WalletDetails = ({ onConnect }: { onConnect?: () => void }): ReactElement => {
   const onboard = useOnboard()
-  const theme = useTheme()
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
-
-  // On mobile, automatically choose WalletConnect
-  const options = isMobile
-    ? {
-        autoSelect: WalletNames.WALLET_CONNECT,
-      }
-    : undefined
 
   const handleConnect = async () => {
     if (!onboard) return
@@ -26,7 +16,7 @@ const WalletDetails = ({ onConnect }: { onConnect?: () => void }): ReactElement 
     trackEvent(OVERVIEW_EVENTS.OPEN_ONBOARD)
 
     onConnect?.()
-    connectWallet(onboard, options)
+    connectWallet(onboard)
   }
 
   return (

--- a/src/components/common/ConnectWallet/styles.module.css
+++ b/src/components/common/ConnectWallet/styles.module.css
@@ -22,6 +22,7 @@
 }
 
 .addressName {
+  text-align: center;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { type EIP1193Provider, type WalletState, type OnboardAPI } from '@web3-onboard/core'
+import { getDevice } from '@web3-onboard/core/dist/utils'
 import { type ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { getAddress } from 'ethers/lib/utils'
 import useChains, { useCurrentChain } from '@/hooks/useChains'
@@ -9,7 +10,7 @@ import { logError, Errors } from '@/services/exceptions'
 import { trackEvent, WALLET_EVENTS } from '@/services/analytics'
 import { WALLET_KEYS } from '@/hooks/wallets/wallets'
 import { useInitPairing } from '@/services/pairing/hooks'
-import { isWalletUnlocked } from '@/utils/wallets'
+import { isWalletUnlocked, WalletNames } from '@/utils/wallets'
 
 export type ConnectedWallet = {
   label: string
@@ -76,6 +77,13 @@ const trackWalletType = async (wallet: ConnectedWallet) => {
 
 // Wrapper that tracks/sets the last used wallet
 export const connectWallet = (onboard: OnboardAPI, options?: Parameters<OnboardAPI['connectWallet']>[0]) => {
+  // On mobile/tablet, automatically choose WalletConnect
+  if (!options && getDevice().type !== 'desktop') {
+    options = {
+      autoSelect: WalletNames.WALLET_CONNECT,
+    }
+  }
+
   onboard
     .connectWallet(options)
     .then(async (wallets) => {

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -1,6 +1,5 @@
 import { useEffect } from 'react'
 import { type EIP1193Provider, type WalletState, type OnboardAPI } from '@web3-onboard/core'
-import { getDevice } from '@web3-onboard/core/dist/utils'
 import { type ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { getAddress } from 'ethers/lib/utils'
 import useChains, { useCurrentChain } from '@/hooks/useChains'
@@ -75,10 +74,13 @@ const trackWalletType = async (wallet: ConnectedWallet) => {
   }
 }
 
+// Detect mobile devices
+const isMobile = () => /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
+
 // Wrapper that tracks/sets the last used wallet
 export const connectWallet = (onboard: OnboardAPI, options?: Parameters<OnboardAPI['connectWallet']>[0]) => {
-  // On mobile/tablet, automatically choose WalletConnect
-  if (!options && getDevice().type !== 'desktop') {
+  // On mobile, automatically choose WalletConnect
+  if (!options && isMobile()) {
     options = {
       autoSelect: WalletNames.WALLET_CONNECT,
     }

--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -24,7 +24,7 @@ export const isWalletRejection = (err: Error & { code?: number }): boolean => {
   return isMMRejection(err) || isWCRejection(err) || isKeystoneError(err)
 }
 
-const WalletNames = {
+export const WalletNames = {
   METAMASK: ProviderLabel.MetaMask,
   WALLET_CONNECT: 'WalletConnect',
   SAFE_MOBILE_PAIRING: PAIRING_MODULE_LABEL,


### PR DESCRIPTION
## What it solves

Resolves #871

## How this PR fixes it
When the user presses "Connect wallet" on mobile, it automatically pops up the WalletConnect modal instead the onboard modal.