### PR TITLE
fix: disable address book export when no entries exist on all chains

### DIFF
--- a/src/components/address-book/AddressBookHeader/index.tsx
+++ b/src/components/address-book/AddressBookHeader/index.tsx
@@ -56,7 +56,7 @@ type Props = {
 
 const AddressBookHeader = ({ handleOpenModal, searchQuery, onSearchQueryChange }: Props): ReactElement => {
   const allAddressBooks = useAppSelector(selectAllAddressBooks)
-  const canExport = Object.values(allAddressBooks).length > 0
+  const canExport = Object.values(allAddressBooks).some((addressBook) => Object.keys(addressBook || {}).length > 0)
 
   return (
     <PageHeader

--- a/src/components/address-book/AddressBookTable/index.tsx
+++ b/src/components/address-book/AddressBookTable/index.tsx
@@ -21,6 +21,7 @@ import { ADDRESS_BOOK_EVENTS } from '@/services/analytics/events/addressBook'
 import SvgIcon from '@mui/material/SvgIcon'
 import PagePlaceholder from '@/components/common/PagePlaceholder'
 import AddressBookIcon from '@/public/images/address-book/address-book.svg'
+import { useCurrentChain } from '@/hooks/useChains'
 
 const headCells = [
   { id: 'name', label: 'Name' },
@@ -43,6 +44,7 @@ const defaultOpen = {
 }
 
 const AddressBookTable = () => {
+  const chain = useCurrentChain()
   const isSafeOwner = useIsSafeOwner()
   const [open, setOpen] = useState<typeof defaultOpen>(defaultOpen)
   const [searchQuery, setSearchQuery] = useState('')
@@ -136,7 +138,10 @@ const AddressBookTable = () => {
         {filteredEntries.length > 0 ? (
           <EnhancedTable rows={rows} headCells={headCells} />
         ) : (
-          <PagePlaceholder img={<AddressBookIcon />} text="No entries found" />
+          <PagePlaceholder
+            img={<AddressBookIcon />}
+            text={`No entries found${chain ? ` on ${chain.chainName}` : ''}`}
+          />
         )}
       </main>
 


### PR DESCRIPTION
## What it solves

Resolves #949

## How this PR fixes it

The length of chain-specific address books are checked to ensure exporting is possible as they can be an empty object.

The "No entries found" placeholder has been updated to include the chain name as well, e.g. "No entries found on Polygon".

## How to test it

1. Remove the `SAFE_v2__addressBook` `localStorage` entry.
2. Add an address book entry on chain X, and another on a chain Y.
3. Observe the export button enabled when on chain Y, even after deleting the entry (as well as "No entries found on Polygon" shown).
4. Switch to chain Y and observe that the address book is still exportable. Deleting the entry disables the button.

## Screenshots

![address book export](https://user-images.githubusercontent.com/20442784/197142113-87e6ab62-321e-4aa6-8fa4-5d8fd4ac15de.gif)