### PR TITLE
Fix: rm QR camera facing mode

### DIFF
--- a/src/components/common/ScanQRModal/index.tsx
+++ b/src/components/common/ScanQRModal/index.tsx
@@ -78,7 +78,6 @@ const ScanQRModal = ({ isOpen, onClose, onScan }: Props): React.ReactElement => 
           onScan={onFileScannedResolve}
           ref={scannerRef}
           style={{ width: '400px', height: '400px' }}
-          facingMode="user"
         />
       </Box>
 


### PR DESCRIPTION
## What it solves

@francovenica:
> For mobile. When you try to use the QR code feature the system will turn on your frontal camera and there is no way to change it to the back camera, making it really hard to read a QR code that way. I'd like to discuss it here first since idk if there is anything we can do about it

I've removed `facingMode: user` so that it choses whichever camera is the default.