### PR TITLE
Fix: center network selector

### DIFF
--- a/src/components/common/NetworkSelector/index.tsx
+++ b/src/components/common/NetworkSelector/index.tsx
@@ -59,6 +59,9 @@ const NetworkSelector = (): ReactElement => {
         },
       }}
       sx={{
+        '& .MuiSelect-select': {
+          py: 0,
+        },
         '& svg path': {
           fill: ({ palette }) => palette.border.main,
         },


### PR DESCRIPTION
## What it solves

A small CSS fix: the NetworkSelector wasn't centered vertically.

<img width="319" alt="Screenshot 2022-10-18 at 13 13 04" src="https://user-images.githubusercontent.com/381895/196414485-dd70cd16-9a44-4b4e-9f4c-96a5cf060071.png">