### PR TITLE
Fix: encode executor sig only if owner

### DIFF
--- a/src/components/tx/TxSimulation/__tests__/utils.test.ts
+++ b/src/components/tx/TxSimulation/__tests__/utils.test.ts
@@ -6,12 +6,13 @@ import * as safeContracts from '@/services/contracts/safeContracts'
 import { getMultiSendCallOnlyDeployment, getSafeSingletonDeployment } from '@gnosis.pm/safe-deployments'
 import EthSafeTransaction from '@gnosis.pm/safe-core-sdk/dist/src/utils/transactions/SafeTransaction'
 import { ZERO_ADDRESS } from '@gnosis.pm/safe-core-sdk/dist/src/utils/constants'
-import { getPreValidatedSignature } from '@/hooks/useGasLimit'
 import { generatePreValidatedSignature } from '@gnosis.pm/safe-core-sdk/dist/src/utils/signatures'
 import { hexZeroPad } from 'ethers/lib/utils'
 import * as Web3 from '@/hooks/wallets/web3'
 
 const SIGNATURE_LENGTH = 65 * 2
+
+const getPreValidatedSignature = (addr: string): string => generatePreValidatedSignature(addr).data
 
 describe('simulation utils', () => {
   const safeContractInterface = new ethers.utils.Interface(getSafeSingletonDeployment({ version: '1.3.0' })?.abi || [])

--- a/src/hooks/useGasLimit.ts
+++ b/src/hooks/useGasLimit.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import type { BigNumber } from 'ethers'
 import type Safe from '@gnosis.pm/safe-core-sdk'
+import { generatePreValidatedSignature } from '@gnosis.pm/safe-core-sdk/dist/src/utils/signatures'
 import type { SafeTransaction } from '@gnosis.pm/safe-core-sdk-types'
 import { OperationType } from '@gnosis.pm/safe-core-sdk-types'
 import useAsync from '@/hooks/useAsync'
@@ -10,26 +11,14 @@ import useWallet from './wallets/useWallet'
 import { useSafeSDK } from './coreSDK/safeCoreSDK'
 import useIsSafeOwner from './useIsSafeOwner'
 
-export const getPreValidatedSignature = (from: string): string => {
-  return `0x000000000000000000000000${from
-    .toLowerCase()
-    .replace('0x', '')}000000000000000000000000000000000000000000000000000000000000000001`
-}
-
 export const _encodeSignatures = (safeTx: SafeTransaction, from?: string): string => {
   const owner = from?.toLowerCase()
   const needsOwnerSig = owner && !safeTx.signatures.has(owner)
 
   // https://docs.gnosis.io/safe/docs/contracts_signatures/#pre-validated-signatures
   if (needsOwnerSig) {
-    const ownerSig = getPreValidatedSignature(owner)
-
-    safeTx.addSignature({
-      signer: owner,
-      data: ownerSig,
-      staticPart: () => ownerSig,
-      dynamicPart: () => '',
-    })
+    const ownerSig = generatePreValidatedSignature(owner)
+    safeTx.addSignature(ownerSig)
   }
 
   const encoded = safeTx.encodedSignatures()


### PR DESCRIPTION
## What it solves

Resolves #886

## How this PR fixes it

The problem was that we were adding the executing wallet's address as a "fake" signature.
It should only add the "fake" signature if the wallet is an owner and their signature is still missing.

## How to test it
Try to execute a tx as a non-owner – gas estimation should work