### PR TITLE
fix: placeholder when no apps found

### DIFF
--- a/src/components/safe-apps/SafeAppList.tsx
+++ b/src/components/safe-apps/SafeAppList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Grid from '@mui/material/Grid'
 import Typography from '@mui/material/Typography'
 import { SafeAppsSection } from './SafeAppsSection'
@@ -9,8 +9,17 @@ import { useRemoveAppModal } from '@/hooks/safe-apps/useRemoveAppModal'
 import useDebounce from '@/hooks/useDebounce'
 import { RemoveCustomAppModal } from '@/components/safe-apps/RemoveCustomAppModal'
 import { SAFE_APPS_EVENTS, trackEvent } from '@/services/analytics'
+import PagePlaceholder from '../common/PagePlaceholder'
+import { Button } from '@mui/material'
+import AddCustomAppIcon from '@/public/images/apps/add-custom-app.svg'
+import { useRouter } from 'next/router'
+import { AppRoutes } from '@/config/routes'
+import Link from 'next/link'
+import type { LinkProps } from 'next/link'
+import { SafeAppsTag } from '@/config/constants'
 
 const SafeAppList = () => {
+  const router = useRouter()
   const [searchQuery, setSearchQuery] = useState('')
   const {
     allSafeApps,
@@ -27,6 +36,22 @@ const SafeAppList = () => {
   const { state: removeCustomAppModalState, open: openRemoveAppModal, close } = useRemoveAppModal()
 
   const debouncedSearchQuery = useDebounce(searchQuery, 500)
+
+  const wcLink: LinkProps['href'] = useMemo(() => {
+    const wc = allSafeApps.find((app) => app.tags.includes(SafeAppsTag.WALLET_CONNECT))
+
+    if (!wc) {
+      return '#'
+    }
+
+    return {
+      pathname: AppRoutes.apps,
+      query: {
+        safe: router.query.safe,
+        appUrl: wc.url,
+      },
+    }
+  }, [allSafeApps, router.query.safe])
 
   useEffect(() => {
     if (debouncedSearchQuery) {
@@ -68,9 +93,21 @@ const SafeAppList = () => {
   if (searchQuery) {
     if (filteredApps.length === 0) {
       pageBody = (
-        <Typography variant="body1" p={2}>
-          No apps found
-        </Typography>
+        <PagePlaceholder
+          img={<AddCustomAppIcon />}
+          text={
+            <Typography variant="body1" color="primary.light" m={2}>
+              No apps found matching <strong>{searchQuery}</strong>. Connect to dApps that haven&apos;t yet been
+              integrated with the Safe using the WalletConnect App.
+            </Typography>
+          }
+        >
+          <Link href={wcLink} passHref>
+            <Button variant="contained" disableElevation size="small">
+              Use WalletConnect
+            </Button>
+          </Link>
+        </PagePlaceholder>
       )
     } else {
       pageBody = <SafeAppsSection title={`Search results (${filteredApps.length})`} apps={filteredApps} />

--- a/src/components/safe-apps/SafeAppList.tsx
+++ b/src/components/safe-apps/SafeAppList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import Grid from '@mui/material/Grid'
 import Typography from '@mui/material/Typography'
 import { SafeAppsSection } from './SafeAppsSection'
@@ -9,17 +9,9 @@ import { useRemoveAppModal } from '@/hooks/safe-apps/useRemoveAppModal'
 import useDebounce from '@/hooks/useDebounce'
 import { RemoveCustomAppModal } from '@/components/safe-apps/RemoveCustomAppModal'
 import { SAFE_APPS_EVENTS, trackEvent } from '@/services/analytics'
-import PagePlaceholder from '../common/PagePlaceholder'
-import { Button } from '@mui/material'
-import AddCustomAppIcon from '@/public/images/apps/add-custom-app.svg'
-import { useRouter } from 'next/router'
-import { AppRoutes } from '@/config/routes'
-import Link from 'next/link'
-import type { LinkProps } from 'next/link'
-import { SafeAppsTag } from '@/config/constants'
+import SafeAppsSearchPlaceholder from './SafeAppsSearchPlaceholder'
 
 const SafeAppList = () => {
-  const router = useRouter()
   const [searchQuery, setSearchQuery] = useState('')
   const {
     allSafeApps,
@@ -36,22 +28,6 @@ const SafeAppList = () => {
   const { state: removeCustomAppModalState, open: openRemoveAppModal, close } = useRemoveAppModal()
 
   const debouncedSearchQuery = useDebounce(searchQuery, 500)
-
-  const wcLink: LinkProps['href'] = useMemo(() => {
-    const wc = allSafeApps.find((app) => app.tags.includes(SafeAppsTag.WALLET_CONNECT))
-
-    if (!wc) {
-      return '#'
-    }
-
-    return {
-      pathname: AppRoutes.apps,
-      query: {
-        safe: router.query.safe,
-        appUrl: wc.url,
-      },
-    }
-  }, [allSafeApps, router.query.safe])
 
   useEffect(() => {
     if (debouncedSearchQuery) {
@@ -92,23 +68,7 @@ const SafeAppList = () => {
   )
   if (searchQuery) {
     if (filteredApps.length === 0) {
-      pageBody = (
-        <PagePlaceholder
-          img={<AddCustomAppIcon />}
-          text={
-            <Typography variant="body1" color="primary.light" m={2}>
-              No apps found matching <strong>{searchQuery}</strong>. Connect to dApps that haven&apos;t yet been
-              integrated with the Safe using the WalletConnect App.
-            </Typography>
-          }
-        >
-          <Link href={wcLink} passHref>
-            <Button variant="contained" disableElevation size="small">
-              Use WalletConnect
-            </Button>
-          </Link>
-        </PagePlaceholder>
-      )
+      pageBody = <SafeAppsSearchPlaceholder searchQuery={searchQuery} />
     } else {
       pageBody = <SafeAppsSection title={`Search results (${filteredApps.length})`} apps={filteredApps} />
     }

--- a/src/components/safe-apps/SafeAppsSearchPlaceholder.tsx
+++ b/src/components/safe-apps/SafeAppsSearchPlaceholder.tsx
@@ -1,0 +1,48 @@
+import React, { useMemo } from 'react'
+import { Button, Typography } from '@mui/material'
+import { useRouter } from 'next/router'
+import Link from 'next/link'
+import type { LinkProps } from 'next/link'
+
+import PagePlaceholder from '../common/PagePlaceholder'
+import AddCustomAppIcon from '@/public/images/apps/add-custom-app.svg'
+import { AppRoutes } from '@/config/routes'
+import { SafeAppsTag } from '@/config/constants'
+import { useSafeApps } from '@/hooks/safe-apps/useSafeApps'
+
+const useWCAppLink = (): LinkProps['href'] => {
+  const router = useRouter()
+  const { allSafeApps } = useSafeApps()
+  const app = allSafeApps.find((app) => app.tags?.includes(SafeAppsTag.TX_BUILDER))
+
+  return useMemo(
+    () => ({
+      pathname: AppRoutes.apps,
+      query: { safe: router.query.safe, appUrl: app?.url },
+    }),
+    [app?.url, router.query.safe],
+  )
+}
+
+const SafeAppsSearchPlaceholder = ({ searchQuery }: { searchQuery: string }) => {
+  const wcLink = useWCAppLink()
+  return (
+    <PagePlaceholder
+      img={<AddCustomAppIcon />}
+      text={
+        <Typography variant="body1" color="primary.light" m={2} maxWidth="600px">
+          No apps found matching <strong>{searchQuery}</strong>. Connect to dApps that haven&apos;t yet been integrated
+          with the Safe using the WalletConnect App.
+        </Typography>
+      }
+    >
+      <Link href={wcLink} passHref>
+        <Button variant="contained" disableElevation size="small">
+          Use WalletConnect
+        </Button>
+      </Link>
+    </PagePlaceholder>
+  )
+}
+
+export default SafeAppsSearchPlaceholder

--- a/src/components/safe-apps/SafeAppsSearchPlaceholder.tsx
+++ b/src/components/safe-apps/SafeAppsSearchPlaceholder.tsx
@@ -13,7 +13,7 @@ import { useSafeApps } from '@/hooks/safe-apps/useSafeApps'
 const useWCAppLink = (): LinkProps['href'] => {
   const router = useRouter()
   const { allSafeApps } = useSafeApps()
-  const app = allSafeApps.find((app) => app.tags?.includes(SafeAppsTag.TX_BUILDER))
+  const app = allSafeApps.find((app) => app.tags?.includes(SafeAppsTag.WALLET_CONNECT))
 
   return useMemo(
     () => ({

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -54,4 +54,5 @@ export enum SafeAppsTag {
   TX_BUILDER = 'transaction-builder',
   DASHBOARD_FEATURED = 'dashboard-widgets',
   SAFE_CLAIMING_APP = 'safe-claiming-app',
+  WALLET_CONNECT = 'wallet-connect',
 }

--- a/src/tests/pages/apps.test.tsx
+++ b/src/tests/pages/apps.test.tsx
@@ -310,7 +310,7 @@ describe('AppsPage', () => {
         fireEvent.change(input, { target: { value: 'gibberish gibberish' } })
       })
 
-      await waitFor(() => expect(screen.getByText('No apps found')).toBeInTheDocument())
+      await waitFor(() => expect(screen.getByText('No apps found', { exact: false })).toBeInTheDocument())
     })
 
     it('shows apps matching the query', async () => {


### PR DESCRIPTION
## What it solves

Resolves #836

## How this PR fixes it

Adds placeholder when no searchs apps are found.

## How to test it

Open Safe and search for apps that don't exist. Observe the placeholder with working WalletConnect button (across networks).

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/195041991-e09e4e72-5e9b-407e-9ab5-f19e17c76e32.png)

![image](https://user-images.githubusercontent.com/20442784/195042005-4121754a-461a-4416-ad88-6793d3f68626.png)