### PR TITLE
test: add test for txHistorySlice middleware

### DIFF
--- a/src/store/__tests__/txHistorySlice.test.ts
+++ b/src/store/__tests__/txHistorySlice.test.ts
@@ -1,0 +1,89 @@
+import { txHistoryMiddleware, txHistorySlice } from '../txHistorySlice'
+import * as txEvents from '@/services/tx/txEvents'
+import * as mockPendingTxs from '../pendingTxsSlice'
+import { PendingStatus } from '../pendingTxsSlice'
+import { TransactionListItemType } from '@gnosis.pm/safe-react-gateway-sdk'
+import { TxEvent } from '@/services/tx/txEvents'
+
+const create = () => {
+  const store: any = {
+    getState: jest.fn(() => ({})),
+    dispatch: jest.fn(),
+  }
+  const next = jest.fn()
+
+  const invoke = (action: any) => txHistoryMiddleware(store)(next)(action)
+
+  return { store, next, invoke }
+}
+
+jest.mock('@/store/common', () => ({
+  makeLoadableSlice: jest.fn(() => ({
+    slice: {
+      actions: {
+        set: {
+          type: 'SET_HISTORY',
+        },
+      },
+    },
+    selector: jest.fn(() => ({ data: undefined })),
+  })),
+}))
+
+describe('txHistorySlice', () => {
+  let txDispatchSpy: jest.SpyInstance
+  describe('txHistoryMiddleware', () => {
+    txDispatchSpy = jest.spyOn(txEvents, 'txDispatch')
+    txDispatchSpy.mockImplementation(() => {})
+    jest.spyOn(mockPendingTxs, 'selectPendingTxs').mockImplementation(() => ({
+      ['0x123']: {
+        chainId: '5',
+        status: PendingStatus.INDEXING,
+        groupKey: '0x123456',
+      },
+    }))
+
+    it('should not dispatch event if tx is not pending', () => {
+      const { next, invoke } = create()
+      const action = {
+        type: txHistorySlice.actions.set.type,
+        payload: {
+          data: {
+            results: [
+              {
+                type: TransactionListItemType.TRANSACTION,
+                transaction: {
+                  id: '0x234',
+                },
+              },
+            ],
+          },
+        },
+      }
+      invoke(action)
+      expect(next).toHaveBeenCalledWith(action)
+      expect(txDispatchSpy).not.toHaveBeenCalled()
+    })
+    it('should dispatch SUCCESS event if tx is pending', () => {
+      const { next, invoke } = create()
+      const action = {
+        type: txHistorySlice.actions.set.type,
+        payload: {
+          data: {
+            results: [
+              {
+                type: TransactionListItemType.TRANSACTION,
+                transaction: {
+                  id: '0x123',
+                },
+              },
+            ],
+          },
+        },
+      }
+      invoke(action)
+      expect(next).toHaveBeenCalledWith(action)
+      expect(txDispatchSpy).toHaveBeenCalledWith(TxEvent.SUCCESS, { txId: '0x123', groupKey: '0x123456' })
+    })
+  })
+})


### PR DESCRIPTION
## What this PR adds
A Jest unit test for the tx history middleware which dispatched `SUCCESS` events if a pending tx was added to the history.

## How to test it
`yarn test txHistory`

## Analytics changes
None
