### PR TITLE
Chore: rm prod flag in load_safe.cy.js

### DIFF
--- a/cypress/e2e/smoke/load_safe.cy.js
+++ b/cypress/e2e/smoke/load_safe.cy.js
@@ -16,8 +16,6 @@ const OWNER_ADDRESS = '0xE297437d6b53890cbf004e401F3acc67c8b39665'
 
 describe('Load existing Safe', () => {
   before(() => {
-    window.localStorage.setItem('SAFE_v2__debugProdCgw', 'true')
-
     cy.visit('/welcome?chain=matic')
     cy.contains('Accept selection').click()
 


### PR DESCRIPTION
## What it solves
This flag isn't necessary, only Dashboard and Tx History tests rely on the prod CGW.