### PR TITLE
fix: Cache transaction info on safe creation

### DIFF
--- a/src/components/create-safe/index.tsx
+++ b/src/components/create-safe/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import type { BigNumber } from 'ethers'
 
 import ConnectWalletStep from '@/components/create-safe/steps/ConnectWalletStep'
 import SetNameStep from '@/components/create-safe/steps/SetNameStep'
@@ -14,7 +15,16 @@ import useChainId from '@/hooks/useChainId'
 import type { SafeFormData } from '@/components/create-safe/types.d'
 import { CREATE_SAFE_CATEGORY } from '@/services/analytics'
 
-export type PendingSafeData = SafeFormData & { txHash?: string; saltNonce: number }
+export type PendingSafeTx = {
+  data: string
+  from: string
+  nonce: number
+  to: string
+  value: BigNumber
+  startBlock: number
+}
+
+export type PendingSafeData = SafeFormData & { txHash?: string; tx?: PendingSafeTx; saltNonce: number }
 export type PendingSafeByChain = Record<string, PendingSafeData | undefined>
 
 export const CreateSafeSteps: TxStepperProps['steps'] = [

--- a/src/components/create-safe/sender.ts
+++ b/src/components/create-safe/sender.ts
@@ -15,7 +15,6 @@ import type { SafeCreationProps } from '@/components/create-safe/useEstimateSafe
 import type { PredictSafeProps } from '@gnosis.pm/safe-core-sdk/dist/src/safeFactory'
 import type { SafeFormData } from '@/components/create-safe/types'
 import type { ConnectedWallet } from '@/services/onboard'
-import { getUserNonce } from '@/hooks/wallets/web3'
 import { BigNumber } from '@ethersproject/bignumber'
 
 export const createNewSafe = async (ethersProvider: Web3Provider, props: DeploySafeProps): Promise<Safe> => {
@@ -77,7 +76,7 @@ export const getSafeCreationTxInfo = async (
   return {
     data,
     from: wallet.address,
-    nonce: await getUserNonce(wallet.address),
+    nonce: await provider.getTransactionCount(wallet.address),
     to: proxyContract.getAddress(),
     value: BigNumber.from(0),
     startBlock: await provider.getBlockNumber(),

--- a/src/components/create-safe/sender.ts
+++ b/src/components/create-safe/sender.ts
@@ -13,6 +13,10 @@ import {
 import { LATEST_SAFE_VERSION } from '@/config/constants'
 import type { SafeCreationProps } from '@/components/create-safe/useEstimateSafeCreationGas'
 import type { PredictSafeProps } from '@gnosis.pm/safe-core-sdk/dist/src/safeFactory'
+import type { SafeFormData } from '@/components/create-safe/types'
+import type { ConnectedWallet } from '@/services/onboard'
+import { getUserNonce } from '@/hooks/wallets/web3'
+import { BigNumber } from '@ethersproject/bignumber'
 
 export const createNewSafe = async (ethersProvider: Web3Provider, props: DeploySafeProps): Promise<Safe> => {
   const ethAdapter = createEthersAdapter(ethersProvider)
@@ -33,9 +37,7 @@ export const getSafeCreationTx = ({
   threshold,
   saltNonce,
   chain,
-}: SafeCreationProps & { chain: ChainInfo | undefined }) => {
-  if (!chain) return
-
+}: SafeCreationProps & { chain: ChainInfo }) => {
   const safeContract = getGnosisSafeContractInstance(chain, LATEST_SAFE_VERSION)
   const proxyContract = getProxyFactoryContractInstance(chain.chainId)
   const fallbackHandlerContract = getFallbackHandlerContractInstance(chain.chainId)
@@ -52,4 +54,32 @@ export const getSafeCreationTx = ({
   ])
 
   return proxyContract.encode('createProxyWithNonce', [safeContract.getAddress(), setupData, saltNonce])
+}
+
+// Returns an object that can be used to detect a replacement tx
+// via ethers _waitForTransaction
+export const getSafeCreationTxInfo = async (
+  provider: Web3Provider,
+  params: SafeFormData,
+  chain: ChainInfo,
+  saltNonce: number,
+  wallet: ConnectedWallet,
+) => {
+  const proxyContract = getProxyFactoryContractInstance(chain.chainId)
+
+  const data = getSafeCreationTx({
+    owners: params.owners.map((owner) => owner.address),
+    threshold: params.threshold,
+    saltNonce,
+    chain,
+  })
+
+  return {
+    data,
+    from: wallet.address,
+    nonce: await getUserNonce(wallet.address),
+    to: proxyContract.getAddress(),
+    value: BigNumber.from(0),
+    startBlock: await provider.getBlockNumber(),
+  }
 }

--- a/src/components/create-safe/status/hooks/useWatchSafeCreation.test.ts
+++ b/src/components/create-safe/status/hooks/useWatchSafeCreation.test.ts
@@ -97,26 +97,6 @@ describe('useWatchSafeCreation', () => {
     expect(setPendingSafeSpy).toHaveBeenCalledWith(undefined)
   })
 
-  it('should not poll safe info on SUCCESS if there is no pending safe data', () => {
-    const pollSafeInfoSpy = jest.spyOn(pendingSafe, 'pollSafeInfo')
-    const setStatusSpy = jest.fn()
-    const setPendingSafeSpy = jest.fn()
-
-    renderHook(() =>
-      useWatchSafeCreation({
-        status: SafeCreationStatus.SUCCESS,
-        safeAddress: '0x10',
-        pendingSafe: undefined,
-        setPendingSafe: setPendingSafeSpy,
-        setStatus: setStatusSpy,
-        chainId: '4',
-      }),
-    )
-
-    expect(pollSafeInfoSpy).not.toHaveBeenCalled()
-    expect(setPendingSafeSpy).toHaveBeenCalledWith(undefined)
-  })
-
   it('should navigate to the dashboard on INDEXED', async () => {
     jest.spyOn(chainIdModule, 'default').mockReturnValue('4')
     const pushMock = jest.fn()

--- a/src/components/create-safe/status/hooks/useWatchSafeCreation.ts
+++ b/src/components/create-safe/status/hooks/useWatchSafeCreation.ts
@@ -68,7 +68,7 @@ const useWatchSafeCreation = ({
       setPendingSafe(undefined)
 
       // Asynchronously wait for Safe creation
-      if (safeAddress && pendingSafe) {
+      if (safeAddress) {
         pollSafeInfo(chainId, safeAddress)
           .then(() => setStatus(SafeCreationStatus.INDEXED))
           .catch(() => setStatus(SafeCreationStatus.INDEX_FAILED))
@@ -81,7 +81,7 @@ const useWatchSafeCreation = ({
       status === SafeCreationStatus.TIMEOUT
     ) {
       if (pendingSafe?.txHash) {
-        setPendingSafe((prev) => (prev ? { ...prev, txHash: undefined } : undefined))
+        setPendingSafe((prev) => (prev ? { ...prev, txHash: undefined, tx: undefined } : undefined))
       }
     }
   }, [router, safeAddress, setPendingSafe, status, pendingSafe, setStatus, chainId])

--- a/src/components/create-safe/status/hooks/useWatchSafeCreation.ts
+++ b/src/components/create-safe/status/hooks/useWatchSafeCreation.ts
@@ -6,7 +6,7 @@ import { type UrlObject } from 'url'
 import { pollSafeInfo } from '@/components/create-safe/status/usePendingSafeCreation'
 import { AppRoutes } from '@/config/routes'
 import { SafeCreationStatus } from '@/components/create-safe/status/useSafeCreation'
-import { trackEvent, CREATE_SAFE_EVENTS, SAFE_APPS_EVENTS } from '@/services/analytics'
+import { CREATE_SAFE_EVENTS, SAFE_APPS_EVENTS, trackEvent } from '@/services/analytics'
 import chains from '@/config/chains'
 
 const getRedirect = (chainId: string, safeAddress: string, redirectQuery?: string | string[]): UrlObject | string => {
@@ -75,7 +75,11 @@ const useWatchSafeCreation = ({
       }
     }
 
-    if (status === SafeCreationStatus.ERROR || status === SafeCreationStatus.REVERTED) {
+    if (
+      status === SafeCreationStatus.ERROR ||
+      status === SafeCreationStatus.REVERTED ||
+      status === SafeCreationStatus.TIMEOUT
+    ) {
       if (pendingSafe?.txHash) {
         setPendingSafe((prev) => (prev ? { ...prev, txHash: undefined } : undefined))
       }

--- a/src/components/create-safe/status/usePendingSafeCreation.ts
+++ b/src/components/create-safe/status/usePendingSafeCreation.ts
@@ -7,10 +7,9 @@ import { useEffect } from 'react'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import type { SafeInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { getSafeInfo } from '@gnosis.pm/safe-react-gateway-sdk'
-import { getProxyFactoryContractInstance } from '@/services/contracts/safeContracts'
-import useChainId from '@/hooks/useChainId'
 import { ErrorCode } from '@ethersproject/logger'
 import { Errors, logError } from '@/services/exceptions'
+import type { PendingSafeData, PendingSafeTx } from '@/components/create-safe'
 
 export const pollSafeInfo = async (chainId: string, safeAddress: string): Promise<SafeInfo> => {
   // exponential delay between attempts for around 4 min
@@ -25,49 +24,15 @@ export const pollSafeInfo = async (chainId: string, safeAddress: string): Promis
   })
 }
 
-export const _getTransactionByHash = (provider: JsonRpcProvider, txHash: string) => {
-  return provider.getTransaction(txHash).then((response) => {
-    if (response === null || response === undefined) {
-      throw new Error('Transaction not found')
-    }
-    return response
-  })
-}
-
-const pollTransaction = async (provider: JsonRpcProvider, txHash: string) => {
-  return backOff(() => _getTransactionByHash(provider, txHash), {
-    startingDelay: 750,
-    maxDelay: 10000,
-    numOfAttempts: 10,
-    retry: (e) => {
-      console.info('waiting for transaction', e)
-      return true
-    },
-  })
-}
-
 export const checkSafeCreationTx = async (
   provider: JsonRpcProvider,
+  pendingTx: PendingSafeTx,
   txHash: string,
-  chainId: string,
 ): Promise<SafeCreationStatus> => {
   const TIMEOUT_TIME = 6.5 * 60 * 1000 // 6.5 minutes
 
   try {
-    const txResponse = await pollTransaction(provider, txHash)
-
-    const proxyContractAddress = getProxyFactoryContractInstance(chainId).getAddress()
-
-    const replacement = {
-      data: txResponse.data,
-      from: txResponse.from,
-      nonce: txResponse.nonce,
-      to: proxyContractAddress,
-      value: txResponse.value,
-      startBlock: txResponse.blockNumber || (await provider.getBlockNumber()),
-    }
-
-    const receipt = await provider._waitForTransaction(txHash, 1, TIMEOUT_TIME, replacement)
+    const receipt = await provider._waitForTransaction(txHash, 1, TIMEOUT_TIME, pendingTx)
 
     if (didRevert(receipt)) {
       return SafeCreationStatus.REVERTED
@@ -92,23 +57,35 @@ export const checkSafeCreationTx = async (
 }
 
 type Props = {
-  txHash: string | undefined
+  pendingSafe?: PendingSafeData
+  status: SafeCreationStatus
   setStatus: (status: SafeCreationStatus) => void
 }
 
-export const usePendingSafeCreation = ({ txHash, setStatus }: Props) => {
+export const usePendingSafeCreation = ({ pendingSafe, status, setStatus }: Props) => {
   const provider = useWeb3ReadOnly()
-  const chainId = useChainId()
 
   useEffect(() => {
-    if (!txHash || !provider) return
+    if (
+      !provider ||
+      !pendingSafe?.txHash ||
+      status === SafeCreationStatus.PROCESSING ||
+      status === SafeCreationStatus.ERROR ||
+      status === SafeCreationStatus.REVERTED ||
+      status === SafeCreationStatus.TIMEOUT ||
+      status === SafeCreationStatus.SUCCESS
+    ) {
+      return
+    }
 
     const monitorTx = async () => {
-      const txStatus = await checkSafeCreationTx(provider, txHash, chainId)
+      if (!pendingSafe.tx || !pendingSafe.txHash) return
+
+      const txStatus = await checkSafeCreationTx(provider, pendingSafe.tx, pendingSafe.txHash)
       setStatus(txStatus)
     }
 
     setStatus(SafeCreationStatus.PROCESSING)
     monitorTx()
-  }, [txHash, provider, setStatus, chainId])
+  }, [pendingSafe, provider, status, setStatus])
 }

--- a/src/components/create-safe/status/usePendingSafeCreation.ts
+++ b/src/components/create-safe/status/usePendingSafeCreation.ts
@@ -26,11 +26,11 @@ export const pollSafeInfo = async (chainId: string, safeAddress: string): Promis
 }
 
 export const _getTransactionByHash = (provider: JsonRpcProvider, txHash: string) => {
-  return provider.getTransaction(txHash).then((resp) => {
-    if (resp === null) {
+  return provider.getTransaction(txHash).then((response) => {
+    if (response === null || response === undefined) {
       throw new Error('Transaction not found')
     }
-    return resp
+    return response
   })
 }
 

--- a/src/components/create-safe/status/useSafeCreation.test.ts
+++ b/src/components/create-safe/status/useSafeCreation.test.ts
@@ -14,6 +14,8 @@ import { checkSafeCreationTx } from '@/components/create-safe/status/usePendingS
 import { EMPTY_DATA, ZERO_ADDRESS } from '@gnosis.pm/safe-core-sdk/dist/src/utils/constants'
 import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { BigNumber } from '@ethersproject/bignumber'
+import type { EthersError } from '@/utils/ethers-utils'
+import { ErrorCode } from '@ethersproject/logger'
 
 describe('useSafeCreation', () => {
   beforeEach(() => {
@@ -49,7 +51,6 @@ describe('useSafeCreation', () => {
 
   it('should return PROCESSING if there is a txHash', async () => {
     const mockSafe: Safe = new Safe()
-    mockSafe.getAddress = jest.fn(() => '0x0')
     jest.spyOn(pendingSafe, 'usePendingSafe').mockImplementation(() => [
       {
         name: 'joyful-rinkeby-safe',
@@ -69,7 +70,6 @@ describe('useSafeCreation', () => {
 
   it('should return SUCCESS if the safe creation promise resolves', async () => {
     const mockSafe: Safe = new Safe()
-    mockSafe.getAddress = jest.fn(() => '0x0')
     jest.spyOn(wallet, 'default').mockReturnValue({} as ConnectedWallet)
     jest.spyOn(wrongChain, 'default').mockReturnValue(false)
     jest.spyOn(createSafe, 'createNewSafe').mockImplementation(() => Promise.resolve(mockSafe))
@@ -92,13 +92,14 @@ describe('useSafeCreation', () => {
     })
   })
 
-  it('should return ERROR if the safe creation promise rejects', async () => {
-    const mockSafe: Safe = new Safe()
-    mockSafe.getAddress = jest.fn(() => '0x0')
+  it('should return ERROR if user rejects transaction', async () => {
     jest.spyOn(wallet, 'default').mockReturnValue({} as ConnectedWallet)
     jest.spyOn(wrongChain, 'default').mockReturnValue(false)
-    jest.spyOn(createSafe, 'computeNewSafeAddress').mockImplementation(() => Promise.resolve(ZERO_ADDRESS))
-    jest.spyOn(createSafe, 'createNewSafe').mockImplementation(() => Promise.reject(mockSafe))
+    jest
+      .spyOn(createSafe, 'createNewSafe')
+      .mockImplementation(() =>
+        Promise.reject({ message: 'User rejected transaction', code: ErrorCode.ACTION_REJECTED } as EthersError),
+      )
     jest.spyOn(pendingSafe, 'usePendingSafe').mockImplementation(() => [
       {
         name: 'joyful-rinkeby-safe',
@@ -115,6 +116,35 @@ describe('useSafeCreation', () => {
 
     await waitFor(() => {
       expect(result.current.status).toBe(SafeCreationStatus.ERROR)
+    })
+  })
+
+  it('should return SUCCESS if transaction was replaced', async () => {
+    jest.spyOn(wallet, 'default').mockReturnValue({} as ConnectedWallet)
+    jest.spyOn(wrongChain, 'default').mockReturnValue(false)
+    jest.spyOn(createSafe, 'createNewSafe').mockImplementation(() =>
+      Promise.reject({
+        message: 'Transaction was replaced',
+        code: ErrorCode.TRANSACTION_REPLACED,
+        reason: 'replaced',
+      } as EthersError),
+    )
+    jest.spyOn(pendingSafe, 'usePendingSafe').mockImplementation(() => [
+      {
+        name: 'joyful-rinkeby-safe',
+        address: '0x10',
+        threshold: 1,
+        owners: [],
+        saltNonce: 123,
+        chainId: '4',
+      },
+      jest.fn,
+    ])
+
+    const { result } = renderHook(() => useSafeCreation())
+
+    await waitFor(() => {
+      expect(result.current.status).toBe(SafeCreationStatus.SUCCESS)
     })
   })
 })

--- a/src/components/create-safe/status/useSafeCreation.test.ts
+++ b/src/components/create-safe/status/useSafeCreation.test.ts
@@ -92,6 +92,35 @@ describe('useSafeCreation', () => {
     })
   })
 
+  it('should return SUCCESS if transaction was replaced', async () => {
+    jest.spyOn(wallet, 'default').mockReturnValue({} as ConnectedWallet)
+    jest.spyOn(wrongChain, 'default').mockReturnValue(false)
+    jest.spyOn(createSafe, 'createNewSafe').mockImplementationOnce(() =>
+      Promise.reject({
+        message: 'Transaction was replaced',
+        code: ErrorCode.TRANSACTION_REPLACED,
+        reason: 'replaced',
+      } as EthersError),
+    )
+    jest.spyOn(pendingSafe, 'usePendingSafe').mockImplementation(() => [
+      {
+        name: 'joyful-rinkeby-safe',
+        address: '0x10',
+        threshold: 1,
+        owners: [],
+        saltNonce: 123,
+        chainId: '4',
+      },
+      jest.fn,
+    ])
+
+    const { result } = renderHook(() => useSafeCreation())
+
+    await waitFor(() => {
+      expect(result.current.status).toBe(SafeCreationStatus.SUCCESS)
+    })
+  })
+
   it('should return ERROR if user rejects transaction', async () => {
     jest.spyOn(wallet, 'default').mockReturnValue({} as ConnectedWallet)
     jest.spyOn(wrongChain, 'default').mockReturnValue(false)
@@ -116,35 +145,6 @@ describe('useSafeCreation', () => {
 
     await waitFor(() => {
       expect(result.current.status).toBe(SafeCreationStatus.ERROR)
-    })
-  })
-
-  it('should return SUCCESS if transaction was replaced', async () => {
-    jest.spyOn(wallet, 'default').mockReturnValue({} as ConnectedWallet)
-    jest.spyOn(wrongChain, 'default').mockReturnValue(false)
-    jest.spyOn(createSafe, 'createNewSafe').mockImplementation(() =>
-      Promise.reject({
-        message: 'Transaction was replaced',
-        code: ErrorCode.TRANSACTION_REPLACED,
-        reason: 'replaced',
-      } as EthersError),
-    )
-    jest.spyOn(pendingSafe, 'usePendingSafe').mockImplementation(() => [
-      {
-        name: 'joyful-rinkeby-safe',
-        address: '0x10',
-        threshold: 1,
-        owners: [],
-        saltNonce: 123,
-        chainId: '4',
-      },
-      jest.fn,
-    ])
-
-    const { result } = renderHook(() => useSafeCreation())
-
-    await waitFor(() => {
-      expect(result.current.status).toBe(SafeCreationStatus.SUCCESS)
     })
   })
 })

--- a/src/components/create-safe/status/useSafeCreation.test.ts
+++ b/src/components/create-safe/status/useSafeCreation.test.ts
@@ -220,4 +220,14 @@ describe('getTransactionByHash', () => {
       expect((err as Error).message).toBe('Transaction not found')
     }
   })
+
+  it('throws an error if getTransaction returns undefined', async () => {
+    jest.spyOn(provider, 'getTransaction').mockImplementationOnce(() => Promise.resolve(undefined) as any)
+
+    try {
+      await _getTransactionByHash(provider, '0x0')
+    } catch (err) {
+      expect((err as Error).message).toBe('Transaction not found')
+    }
+  })
 })

--- a/src/components/create-safe/steps/ReviewStep.tsx
+++ b/src/components/create-safe/steps/ReviewStep.tsx
@@ -10,7 +10,7 @@ import { formatVisualAmount } from '@/utils/formatters'
 import { Box, Button, Divider, Grid, Paper, Typography } from '@mui/material'
 import { useMemo } from 'react'
 import { useEstimateSafeCreationGas } from '../useEstimateSafeCreationGas'
-import { computeNewSafeAddress, getSafeCreationTxInfo } from '@/components/create-safe/sender'
+import { computeNewSafeAddress } from '@/components/create-safe/sender'
 import { useCurrentChain } from '@/hooks/useChains'
 import type { SafeFormData } from '@/components/create-safe/types'
 import { getFallbackHandlerContractInstance } from '@/services/contracts/safeContracts'
@@ -61,9 +61,7 @@ const ReviewStep = ({ params, onSubmit, setStep, onBack }: Props) => {
 
     const safeAddress = await computeNewSafeAddress(ethersProvider, props)
 
-    const tx = await getSafeCreationTxInfo(ethersProvider, params, chain, saltNonce, wallet)
-
-    setPendingSafe({ ...params, address: safeAddress, saltNonce, tx })
+    setPendingSafe({ ...params, address: safeAddress, saltNonce })
     onSubmit(params)
   }
 

--- a/src/components/create-safe/useEstimateSafeCreationGas.test.ts
+++ b/src/components/create-safe/useEstimateSafeCreationGas.test.ts
@@ -71,16 +71,6 @@ describe('useEstimateSafeCreationGas', () => {
     })
   })
 
-  it('should not estimate gas if there is no encoded data', async () => {
-    jest.spyOn(sender, 'getSafeCreationTx').mockReturnValue(undefined)
-    const { result } = renderHook(() => useEstimateSafeCreationGas(mockProps))
-
-    await waitFor(() => {
-      expect(result.current.gasLimit).toBeUndefined()
-      expect(result.current.gasLimitLoading).toBe(false)
-    })
-  })
-
   it('should not estimate gas if there is no provider', async () => {
     jest.spyOn(web3, 'useWeb3ReadOnly').mockReturnValue(undefined)
     const { result } = renderHook(() => useEstimateSafeCreationGas(mockProps))

--- a/src/components/create-safe/useEstimateSafeCreationGas.ts
+++ b/src/components/create-safe/useEstimateSafeCreationGas.ts
@@ -28,11 +28,11 @@ export const useEstimateSafeCreationGas = ({
   const [gasLimit, gasLimitError, gasLimitLoading] = useAsync<BigNumber>(() => {
     if (!wallet?.address || !chain || !web3ReadOnly) return
 
-    const proxyContract = getProxyFactoryContractInstance(chain.chainId)
+    const proxyFactoryContract = getProxyFactoryContractInstance(chain.chainId)
     const encodedSafeCreationTx = getSafeCreationTx({ owners, threshold, saltNonce, chain })
 
     return web3ReadOnly.estimateGas({
-      to: proxyContract.getAddress(),
+      to: proxyFactoryContract.getAddress(),
       from: wallet.address,
       data: encodedSafeCreationTx,
     })

--- a/src/components/create-safe/useEstimateSafeCreationGas.ts
+++ b/src/components/create-safe/useEstimateSafeCreationGas.ts
@@ -1,12 +1,10 @@
 import type { BigNumber } from 'ethers'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
-import useChainId from '@/hooks/useChainId'
-import { useAppSelector } from '@/store'
-import { selectChainById } from '@/store/chainsSlice'
 import useWallet from '@/hooks/wallets/useWallet'
 import { getProxyFactoryContractInstance } from '@/services/contracts/safeContracts'
 import useAsync from '@/hooks/useAsync'
 import { getSafeCreationTx } from '@/components/create-safe/sender'
+import { useCurrentChain } from '@/hooks/useChains'
 
 export type SafeCreationProps = {
   owners: string[]
@@ -24,24 +22,21 @@ export const useEstimateSafeCreationGas = ({
   gasLimitLoading: boolean
 } => {
   const web3ReadOnly = useWeb3ReadOnly()
-  const chainId = useChainId()
-  const currentChain = useAppSelector((state) => selectChainById(state, chainId))
+  const chain = useCurrentChain()
   const wallet = useWallet()
 
-  const proxyContract = getProxyFactoryContractInstance(chainId)
-  const proxyContractAddress = proxyContract.getAddress()
-
-  const encodedSafeCreationTx = getSafeCreationTx({ owners, threshold, saltNonce, chain: currentChain })
-
   const [gasLimit, gasLimitError, gasLimitLoading] = useAsync<BigNumber>(() => {
-    if (!wallet?.address || !encodedSafeCreationTx || !web3ReadOnly) return
+    if (!wallet?.address || !chain || !web3ReadOnly) return
+
+    const proxyContract = getProxyFactoryContractInstance(chain.chainId)
+    const encodedSafeCreationTx = getSafeCreationTx({ owners, threshold, saltNonce, chain })
 
     return web3ReadOnly.estimateGas({
-      to: proxyContractAddress,
+      to: proxyContract.getAddress(),
       from: wallet.address,
       data: encodedSafeCreationTx,
     })
-  }, [proxyContractAddress, wallet, encodedSafeCreationTx, web3ReadOnly])
+  }, [wallet, chain, web3ReadOnly])
 
   return { gasLimit, gasLimitError, gasLimitLoading }
 }

--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -2,6 +2,8 @@ import { ProviderLabel } from '@web3-onboard/injected-wallets'
 import { hasStoredPairingSession } from '@/services/pairing/connector'
 import { PAIRING_MODULE_LABEL } from '@/services/pairing/module'
 import { E2E_WALLET_NAME } from '@/tests/e2e-wallet'
+import type { EthersError } from '@/utils/ethers-utils'
+import { ErrorCode } from '@ethersproject/logger'
 
 const isKeystoneError = (err: unknown): boolean => {
   if (err instanceof Error) {
@@ -14,13 +16,11 @@ const isWCRejection = (err: Error): boolean => {
   return /User rejected/.test(err?.message)
 }
 
-const isMMRejection = (err: Error & { code?: number }): boolean => {
-  const METAMASK_REJECT_CONFIRM_TX_ERROR_CODE = 4001
-
-  return err.code === METAMASK_REJECT_CONFIRM_TX_ERROR_CODE
+const isMMRejection = (err: EthersError): boolean => {
+  return err.code === ErrorCode.ACTION_REJECTED
 }
 
-export const isWalletRejection = (err: Error & { code?: number }): boolean => {
+export const isWalletRejection = (err: EthersError): boolean => {
   return isMMRejection(err) || isWCRejection(err) || isKeystoneError(err)
 }
 


### PR DESCRIPTION
## What it solves

Resolves #917 

## How this PR fixes it

- Caches relevant info of the safe creation tx for the `_waitForTransaction` call to detect a replacement tx
- Only watches an ongoing tx if the original promise is lost (after a page reload)

### Other changes

- Adds the fallback handler address to the safe creation call, not sure about the impact but we forgot to port it from safe-react

## How to test it

- Safe creation on different chains should work as before and there are no instant timeout errors anymore
