### PR TITLE
fix: trigger form validate when resolving ENS

### DIFF
--- a/cypress/e2e/smoke/address_book.cy.js
+++ b/cypress/e2e/smoke/address_book.cy.js
@@ -4,7 +4,8 @@ import { format } from 'date-fns'
 
 const NAME = 'Owner1'
 const EDITED_NAME = 'Edited Owner1'
-const ENS_ADDRESS = '0xE297437d6b53890cbf004e401F3acc67c8b39665'
+const ENS_NAME = 'diogo.eth'
+const ENS_ADDRESS = '0x6a5602335a878ADDCa4BF63a050E34946B56B5bC'
 const GOERLI_TEST_SAFE = 'gor:0x97d314157727D517A706B5D08507A1f9B44AaaE9'
 const GNO_TEST_SAFE = 'gno:0xB8d760a90a5ed54D3c2b3EFC231277e99188642A'
 const GOERLI_CSV_ENTRY = {
@@ -29,7 +30,9 @@ describe('Address book', () => {
       // Add a new entry manually
       cy.contains('Create entry').click()
       cy.get('input[name="name"]').type(NAME)
-      cy.get('input[name="address"]').type(`gor:${ENS_ADDRESS}`)
+      cy.get('input[name="address"]').type(ENS_NAME)
+      // Name was translated
+      cy.get(ENS_NAME).should('not.exist')
       cy.contains('button', 'Save').click()
 
       cy.contains(NAME).should('exist')

--- a/src/components/address-book/EntryDialog/index.tsx
+++ b/src/components/address-book/EntryDialog/index.tsx
@@ -3,6 +3,7 @@ import Button from '@mui/material/Button'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import type { ReactElement } from 'react'
+import { useEffect } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 
 import AddressInput from '@/components/common/AddressInput'
@@ -38,7 +39,16 @@ const EntryDialog = ({
     defaultValues,
     mode: 'onChange',
   })
-  const { handleSubmit, formState } = methods
+
+  const { handleSubmit, formState, watch, trigger } = methods
+
+  const address = watch('address')
+
+  useEffect(() => {
+    if (address) {
+      trigger('address')
+    }
+  }, [address, trigger])
 
   const onSubmit = (data: AddressEntry) => {
     dispatch(upsertAddressBookEntry({ ...data, chainId: chainId || currentChainId }))


### PR DESCRIPTION
## What it solves

Resolves #909 

## How this PR fixes it
Triggers a form validation when the input changes. This will catch the case where ENS resolves and the form validation was not triggered

## How to test it
1. Go to AB > Create entry
2. Insert a ENS name
3. Form should be valid when the name is resolved

## Analytics changes
N/A

## Screenshots
<img width="563" alt="Screenshot 2022-10-17 at 16 39 42" src="https://user-images.githubusercontent.com/32431609/196206616-4fa24ef0-76d5-430e-84ad-12d90b442841.png">
