### PR TITLE
style: use grid template for dashboard pending txs

### DIFF
--- a/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
@@ -1,49 +1,14 @@
 import NextLink from 'next/link'
 import type { LinkProps } from 'next/link'
 import type { ReactElement } from 'react'
-import styled from '@emotion/styled'
 import ChevronRight from '@mui/icons-material/ChevronRight'
 import type { TransactionSummary } from '@gnosis.pm/safe-react-gateway-sdk'
-import { Grid, Typography } from '@mui/material'
+import { Box } from '@mui/material'
 import { isMultisigExecutionInfo } from '@/utils/transaction-guards'
 import TxInfo from '@/components/transactions/TxInfo'
 import TxType from '@/components/transactions/TxType'
-
-const StyledContainer = styled.div`
-  width: 100%;
-  text-decoration: none;
-  background-color: var(--color-background-paper);
-  border: 1px solid var(--color-border-light);
-  border-radius: 8px;
-  box-sizing: border-box;
-  &:hover {
-    background-color: var(--color-background-light);
-    border-color: var(--color-secondary-light);
-  }
-`
-
-const StyledConfirmationsCount = styled.div`
-  padding: 8px 12px;
-  border-radius: 8px;
-  font-weight: bold;
-  font-size: 12px;
-  background-color: var(--color-secondary-light);
-  color: var(--color-static-main);
-`
-
-const TxConfirmations = styled.div`
-  display: flex;
-  align-items: center;
-  margin-left: auto;
-
-  & svg {
-    margin-left: 8px;
-  }
-`
-
-const Spacer = styled.div`
-  flex-grow: 1;
-`
+import css from './styles.module.css'
+import classNames from 'classnames'
 
 type PendingTxType = {
   transaction: TransactionSummary
@@ -53,36 +18,33 @@ type PendingTxType = {
 const PendingTx = ({ transaction, url }: PendingTxType): ReactElement => {
   return (
     <NextLink href={url} passHref>
-      <a>
-        <StyledContainer>
-          <Grid container py={1} px={2} alignItems="center" gap={1}>
-            <Grid item sx={{ minWidth: '36px' }}>
-              <Typography fontSize="lg" component="span">
-                {isMultisigExecutionInfo(transaction.executionInfo) && transaction.executionInfo.nonce}
-              </Typography>
-            </Grid>
+      <Box className={classNames(css.gridContainer, css.columnTemplate)}>
+        <Box gridArea="nonce">
+          {isMultisigExecutionInfo(transaction.executionInfo) && transaction.executionInfo.nonce}
+        </Box>
 
-            <Grid item flexGrow={1}>
-              <TxType tx={transaction} />
-            </Grid>
+        <Box gridArea="type" className={css.columnWrap}>
+          <TxType tx={transaction} />
+        </Box>
 
-            <TxInfo info={transaction.txInfo} />
+        <Box gridArea="info" className={css.columnWrap}>
+          <TxInfo info={transaction.txInfo} />
+        </Box>
 
-            <Grid item xs />
+        <Box gridArea="confirmations">
+          {isMultisigExecutionInfo(transaction.executionInfo) ? (
+            <Box className={css.confirmationsCount}>
+              {`${transaction.executionInfo.confirmationsSubmitted}/${transaction.executionInfo.confirmationsRequired}`}
+            </Box>
+          ) : (
+            <Box flexGrow={1} />
+          )}
+        </Box>
 
-            <TxConfirmations>
-              {isMultisigExecutionInfo(transaction.executionInfo) ? (
-                <StyledConfirmationsCount>
-                  {`${transaction.executionInfo.confirmationsSubmitted}/${transaction.executionInfo.confirmationsRequired}`}
-                </StyledConfirmationsCount>
-              ) : (
-                <Spacer />
-              )}
-              <ChevronRight color="border" />
-            </TxConfirmations>
-          </Grid>
-        </StyledContainer>
-      </a>
+        <Box gridArea="icon" marginLeft="12px">
+          <ChevronRight color="border" />
+        </Box>
+      </Box>
     </NextLink>
   )
 }

--- a/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
@@ -18,33 +18,35 @@ type PendingTxType = {
 const PendingTx = ({ transaction, url }: PendingTxType): ReactElement => {
   return (
     <NextLink href={url} passHref>
-      <Box className={classNames(css.gridContainer, css.columnTemplate)}>
-        <Box gridArea="nonce">
-          {isMultisigExecutionInfo(transaction.executionInfo) && transaction.executionInfo.nonce}
-        </Box>
+      <a>
+        <Box className={classNames(css.gridContainer, css.columnTemplate)}>
+          <Box gridArea="nonce">
+            {isMultisigExecutionInfo(transaction.executionInfo) && transaction.executionInfo.nonce}
+          </Box>
 
-        <Box gridArea="type" className={css.columnWrap}>
-          <TxType tx={transaction} />
-        </Box>
+          <Box gridArea="type" className={css.columnWrap}>
+            <TxType tx={transaction} />
+          </Box>
 
-        <Box gridArea="info" className={css.columnWrap}>
-          <TxInfo info={transaction.txInfo} />
-        </Box>
+          <Box gridArea="info" className={css.columnWrap}>
+            <TxInfo info={transaction.txInfo} />
+          </Box>
 
-        <Box gridArea="confirmations">
-          {isMultisigExecutionInfo(transaction.executionInfo) ? (
-            <Box className={css.confirmationsCount}>
-              {`${transaction.executionInfo.confirmationsSubmitted}/${transaction.executionInfo.confirmationsRequired}`}
-            </Box>
-          ) : (
-            <Box flexGrow={1} />
-          )}
-        </Box>
+          <Box gridArea="confirmations">
+            {isMultisigExecutionInfo(transaction.executionInfo) ? (
+              <Box className={css.confirmationsCount}>
+                {`${transaction.executionInfo.confirmationsSubmitted}/${transaction.executionInfo.confirmationsRequired}`}
+              </Box>
+            ) : (
+              <Box flexGrow={1} />
+            )}
+          </Box>
 
-        <Box gridArea="icon" marginLeft="12px">
-          <ChevronRight color="border" />
+          <Box gridArea="icon" marginLeft="12px">
+            <ChevronRight color="border" />
+          </Box>
         </Box>
-      </Box>
+      </a>
     </NextLink>
   )
 }

--- a/src/components/dashboard/PendingTxs/styles.module.css
+++ b/src/components/dashboard/PendingTxs/styles.module.css
@@ -27,8 +27,7 @@
 .columnTemplate {
   grid-template-columns: repeat(12, 1fr);
   grid-template-areas:
-    'nonce type type type type type type type type type confirmations icon'
-    'empty info info info info info info info info info info info';
+    'nonce type type type type type type info info info confirmations icon';
 }
 
 .columnWrap {
@@ -39,5 +38,11 @@
 @media (max-width: 600px) {
   .confirmationsCount {
     padding: 4px var(--space-1);
+  }
+
+  .columnTemplate {
+    grid-template-areas:
+      'nonce type type type type type type type type type confirmations icon'
+      'empty info info info info info info info info info info info';
   }
 }

--- a/src/components/dashboard/PendingTxs/styles.module.css
+++ b/src/components/dashboard/PendingTxs/styles.module.css
@@ -21,6 +21,7 @@
   font-size: 12px;
   background-color: var(--color-secondary-light);
   color: var(--color-static-main);
+  text-align: center;
 }
 
 .columnTemplate {

--- a/src/components/dashboard/PendingTxs/styles.module.css
+++ b/src/components/dashboard/PendingTxs/styles.module.css
@@ -3,7 +3,7 @@
   display:grid;
   grid-gap: 4px;
   align-items: center;
-  padding: 12px 16px;
+  padding: 8px 16px;
   background-color: var(--color-background-paper);
   border: 1px solid var(--color-border-light);
   border-radius: 8px;

--- a/src/components/dashboard/PendingTxs/styles.module.css
+++ b/src/components/dashboard/PendingTxs/styles.module.css
@@ -1,0 +1,42 @@
+.gridContainer {
+  width: 100%;
+  display:grid;
+  grid-gap: 4px;
+  align-items: center;
+  padding: 12px 16px;
+  background-color: var(--color-background-paper);
+  border: 1px solid var(--color-border-light);
+  border-radius: 8px;
+}
+
+.gridContainer:hover {
+  background-color: var(--color-background-light);
+  border-color: var(--color-secondary-light);
+}
+
+.confirmationsCount {
+  padding: var(--space-1) 12px;
+  border-radius: 8px;
+  font-weight: bold;
+  font-size: 12px;
+  background-color: var(--color-secondary-light);
+  color: var(--color-static-main);
+}
+
+.columnTemplate {
+  grid-template-columns: repeat(12, 1fr);
+  grid-template-areas:
+    'nonce type type type type type type type type type confirmations icon'
+    'empty info info info info info info info info info info info';
+}
+
+.columnWrap {
+  white-space: normal;
+  word-break: break-word;
+}
+
+@media (max-width: 600px) {
+  .confirmationsCount {
+    padding: 4px var(--space-1);
+  }
+}

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -12,7 +12,7 @@ const Dashboard = (): ReactElement => {
         <Overview />
       </Grid>
 
-      <Grid item xs={12} md={6}>
+      <Grid item xs={12} md={12} lg={6}>
         <PendingTxsList size={4} />
       </Grid>
 

--- a/src/components/transactions/TxSummary/styles.module.css
+++ b/src/components/transactions/TxSummary/styles.module.css
@@ -1,7 +1,3 @@
-.container {
-  margin: 6px 0;
-}
-
 .gridContainer {
   width: 100%;
   display: grid;


### PR DESCRIPTION
## What it solves

Resolves #914

## How this PR fixes it
Uses grid templates to style the Transaction queue items in the Dashboard

## How to test it
1. Open a Safe with existing pending transactions
2. Go to Dashboard
3. Reduce the viewport width and observe the pending transactions do not get cramped.
4. Toggle mobile viewport observe the pending transactions do not get cramped.

## Analytics changes
N/A

## Screenshots
<img width="391" alt="Screenshot 2022-10-18 at 13 18 24" src="https://user-images.githubusercontent.com/32431609/196415463-a29539ab-9888-458e-8be6-8f4e83db0ed2.png">
