### PR TITLE
Fix: read chainId directly from location

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,6 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: ${{ secrets.NEXT_PUBLIC_PORTIS_KEY }}
           NEXT_PUBLIC_CYPRESS_MNEMONIC: ${{ secrets.NEXT_PUBLIC_CYPRESS_MNEMONIC }}
           NEXT_PUBLIC_WC_BRIDGE: ${{ secrets.NEXT_PUBLIC_WC_BRIDGE }}
-          NEXT_PUBLIC_IS_PRODUCTION: ${{ true }}
 
       - name: Serve
         run: yarn serve &

--- a/.github/workflows/safe-apps-e2e.yml
+++ b/.github/workflows/safe-apps-e2e.yml
@@ -44,7 +44,6 @@ jobs:
           NEXT_PUBLIC_FORTMATIC_KEY: ${{ secrets.NEXT_PUBLIC_FORTMATIC_KEY }}
           NEXT_PUBLIC_PORTIS_KEY: ${{ secrets.NEXT_PUBLIC_PORTIS_KEY }}
           NEXT_PUBLIC_CYPRESS_MNEMONIC: ${{ secrets.NEXT_PUBLIC_CYPRESS_MNEMONIC }}
-          NEXT_PUBLIC_IS_PRODUCTION: ${{ true }}
 
       - name: Serve
         run: yarn serve &

--- a/cypress/e2e/smoke/dashboard.cy.js
+++ b/cypress/e2e/smoke/dashboard.cy.js
@@ -2,6 +2,8 @@ const SAFE = 'gor:0xCD4FddB8FfA90012DFE11eD4bf258861204FeEAE'
 
 describe('Dashboard', () => {
   before(() => {
+    window.localStorage.setItem('SAFE_v2__debugProdCgw', 'true')
+
     // Go to the test Safe home page
     cy.visit(`/${SAFE}/home`, { failOnStatusCode: false })
     cy.contains('button', 'Accept selection').click()

--- a/cypress/e2e/smoke/load_safe.cy.js
+++ b/cypress/e2e/smoke/load_safe.cy.js
@@ -16,7 +16,9 @@ const OWNER_ADDRESS = '0xE297437d6b53890cbf004e401F3acc67c8b39665'
 
 describe('Load existing Safe', () => {
   before(() => {
-    cy.visit('/welcome')
+    window.localStorage.setItem('SAFE_v2__debugProdCgw', 'true')
+
+    cy.visit('/welcome?chain=matic')
     cy.contains('Accept selection').click()
 
     // Enters Loading Safe form
@@ -26,7 +28,7 @@ describe('Load existing Safe', () => {
 
   it('should allow choosing the network where the Safe exists', () => {
     // Click the network selector inside the Stepper content
-    cy.contains('Select network on which the Safe was created:').contains('span', 'Ethereum').click()
+    cy.contains('Select network on which the Safe was created:').contains('span', 'Polygon').click()
 
     // Selects Goerli
     cy.get('ul li')

--- a/cypress/e2e/smoke/tx_history.cy.js
+++ b/cypress/e2e/smoke/tx_history.cy.js
@@ -6,6 +6,8 @@ const CONTRACT_INTERACTION = '/images/transactions/custom.svg'
 
 describe('Transaction history', () => {
   before(() => {
+    window.localStorage.setItem('SAFE_v2__debugProdCgw', 'true')
+
     // Go to the test Safe transaction history
     cy.visit(`/${SAFE}/transactions/history`, { failOnStatusCode: false })
     cy.contains('button', 'Accept selection').click()

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -29,7 +29,7 @@ const nextConfig = {
   async rewrites() {
     return [
       {
-        source: '/:safe([a-z]+\\:0x[a-fA-F0-9]{40})/:path*',
+        source: '/:safe([a-z0-9-]+\\:0x[a-fA-F0-9]{40})/:path*',
         destination: '/:path*?safe=:safe',
       },
     ]

--- a/src/components/common/NetworkSelector/index.tsx
+++ b/src/components/common/NetworkSelector/index.tsx
@@ -26,13 +26,21 @@ const NetworkSelector = (): ReactElement => {
 
     const shouldKeepPath = [AppRoutes.load, AppRoutes.open].includes(router.pathname)
 
-    return router.push({
+    const newRoute = {
       pathname: shouldKeepPath ? router.pathname : '/',
       query: {
         chain: newShortName,
-        safeViewRedirectURL: router.query?.safeViewRedirectURL,
+      } as {
+        chain: string
+        safeViewRedirectURL?: string
       },
-    })
+    }
+
+    if (router.query?.safeViewRedirectURL) {
+      newRoute.query.safeViewRedirectURL = router.query?.safeViewRedirectURL.toString()
+    }
+
+    return router.push(newRoute)
   }
 
   return configs.length ? (

--- a/src/hooks/__tests__/useChainId.test.ts
+++ b/src/hooks/__tests__/useChainId.test.ts
@@ -42,6 +42,24 @@ describe('useChainId hook', () => {
     expect(result.current).toEqual('43114')
   })
 
+  it('should read location.search if useRouter query.safe is empty', () => {
+    ;(useRouter as any).mockImplementation(() => ({
+      query: {},
+    }))
+
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: {
+        pathname: '/balances',
+        search: '?safe=avax:0x0000000000000000000000000000000000000123&redirect=true',
+      },
+    })
+
+    const { result } = renderHook(() => useChainId())
+
+    expect(result.current).toEqual('43114')
+  })
+
   it('should read location.search if useRouter query.chain is empty', () => {
     ;(useRouter as any).mockImplementation(() => ({
       query: {},

--- a/src/hooks/__tests__/useChainId.test.ts
+++ b/src/hooks/__tests__/useChainId.test.ts
@@ -17,6 +17,47 @@ describe('useChainId hook', () => {
     ;(useRouter as any).mockImplementation(() => ({
       query: {},
     }))
+
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: undefined,
+    })
+  })
+
+  it('should read location.pathname if useRouter query.safe is empty', () => {
+    ;(useRouter as any).mockImplementation(() => ({
+      query: {},
+    }))
+
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: {
+        pathname: '/avax:0x0000000000000000000000000000000000000123/balances',
+        search: '',
+      },
+    })
+
+    const { result } = renderHook(() => useChainId())
+
+    expect(result.current).toEqual('43114')
+  })
+
+  it('should read location.search if useRouter query.chain is empty', () => {
+    ;(useRouter as any).mockImplementation(() => ({
+      query: {},
+    }))
+
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: {
+        pathname: '/welcome',
+        search: '?chain=matic',
+      },
+    })
+
+    const { result } = renderHook(() => useChainId())
+
+    expect(result.current).toEqual('137')
   })
 
   it('should return the default chainId if no query params', () => {

--- a/src/hooks/useChainId.ts
+++ b/src/hooks/useChainId.ts
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { parse } from 'querystring'
 import { IS_PRODUCTION } from '@/config/constants'
 import chains from '@/config/chains'
 import { useAppSelector } from '@/store'
@@ -7,11 +8,24 @@ import { parsePrefixedAddress } from '@/utils/addresses'
 
 const defaultChainId = IS_PRODUCTION ? chains.eth : chains.gor
 
-export const useChainId = (): string => {
+// Use the location object directly because Next.js's router.query is not available initially
+const getUrlSafeParam = (): string => {
+  if (typeof location === 'undefined') return ''
+  const pathParam = location.pathname.split('/')[1]
+  const safeParam = /[a-z0-9-]+\:0x[a-f0-9]{40}/i.test(pathParam) ? pathParam : ''
+  return safeParam
+}
+
+const getUrlChainParam = (): string => {
+  if (typeof location === 'undefined') return ''
+  const query = parse(location.search.slice(1))
+  return query.chain ? query.chain.toString() : ''
+}
+
+export const useUrlChainId = (): string | undefined => {
   const router = useRouter()
-  const session = useAppSelector(selectSession)
-  const chain = Array.isArray(router.query.chain) ? router.query.chain[0] : router.query.chain || ''
-  const safe = Array.isArray(router.query.safe) ? router.query.safe[0] : router.query.safe || ''
+  const chain = router.query.chain?.toString() || getUrlChainParam()
+  const safe = router.query.safe?.toString() || getUrlSafeParam()
 
   const { prefix } = parsePrefixedAddress(safe)
   const shortName = prefix || chain
@@ -23,8 +37,12 @@ export const useChainId = (): string => {
     }
     return chainId
   }
+}
 
-  return session.lastChainId || defaultChainId
+export const useChainId = (): string => {
+  const session = useAppSelector(selectSession)
+  const urlChainId = useUrlChainId()
+  return urlChainId || session.lastChainId || defaultChainId
 }
 
 export default useChainId

--- a/src/hooks/useInitSession.ts
+++ b/src/hooks/useInitSession.ts
@@ -1,17 +1,19 @@
 import { useAppDispatch } from '@/store'
 import { setLastChainId, setLastSafeAddress } from '@/store/sessionSlice'
 import { useEffect } from 'react'
-import useChainId from './useChainId'
+import { useUrlChainId } from './useChainId'
 import useSafeInfo from './useSafeInfo'
 
 export const useInitSession = (): void => {
   const dispatch = useAppDispatch()
-  const chainId = useChainId()
+  const chainId = useUrlChainId()
   // N.B. only successfully loaded Safes, don't use useSafeAddress() here!
   const { safe, safeAddress } = useSafeInfo()
 
   useEffect(() => {
-    dispatch(setLastChainId(chainId))
+    if (chainId) {
+      dispatch(setLastChainId(chainId))
+    }
   }, [dispatch, chainId])
 
   useEffect(() => {

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -7,7 +7,7 @@ const getRedirectUrl = (): string | undefined => {
   if (typeof location === 'undefined') return
 
   const { pathname, search } = location
-  const re = /^\/([^/]+?:0x[0-9a-fA-F]{40})/
+  const re = /^\/([^/]+?:0x[0-9a-f]{40})/i
   const [, pathSafe] = pathname.match(re) || []
 
   if (pathSafe) {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -4,7 +4,7 @@ import { parsePrefixedAddress, sameAddress } from './addresses'
 import { safeFormatUnits, safeParseUnits } from './formatters'
 
 export const validateAddress = (address: string) => {
-  const ADDRESS_RE = /^0x[0-9a-zA-Z]{40}$/
+  const ADDRESS_RE = /^0x[0-9a-f]{40}$/i
 
   if (!ADDRESS_RE.test(address)) {
     return 'Invalid address format'


### PR DESCRIPTION
## What it solves

Resolves #915

## How this PR fixes it
Next.js router's dynamic query params are only available in an effect, so useChainId was always falling back to the default/stored chainId.

I've added a fallback to window.location as a workaround. It causes hydration errors tho. We should have probably made `useChainId()` nullable, but now it would mean too many changes.

Also fixes the storing of the last chainId that was self-referential and thus not working properly.

## How to test it
Load the app and see that it doesn't log two page views.