### PR TITLE
test: remove LS workaround

### DIFF
--- a/cypress/e2e/smoke/dashboard.cy.js
+++ b/cypress/e2e/smoke/dashboard.cy.js
@@ -2,8 +2,6 @@ const SAFE = 'gor:0xCD4FddB8FfA90012DFE11eD4bf258861204FeEAE'
 
 describe('Dashboard', () => {
   before(() => {
-    window.localStorage.setItem('SAFE_v2__debugProdCgw', 'true')
-
     // Go to the test Safe home page
     cy.visit(`/${SAFE}/home`, { failOnStatusCode: false })
     cy.contains('button', 'Accept selection').click()

--- a/cypress/e2e/smoke/tx_history.cy.js
+++ b/cypress/e2e/smoke/tx_history.cy.js
@@ -6,8 +6,6 @@ const CONTRACT_INTERACTION = '/images/transactions/custom.svg'
 
 describe('Transaction history', () => {
   before(() => {
-    window.localStorage.setItem('SAFE_v2__debugProdCgw', 'true')
-
     // Go to the test Safe transaction history
     cy.visit(`/${SAFE}/transactions/history`, { failOnStatusCode: false })
     cy.contains('button', 'Accept selection').click()


### PR DESCRIPTION
## What it solves
Removes the Local Storage workaround after creating Goerli pending transactions in `staging`

## How to test it
1. Delete `SAFE_v2__debugProdCgw` from your local storage
2. Run `dashboard` and `tx_history` tests on Cypress
