### PR TITLE
fix: better AB import error

### DIFF
--- a/src/components/address-book/ImportDialog/__tests__/validation.test.ts
+++ b/src/components/address-book/ImportDialog/__tests__/validation.test.ts
@@ -18,14 +18,6 @@ describe('Address book import validation', () => {
 
       expect(abCsvReaderValidator(file)).toBeUndefined()
     })
-    it('should return an error if file is not a CSV', () => {
-      const file = {
-        type: 'text/plain',
-        size: 100,
-      } as File
-
-      expect(abCsvReaderValidator(file)).toEqual(['Address book must be a CSV file'])
-    })
     it('should return an error if file is too large', () => {
       const file = {
         type: 'text/csv',

--- a/src/components/address-book/ImportDialog/index.tsx
+++ b/src/components/address-book/ImportDialog/index.tsx
@@ -88,8 +88,7 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
             const error = result?.[0].errors?.pop()
 
             if (error) {
-              const errorDescription =
-                error instanceof Error ? error.message : typeof error === 'string' ? error.toString() : error.message
+              const errorDescription = typeof error === 'string' ? error.toString() : error.message
               setError(errorDescription)
               logError(Errors._703, errorDescription)
             }

--- a/src/components/address-book/ImportDialog/index.tsx
+++ b/src/components/address-book/ImportDialog/index.tsx
@@ -22,10 +22,11 @@ type AddressBookCSVRow = ['address', 'name', 'chainId']
 
 // https://react-papaparse.js.org/docs#errors
 type PapaparseErrorType = {
-  type: string
-  code: string
+  type: 'Quotes' | 'Delimiter' | 'FieldMismatch'
+  code: 'MissingQuotes' | 'UndetectableDelimiter' | 'TooFewFields' | 'TooManyFields'
   message: string
-  row: number
+  row?: number
+  index?: number
 }
 
 const hasEntry = (entry: string[]) => {

--- a/src/components/address-book/ImportDialog/index.tsx
+++ b/src/components/address-book/ImportDialog/index.tsx
@@ -89,11 +89,7 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
 
             if (error) {
               const errorDescription =
-                error instanceof Error
-                  ? error.message
-                  : typeof error === 'string'
-                  ? error.toString()
-                  : JSON.stringify(error)
+                error instanceof Error ? error.message : typeof error === 'string' ? error.toString() : error.message
               setError(errorDescription)
               logError(Errors._703, errorDescription)
             }

--- a/src/components/address-book/ImportDialog/index.tsx
+++ b/src/components/address-book/ImportDialog/index.tsx
@@ -76,6 +76,7 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
 
             // csvReaderValidator error
             const error = result?.[0].errors?.pop()
+            console.error(error)
 
             if (error) {
               setError(error instanceof Error ? error.message : error.toString())

--- a/src/components/address-book/ImportDialog/index.tsx
+++ b/src/components/address-book/ImportDialog/index.tsx
@@ -16,6 +16,7 @@ import css from './styles.module.css'
 import { trackEvent, ADDRESS_BOOK_EVENTS } from '@/services/analytics'
 import { abCsvReaderValidator, abOnUploadValidator } from './validation'
 import ErrorMessage from '@/components/tx/ErrorMessage'
+import { Errors, logError } from '@/services/exceptions'
 
 type AddressBookCSVRow = ['address', 'name', 'chainId']
 
@@ -76,10 +77,11 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
 
             // csvReaderValidator error
             const error = result?.[0].errors?.pop()
-            console.error(error)
 
             if (error) {
-              setError(error instanceof Error ? error.message : error.toString())
+              const errorDescription = error instanceof Error ? error.message : JSON.stringify(error)
+              setError(errorDescription)
+              logError(Errors._703, errorDescription)
             }
           }}
           onUploadAccepted={(result: ParseResult<['address', 'name', 'chainId']>) => {

--- a/src/components/address-book/ImportDialog/index.tsx
+++ b/src/components/address-book/ImportDialog/index.tsx
@@ -20,6 +20,14 @@ import { Errors, logError } from '@/services/exceptions'
 
 type AddressBookCSVRow = ['address', 'name', 'chainId']
 
+// https://react-papaparse.js.org/docs#errors
+type PapaparseErrorType = {
+  type: string
+  code: string
+  message: string
+  row: number
+}
+
 const hasEntry = (entry: string[]) => {
   return entry.length === 3 && entry[0] && entry[1] && entry[2]
 }
@@ -71,7 +79,7 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
             setZoneHover(false)
           }}
           validator={abCsvReaderValidator}
-          onUploadRejected={(result: { file: File; errors?: Array<Error | string> }[]) => {
+          onUploadRejected={(result: { file: File; errors?: Array<Error | string | PapaparseErrorType> }[]) => {
             setZoneHover(false)
             setError(undefined)
 

--- a/src/components/address-book/ImportDialog/index.tsx
+++ b/src/components/address-book/ImportDialog/index.tsx
@@ -88,7 +88,12 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
             const error = result?.[0].errors?.pop()
 
             if (error) {
-              const errorDescription = error instanceof Error ? error.message : JSON.stringify(error)
+              const errorDescription =
+                error instanceof Error
+                  ? error.message
+                  : typeof error === 'string'
+                  ? error.toString()
+                  : JSON.stringify(error)
               setError(errorDescription)
               logError(Errors._703, errorDescription)
             }

--- a/src/components/address-book/ImportDialog/validation.ts
+++ b/src/components/address-book/ImportDialog/validation.ts
@@ -3,10 +3,6 @@ import type { ParseResult } from 'papaparse'
 import { validateAddress, validateChainId } from '@/utils/validation'
 
 export const abCsvReaderValidator = ({ type, size }: File): string[] | undefined => {
-  if (type !== 'text/csv') {
-    return ['Address book must be a CSV file']
-  }
-
   if (size > 1_000_000) {
     return ['Address book cannot be larger than 1MB']
   }

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -31,7 +31,7 @@ enum ErrorCodes {
   _700 = '700: Failed to read from local/session storage',
   _701 = '701: Failed to write to local/session storage',
   _702 = '702: Failed to remove from local/session storage',
-  _703 = '703: Error uploading a file',
+  _703 = '703: Error importing an address book',
 
   _800 = '800: Safe creation tx failed',
   _801 = '801: Failed to send a tx with a spending limit',

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -31,6 +31,7 @@ enum ErrorCodes {
   _700 = '700: Failed to read from local/session storage',
   _701 = '701: Failed to write to local/session storage',
   _702 = '702: Failed to remove from local/session storage',
+  _703 = '703: Error uploading a file',
 
   _800 = '800: Safe creation tx failed',
   _801 = '801: Failed to send a tx with a spending limit',


### PR DESCRIPTION
## What it solves
Resolves #889

## How this PR fixes it
Removes the extraneous content type validation.
Adds a `papaparse` error type.

## How to test it
Follow #[889](https://github.com/safe-global/web-core/issues/889) steps
