### PR TITLE
Fix: space out page header tabs

### DIFF
--- a/src/components/common/NavTabs/styles.module.css
+++ b/src/components/common/NavTabs/styles.module.css
@@ -21,10 +21,9 @@
 
 .tab {
   opacity: 1;
-  padding: 0 var(--space-2);
+  padding: 0 var(--space-3);
   position: relative;
   z-index: 2;
-  min-width: 0;
 }
 
 .label {

--- a/src/components/common/PageHeader/styles.module.css
+++ b/src/components/common/PageHeader/styles.module.css
@@ -12,6 +12,6 @@
 }
 
 .title {
-  padding-bottom: 12px;
   font-weight: 700;
+  margin-bottom: var(--space-3);
 }


### PR DESCRIPTION
## What it solves

Makes the tabs a bit bigger and easier to click on.

As per @liliiaorlenko:

> Yes maybe we can widen the area for 5pm and lower the tabs 15px, may this can visually improve it

<img width="357" alt="Screenshot 2022-10-19 at 07 38 57" src="https://user-images.githubusercontent.com/381895/196606172-a8418d8c-6f81-48ab-8dca-616954b445fb.png">
<img width="808" alt="Screenshot 2022-10-19 at 07 38 48" src="https://user-images.githubusercontent.com/381895/196606190-418cf5a5-843f-404e-b0e2-3fcc46c93a2e.png">
