### PR TITLE
Fix: remove filetype check in AB import (breaks Android)

### DIFF
--- a/src/components/address-book/ImportDialog/__tests__/validation.test.ts
+++ b/src/components/address-book/ImportDialog/__tests__/validation.test.ts
@@ -18,14 +18,6 @@ describe('Address book import validation', () => {
 
       expect(abCsvReaderValidator(file)).toBeUndefined()
     })
-    it('should return an error if file is not a CSV', () => {
-      const file = {
-        type: 'text/plain',
-        size: 100,
-      } as File
-
-      expect(abCsvReaderValidator(file)).toEqual(['Address book must be a CSV file'])
-    })
     it('should return an error if file is too large', () => {
       const file = {
         type: 'text/csv',

--- a/src/components/address-book/ImportDialog/validation.ts
+++ b/src/components/address-book/ImportDialog/validation.ts
@@ -2,11 +2,7 @@ import type { ParseResult } from 'papaparse'
 
 import { validateAddress, validateChainId } from '@/utils/validation'
 
-export const abCsvReaderValidator = ({ type, size }: File): string[] | undefined => {
-  if (type !== 'text/csv') {
-    return ['Address book must be a CSV file']
-  }
-
+export const abCsvReaderValidator = ({ size }: File): string[] | undefined => {
   if (size > 1_000_000) {
     return ['Address book cannot be larger than 1MB']
   }


### PR DESCRIPTION
## What it solves

Resolves #889

## How this PR fixes it
Removes the extraneous content type validation.

## How to test it
Import an exported Safe address book on Android.
