### PR TITLE
Fix: AB errors can be Error

### DIFF
--- a/src/components/address-book/ImportDialog/styles.module.css
+++ b/src/components/address-book/ImportDialog/styles.module.css
@@ -5,4 +5,7 @@
   flex-direction: column;
   justify-content: center;
   cursor: pointer;
+  padding: var(--space-2) 0;
+  margin: var(--space-3) 0;
+  min-height: 200px;
 }


### PR DESCRIPTION
## What it solves

Resolves #889

## How this PR fixes it

Internal CSV errors are actual Error objects, not just strings. Our own validation functions return strings, however.
I decided not to change our validation functions, and adjusted the error handling instead. It now supports both errors and strings. Before that it was crashing the app because it couldn't render an error.

Also adjusted the styles a bit.

## How to test it
Upload some non-CSV file. It should show an error and not crash the app.

## Screenshots
<img width="617" alt="Screenshot 2022-10-12 at 15 34 12" src="https://user-images.githubusercontent.com/381895/195356718-6e3a7328-5c15-4fff-96ae-64544bd03322.png">
