### PR TITLE
style: adjust tx summary grid on mobile viewport

### DIFF
--- a/src/components/transactions/TxSummary/styles.module.css
+++ b/src/components/transactions/TxSummary/styles.module.css
@@ -47,23 +47,31 @@
   .columnTemplate {
     grid-template-columns: repeat(12, auto);
     grid-template-areas:
-      'nonce type type type type type info info info info info info'
-      'date date date date date date confirmations confirmations confirmations confirmations confirmations confirmations'
-      'status status status status status status actions actions actions actions actions actions';
-  }
-
+      'nonce type type type type type type type type type type type'
+      'empty info info info info info info info info info info info'
+      'empty date date date date date date date date date date date'
+      'empty confirmations confirmations confirmations confirmations confirmations confirmations confirmations confirmations confirmations confirmations confirmations'
+      'empty status status status status status status status status status status status'
+      'empty actions actions actions actions actions actions actions actions actions actions actions';
+    }
+    
   .columnTemplateWithoutNonce {
     grid-template-columns: repeat(12, 1fr);
     grid-template-areas:
-      'type type type type type type info info info info info info'
-      'date date date date date date confirmations confirmations confirmations confirmations confirmations confirmations'
-      'status status status status status status actions actions actions actions actions actions';
+      'nonce type type type type type type type type type type type'
+      'empty info info info info info info info info info info info'
+      'empty date date date date date date date date date date date'
+      'empty confirmations confirmations confirmations confirmations confirmations confirmations confirmations confirmations confirmations confirmations confirmations'
+      'empty status status status status status status status status status status status'
+      'empty actions actions actions actions actions actions actions actions actions actions actions';
   }
 
   .columnTemplateTxHistory {
     grid-template-columns: repeat(12, 1fr);
     grid-template-areas:
-      'nonce type type type type type info info info info info info'
-      'date date date date date date status status status status status status';
+      'nonce type type type type type type type type type type type' 
+      'empty info info info info info info info info info info info'
+      'empty date date date date date date date date date date date'
+      'empty status status status status status status status status status status status';
   }
 }


### PR DESCRIPTION
## What it solves

Resolves #887

## How this PR fixes it
The TxSummary mobile styles are reorganized to display one element per line.

## How to test it
1. Go to any transaction history or queue and observe the collapsed TxSummary not cramping
2. If you reduce a lot the viewport width, you will observe the TxSummary is scrollable

## Analytics changes

## Screenshots
<img width="483" alt="Screenshot 2022-10-14 at 12 40 58" src="https://user-images.githubusercontent.com/32431609/195828984-279a9d6c-49a1-4f1c-b980-276e9ac735cd.png">
<img width="393" alt="Screenshot 2022-10-14 at 12 50 49" src="https://user-images.githubusercontent.com/32431609/195829902-993ca077-db70-491f-a21b-98adb463f945.png">
<img width="463" alt="Screenshot 2022-10-14 at 12 40 44" src="https://user-images.githubusercontent.com/32431609/195828992-f7ea994e-d3e3-4d62-b944-80850d1e825e.png">
