### PR TITLE
fix: add signing to pending tx states

### DIFF
--- a/src/components/transactions/SignTxButton/index.tsx
+++ b/src/components/transactions/SignTxButton/index.tsx
@@ -1,7 +1,7 @@
 import type { SyntheticEvent } from 'react'
-import { useState, type ReactElement, useEffect } from 'react'
+import { useState, type ReactElement } from 'react'
 import { type TransactionSummary } from '@gnosis.pm/safe-react-gateway-sdk'
-import { Button, CircularProgress, Tooltip } from '@mui/material'
+import { Button, Tooltip } from '@mui/material'
 
 import { isSignableBy } from '@/utils/transaction-guards'
 import useWallet from '@/hooks/wallets/useWallet'
@@ -12,23 +12,6 @@ import IconButton from '@mui/material/IconButton'
 import CheckIcon from '@mui/icons-material/Check'
 import Track from '@/components/common/Track'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
-import { txSubscribe, TxEvent } from '@/services/tx/txEvents'
-
-const useIsSignatureProposalPending = (txSummary: TransactionSummary) => {
-  const [isSignatureProposalPending, setIsSignatureProposalPending] = useState<boolean>(false)
-
-  // There's lag between a successful signature proposal w/ backend and the queued tx confirmation list updating
-  // so we need a local pending state until the confirmation list successfully updates
-  useEffect(() => {
-    return txSubscribe(TxEvent.SIGNATURE_PROPOSED, ({ txId }) => {
-      if (txSummary.id === txId) {
-        setIsSignatureProposalPending(true)
-      }
-    })
-  }, [txSummary.id])
-
-  return isSignatureProposalPending
-}
 
 const SignTxButton = ({
   txSummary,
@@ -42,14 +25,13 @@ const SignTxButton = ({
   const isSignable = isSignableBy(txSummary, wallet?.address || '')
   const isSafeOwner = useIsSafeOwner()
   const isPending = useIsPending(txSummary.id)
-  const isSignatureProposalPending = useIsSignatureProposalPending(txSummary)
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()
     setOpen(true)
   }
 
-  const isDisabled = !isSignable || !isSafeOwner || isPending || isSignatureProposalPending
+  const isDisabled = !isSignable || !isSafeOwner || isPending
 
   return (
     <>
@@ -58,7 +40,7 @@ const SignTxButton = ({
           <Tooltip title="Confirm" arrow placement="top">
             <span>
               <IconButton onClick={onClick} color="primary" disabled={isDisabled} size="small">
-                {isSignatureProposalPending ? <CircularProgress size={14} /> : <CheckIcon fontSize="small" />}
+                <CheckIcon fontSize="small" />
               </IconButton>
             </span>
           </Tooltip>

--- a/src/components/transactions/TxSigners/index.tsx
+++ b/src/components/transactions/TxSigners/index.tsx
@@ -113,9 +113,7 @@ export const TxSigners = ({
 
   const { confirmations, confirmationsRequired, executor } = detailedExecutionInfo
 
-  // Backend doesn't return all confirmations for immediately executed transactions
-  const confirmationsCount =
-    isPending && confirmations.length < confirmationsRequired ? confirmationsRequired : confirmations.length
+  const confirmationsCount = confirmations.length
   const canExecute = wallet?.address ? isExecutable(txSummary, wallet.address, safe) : false
   const confirmationsNeeded = confirmationsRequired - confirmations.length
   const isConfirmed = confirmationsNeeded <= 0 || isPending || canExecute

--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -50,10 +50,7 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
     ? tx.executionInfo.confirmationsRequired
     : undefined
   const submittedConfirmations = isMultisigExecutionInfo(tx.executionInfo)
-    ? // Backend does not update confirmationsSubmitted for immediately executed transactions
-      isPending && tx.executionInfo.confirmationsSubmitted < tx.executionInfo.confirmationsRequired
-      ? requiredConfirmations
-      : tx.executionInfo.confirmationsSubmitted
+    ? tx.executionInfo.confirmationsSubmitted
     : undefined
 
   const displayConfirmations = isQueue && !!submittedConfirmations && !!requiredConfirmations

--- a/src/hooks/useTransactionStatus.ts
+++ b/src/hooks/useTransactionStatus.ts
@@ -20,6 +20,7 @@ const STATUS_LABELS: Record<TxLocalStatus, string> = {
   [PendingStatus.SUBMITTING]: 'Submitting',
   [PendingStatus.PROCESSING]: 'Processing',
   [PendingStatus.INDEXING]: 'Indexing',
+  [PendingStatus.SIGNING]: 'Signing',
   [ReplacedStatus]: 'Transaction will be replaced',
 }
 

--- a/src/hooks/useTxPendingStatuses.ts
+++ b/src/hooks/useTxPendingStatuses.ts
@@ -58,7 +58,6 @@ const useTxPendingStatuses = (): void => {
   useEffect(() => {
     const unsubFns = Object.entries(pendingStatuses).map(([event, status]) =>
       txSubscribe(event as TxEvent, (detail) => {
-        console.log('Tx Event:', detail)
         // All pending txns should have a txId
         const txId = 'txId' in detail && detail.txId
         if (!txId) return
@@ -66,11 +65,9 @@ const useTxPendingStatuses = (): void => {
         // Clear the pending status if the tx is no longer pending
         const isFinished = status === null
         if (isFinished) {
-          console.log('Tx finished')
           dispatch(clearPendingTx({ txId }))
           return
         }
-        console.log('Tx in status', status)
 
         // Or set a new status
         dispatch(

--- a/src/services/tx/__tests__/txSender.test.ts
+++ b/src/services/tx/__tests__/txSender.test.ts
@@ -184,7 +184,7 @@ describe('txSender', () => {
       expect(proposeTx).toHaveBeenCalledWith('4', '0x123', '0x456', tx, '0x1234567890')
       expect(proposedTx).toEqual({ txId: '123' })
 
-      expect(txEvents.txDispatch).toHaveBeenCalledWith('SIGNATURE_PROPOSED', { txId: '123' })
+      expect(txEvents.txDispatch).toHaveBeenCalledWith('SIGNATURE_PROPOSED', { txId: '123', signerAddress: '0x456' })
     })
 
     it('should fail to propose a signature', async () => {

--- a/src/services/tx/txEvents.ts
+++ b/src/services/tx/txEvents.ts
@@ -9,6 +9,7 @@ export enum TxEvent {
   PROPOSE_FAILED = 'PROPOSE_FAILED',
   SIGNATURE_PROPOSED = 'SIGNATURE_PROPOSED',
   SIGNATURE_PROPOSE_FAILED = 'SIGNATURE_PROPOSE_FAILED',
+  SIGNATURE_INDEXED = 'SIGNATURE_INDEXED',
   AWAITING_ON_CHAIN_SIGNATURE = 'AWAITING_ON_CHAIN_SIGNATURE',
   EXECUTING = 'EXECUTING',
   PROCESSING = 'PROCESSING',
@@ -28,7 +29,8 @@ interface TxEvents {
   [TxEvent.PROPOSE_FAILED]: { error: Error }
   [TxEvent.PROPOSED]: { txId: string }
   [TxEvent.SIGNATURE_PROPOSE_FAILED]: { txId: string; error: Error }
-  [TxEvent.SIGNATURE_PROPOSED]: { txId: string }
+  [TxEvent.SIGNATURE_PROPOSED]: { txId: string; signerAddress: string }
+  [TxEvent.SIGNATURE_INDEXED]: { txId: string }
   [TxEvent.AWAITING_ON_CHAIN_SIGNATURE]: Id
   [TxEvent.EXECUTING]: Id
   [TxEvent.PROCESSING]: Id & { txHash: string }

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -217,7 +217,10 @@ export const dispatchTxProposal = async (
     throw error
   }
 
-  txDispatch(txId ? TxEvent.SIGNATURE_PROPOSED : TxEvent.PROPOSED, { txId: proposedTx.txId, signerAddress: sender })
+  txDispatch(txId ? TxEvent.SIGNATURE_PROPOSED : TxEvent.PROPOSED, {
+    txId: proposedTx.txId,
+    signerAddress: txId ? sender : undefined,
+  })
 
   return proposedTx
 }

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -217,7 +217,7 @@ export const dispatchTxProposal = async (
     throw error
   }
 
-  txDispatch(txId ? TxEvent.SIGNATURE_PROPOSED : TxEvent.PROPOSED, { txId: proposedTx.txId })
+  txDispatch(txId ? TxEvent.SIGNATURE_PROPOSED : TxEvent.PROPOSED, { txId: proposedTx.txId, signerAddress: sender })
 
   return proposedTx
 }

--- a/src/store/__tests__/txQueueSlice.test.ts
+++ b/src/store/__tests__/txQueueSlice.test.ts
@@ -1,0 +1,103 @@
+import { txQueueMiddleware, txQueueSlice } from '../txQueueSlice'
+import * as txEvents from '@/services/tx/txEvents'
+
+import * as mockPendingTxs from '../pendingTxsSlice'
+import { PendingStatus } from '../pendingTxsSlice'
+import { DetailedExecutionInfoType, TransactionListItemType } from '@gnosis.pm/safe-react-gateway-sdk'
+import { TxEvent } from '@/services/tx/txEvents'
+
+const create = () => {
+  const store: any = {
+    getState: jest.fn(() => ({})),
+    dispatch: jest.fn(),
+  }
+  const next = jest.fn()
+
+  const invoke = (action: any) => txQueueMiddleware(store)(next)(action)
+
+  return { store, next, invoke }
+}
+
+jest.mock('@/store/common', () => ({
+  makeLoadableSlice: jest.fn(() => ({
+    slice: {
+      actions: {
+        set: {
+          type: 'SET_QUEUE',
+        },
+      },
+    },
+    selector: jest.fn(() => ({ data: undefined })),
+  })),
+}))
+
+describe('txQueueSlice', () => {
+  let txDispatchSpy: jest.SpyInstance
+  beforeEach(() => {
+    txDispatchSpy = jest.spyOn(txEvents, 'txDispatch')
+    txDispatchSpy.mockImplementation(() => {})
+    jest.spyOn(mockPendingTxs, 'selectPendingTxs').mockImplementation(() => ({
+      ['0x123']: {
+        chainId: '5',
+        status: PendingStatus.SIGNING,
+        signerAddress: '0x456',
+      },
+    }))
+  })
+
+  it('should not dispatch event if signature is still missing', () => {
+    const { next, invoke } = create()
+    const action = {
+      type: txQueueSlice.actions.set.type,
+      payload: {
+        data: {
+          results: [
+            {
+              type: TransactionListItemType.TRANSACTION,
+              transaction: {
+                id: '0x123',
+                executionInfo: {
+                  type: DetailedExecutionInfoType.MULTISIG,
+                  missingSigners: [
+                    {
+                      value: '0x456',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      },
+    }
+    invoke(action)
+    expect(next).toHaveBeenCalledWith(action)
+    expect(txDispatchSpy).not.toHaveBeenCalled()
+  })
+
+  it('should dispatch SIGNATURE_INDEXED event for added signature', () => {
+    const { next, invoke } = create()
+    const action = {
+      type: txQueueSlice.actions.set.type,
+      payload: {
+        data: {
+          results: [
+            {
+              type: TransactionListItemType.TRANSACTION,
+              transaction: {
+                id: '0x123',
+                executionInfo: {
+                  type: DetailedExecutionInfoType.MULTISIG,
+                  missingSigners: [],
+                },
+              },
+            },
+          ],
+        },
+      },
+    }
+    invoke(action)
+    expect(next).toHaveBeenCalledWith(action)
+    expect(txDispatchSpy).toHaveBeenCalledWith(TxEvent.SIGNATURE_INDEXED, { txId: '0x123' })
+  })
+})

--- a/src/store/pendingTxsSlice.ts
+++ b/src/store/pendingTxsSlice.ts
@@ -3,6 +3,7 @@ import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolki
 import type { RootState } from '@/store'
 
 export enum PendingStatus {
+  SIGNING = 'SIGNING',
   SUBMITTING = 'SUBMITTING',
   PROCESSING = 'PROCESSING',
   INDEXING = 'INDEXING',
@@ -15,6 +16,7 @@ type PendingTxsState =
         status: PendingStatus
         txHash?: string
         groupKey?: string
+        signerAddress?: string
       }
     }
   | Record<string, never>
@@ -33,6 +35,7 @@ export const pendingTxsSlice = createSlice({
         txHash?: string
         groupKey?: string
         status: PendingStatus
+        signerAddress?: string
       }>,
     ) => {
       const { txId, ...pendingTx } = action.payload

--- a/src/store/txQueueSlice.ts
+++ b/src/store/txQueueSlice.ts
@@ -6,6 +6,9 @@ import type { RootState } from '@/store'
 import { makeLoadableSlice } from './common'
 import { isMultisigExecutionInfo, isTransactionListItem } from '@/utils/transaction-guards'
 import { trackEvent, TX_LIST_EVENTS } from '@/services/analytics'
+import { selectPendingTxs } from './pendingTxsSlice'
+import { sameAddress } from '@/utils/addresses'
+import { txDispatch, TxEvent } from '@/services/tx/txEvents'
 
 const { slice, selector } = makeLoadableSlice('txQueue', undefined as TransactionListPage | undefined)
 
@@ -49,6 +52,44 @@ export const txQueueMiddleware: Middleware<{}, RootState> = (store) => (next) =>
   switch (action.type) {
     case txQueueSlice.actions.set.type: {
       trackQueueSize(prevState, action)
+
+      // Update proposed txs if signature was added successfully
+      const state = store.getState()
+      const pendingTxs = selectPendingTxs(state)
+
+      const { payload } = action as ReturnType<typeof txQueueSlice.actions.set>
+      const results = payload.data?.results
+      if (!results) {
+        return
+      }
+
+      for (const result of results) {
+        if (!isTransactionListItem(result)) {
+          continue
+        }
+
+        const id = result.transaction.id
+
+        const pendingTx = pendingTxs[id]
+        if (!pendingTx) {
+          continue
+        }
+
+        const awaitingSigner = pendingTx.signerAddress
+        if (!awaitingSigner) {
+          continue
+        }
+
+        // The transaction is waiting for a signature of awaitingSigner
+        if (
+          isMultisigExecutionInfo(result.transaction.executionInfo) &&
+          !result.transaction.executionInfo.missingSigners?.some((address) =>
+            sameAddress(address.value, awaitingSigner),
+          )
+        ) {
+          txDispatch(TxEvent.SIGNATURE_INDEXED, { txId: id })
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## What it solves
There is a delay of a few seconds between signing a queued tx and receiving the new signature from the tx services. 
Currently the pending signature is only reflected by the signing button and not reflected in the redux store causing the loading spinner to disappear when switching views.

Resolves #872 

## How this PR fixes it
Adds a new `PendingStatus.SIGNING` which receives the pending `signerAddress` as payload.
The `txQueueSlice` middleware will update the pending status once the pending signature is returned by the tx service queue.

## How to test it
1. Queue any tx is a 2/n safe
2. add the second signature without executing the tx
3. witness the new "Signing" status which is persisted when switching to the history tab and back

## Analytics changes
None

## Screenshots
![pendingSignature](https://user-images.githubusercontent.com/2670790/194913556-9e340b50-c884-4fd4-95a7-056bb2d6a803.gif)

