### PR TITLE
Fix: hide error details in notifications

### DIFF
--- a/src/components/common/Notifications/index.tsx
+++ b/src/components/common/Notifications/index.tsx
@@ -45,6 +45,7 @@ export const NotificationLink = ({
 
 const Toast = ({
   message,
+  detailedMessage,
   variant,
   link,
   onClose,
@@ -72,6 +73,13 @@ const Toast = ({
     <Snackbar open onClose={handleClose} sx={toastStyle} autoHideDuration={autoHideDuration}>
       <Alert severity={variant} onClose={handleClose} elevation={3} sx={{ width: '340px' }}>
         {message}
+
+        {detailedMessage && (
+          <details>
+            <Link component="summary">Details</Link>
+            <pre>{detailedMessage}</pre>
+          </details>
+        )}
         <NotificationLink link={link} onClick={handleClose} />
       </Alert>
     </Snackbar>

--- a/src/components/common/Notifications/styles.module.css
+++ b/src/components/common/Notifications/styles.module.css
@@ -19,3 +19,26 @@
   align-items: center;
   margin-top: 0.3em;
 }
+
+.container details {
+  margin-bottom: var(--space-1);
+  max-height: 200px;
+  overflow: auto;
+}
+
+.container pre {
+  margin: var(--space-1) 0 var(--space-2);
+  white-space: pre-wrap;
+  color: var(--color-primary-light);
+}
+
+.container summary {
+  text-decoration: underline;
+  cursor: pointer;
+  list-style: none;
+  margin-top: 4px;
+}
+
+.container summary::-webkit-details-marker {
+  display: none;
+}

--- a/src/components/tx/ErrorMessage/index.tsx
+++ b/src/components/tx/ErrorMessage/index.tsx
@@ -3,7 +3,6 @@ import { Link, Typography, SvgIcon } from '@mui/material'
 import WarningIcon from '@/public/images/notifications/warning.svg'
 import css from './styles.module.css'
 
-// TODO: Replace with notification
 const ErrorMessage = ({
   children,
   error,

--- a/src/hooks/safe-apps/permissions/index.ts
+++ b/src/hooks/safe-apps/permissions/index.ts
@@ -1,5 +1,6 @@
 import { RestrictedMethods } from '@gnosis.pm/safe-apps-sdk'
 import type { AllowedFeatures } from '@/components/safe-apps/types'
+import { capitalize } from '@/utils/formatters'
 
 type PermissionsDisplayType = {
   displayName: string
@@ -19,8 +20,6 @@ const SAFE_PERMISSIONS_TEXTS: Record<string, PermissionsDisplayType> = {
 export const getSafePermissionDisplayValues = (method: string) => {
   return SAFE_PERMISSIONS_TEXTS[method]
 }
-
-const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
 
 export const getBrowserPermissionDisplayValues = (feature: AllowedFeatures) => {
   return {

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -1,4 +1,6 @@
 import { useEffect, useMemo } from 'react'
+import type { EthersError } from '@/utils/ethers-utils'
+import { capitalize } from '@/utils/formatters'
 import { selectNotifications, showNotification } from '@/store/notificationsSlice'
 import { useAppDispatch, useAppSelector } from '@/store'
 import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
@@ -51,7 +53,9 @@ const useTxNotifications = (): void => {
       txSubscribe(event, (detail) => {
         const isError = 'error' in detail
         const isSuccess = event === TxEvent.SUCCESS || event === TxEvent.PROPOSED
-        const message = isError ? `${baseMessage} ${detail.error.message.slice(0, 300)}` : baseMessage
+        const message = isError
+          ? `${baseMessage} ${capitalize((detail.error as EthersError).reason || '')}`
+          : baseMessage
 
         const txId = 'txId' in detail ? detail.txId : undefined
         const groupKey = 'groupKey' in detail && detail.groupKey ? detail.groupKey : txId || ''
@@ -61,6 +65,7 @@ const useTxNotifications = (): void => {
         dispatch(
           showNotification({
             message,
+            detailedMessage: isError ? detail.error.message : undefined,
             groupKey,
             variant: isError ? Variant.ERROR : isSuccess ? Variant.SUCCESS : Variant.INFO,
             ...(shouldShowLink && {

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -60,9 +60,7 @@ const useTxNotifications = (): void => {
       txSubscribe(event, (detail) => {
         const isError = 'error' in detail
         const isSuccess = event === TxEvent.SUCCESS || event === TxEvent.PROPOSED
-        const message = isError
-          ? `${baseMessage} ${formatError(detail.error)}`
-          : baseMessage
+        const message = isError ? `${baseMessage} ${formatError(detail.error)}` : baseMessage
 
         const txId = 'txId' in detail ? detail.txId : undefined
         const groupKey = 'groupKey' in detail && detail.groupKey ? detail.groupKey : txId || ''

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -1,5 +1,4 @@
 import { useEffect, useMemo } from 'react'
-import type { EthersError } from '@/utils/ethers-utils'
 import { capitalize } from '@/utils/formatters'
 import { selectNotifications, showNotification } from '@/store/notificationsSlice'
 import { useAppDispatch, useAppSelector } from '@/store'
@@ -37,6 +36,14 @@ enum Variant {
   ERROR = 'error',
 }
 
+// Format the error message
+const formatError = (error: Error & { reason?: string }): string => {
+  let { reason } = error
+  if (!reason) return ''
+  if (!reason.endsWith('.')) reason += '.'
+  return capitalize(reason)
+}
+
 const useTxNotifications = (): void => {
   const dispatch = useAppDispatch()
   const chain = useCurrentChain()
@@ -54,7 +61,7 @@ const useTxNotifications = (): void => {
         const isError = 'error' in detail
         const isSuccess = event === TxEvent.SUCCESS || event === TxEvent.PROPOSED
         const message = isError
-          ? `${baseMessage} ${capitalize((detail.error as EthersError).reason || '')}`
+          ? `${baseMessage} ${formatError(detail.error)}`
           : baseMessage
 
         const txId = 'txId' in detail ? detail.txId : undefined

--- a/src/store/notificationsSlice.ts
+++ b/src/store/notificationsSlice.ts
@@ -6,6 +6,7 @@ import type { LinkProps } from 'next/link'
 export type Notification = {
   id: string
   message: string
+  detailedMessage?: string
   groupKey: string
   variant: AlertColor
   timestamp: number

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -77,3 +77,7 @@ export const camelCaseToSpaces = (str: string): string => {
 export const ellipsis = (str: string, length: number): string => {
   return str.length > length ? `${str.slice(0, length)}...` : str
 }
+
+export const capitalize = (str: string): string => {
+  return str.slice(0, 1).toUpperCase() + str.slice(1)
+}


### PR DESCRIPTION
## What it solves

Resolves #884

## How this PR fixes it
<img width="390" alt="Screenshot 2022-10-12 at 12 01 56" src="https://user-images.githubusercontent.com/381895/195314892-304d682b-8efb-427d-831f-1a16fd5d7a1b.png">
<img width="376" alt="Screenshot 2022-10-12 at 12 02 00" src="https://user-images.githubusercontent.com/381895/195314896-75351f1c-f60d-45c4-aa5d-6bd823563d9e.png">
