### PR TITLE
fix: replace "New transaction" button for "Switch to ..." button if on wrong chain

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -4,6 +4,7 @@ import { IconButton, Paper } from '@mui/material'
 import MenuIcon from '@mui/icons-material/Menu'
 import classnames from 'classnames'
 import css from './styles.module.css'
+import ChainSwitcher from '@/components/common/ChainSwitcher'
 import ConnectWallet from '@/components/common/ConnectWallet'
 import NetworkSelector from '@/components/common/NetworkSelector'
 import SafeTokenWidget, { getSafeTokenAddress } from '@/components/common/SafeTokenWidget'
@@ -39,6 +40,10 @@ const Header = ({ onMenuToggle }: HeaderProps): ReactElement => {
             <SafeLogo alt="Safe logo" />
           </a>
         </Link>
+      </div>
+
+      <div className={classnames(css.element, css.hideMobile)}>
+        <ChainSwitcher />
       </div>
 
       {showSafeToken && (

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -4,7 +4,6 @@ import { IconButton, Paper } from '@mui/material'
 import MenuIcon from '@mui/icons-material/Menu'
 import classnames from 'classnames'
 import css from './styles.module.css'
-import ChainSwitcher from '@/components/common/ChainSwitcher'
 import ConnectWallet from '@/components/common/ConnectWallet'
 import NetworkSelector from '@/components/common/NetworkSelector'
 import SafeTokenWidget, { getSafeTokenAddress } from '@/components/common/SafeTokenWidget'
@@ -40,10 +39,6 @@ const Header = ({ onMenuToggle }: HeaderProps): ReactElement => {
             <SafeLogo alt="Safe logo" />
           </a>
         </Link>
-      </div>
-
-      <div className={classnames(css.element, css.hideMobile)}>
-        <ChainSwitcher />
       </div>
 
       {showSafeToken && (

--- a/src/components/sidebar/NewTxButton/index.tsx
+++ b/src/components/sidebar/NewTxButton/index.tsx
@@ -6,6 +6,7 @@ import useWallet from '@/hooks/wallets/useWallet'
 import useIsWrongChain from '@/hooks/useIsWrongChain'
 import css from './styles.module.css'
 import { trackEvent, OVERVIEW_EVENTS } from '@/services/analytics'
+import ChainSwitcher from '@/components/common/ChainSwitcher'
 
 const NewTxModal = dynamic(() => import('@/components/tx/modals/NewTxModal'))
 
@@ -21,6 +22,8 @@ const NewTxButton = (): ReactElement => {
     trackEvent(OVERVIEW_EVENTS.NEW_TRANSACTION)
   }
 
+  if (isWrongChain) return <ChainSwitcher fullWidth />
+
   return (
     <>
       <Button
@@ -32,13 +35,7 @@ const NewTxButton = (): ReactElement => {
         className={css.button}
         disableElevation
       >
-        {!wallet
-          ? 'Not connected'
-          : isWrongChain
-          ? 'Wrong wallet chain'
-          : isSafeOwner
-          ? 'New transaction'
-          : 'Read only'}
+        {!wallet ? 'Not connected' : isSafeOwner ? 'New transaction' : 'Read only'}
       </Button>
 
       {txOpen && (


### PR DESCRIPTION
## What it solves

Resolves #897

## How this PR fixes it
If the connected wallet is in a different chain that the opened Safe, the "Switch to ..." button is displayed instead of the "New transaction" button.

## How to test it
1. Connect your wallet on Goerli
2. Open a Ethereum Safe
3. The "New transaction" button is replaced by the "Switch to ..." button
4. "Switch to ..." button is removed from the Header

## Screenshots
_Mobile resolution_
<img width="422" alt="Screenshot 2022-10-14 at 10 31 20" src="https://user-images.githubusercontent.com/32431609/195800991-ec736ae8-90e7-47d5-a577-a3eeb1d0505c.png">
_Web_
<img width="1344" alt="Screenshot 2022-10-14 at 10 31 52" src="https://user-images.githubusercontent.com/32431609/195801045-f2048e35-fdea-4244-a9a0-d3dc0b0009f9.png">
