### PR TITLE
fix: Hide execute checkbox if tx has enough confirmations

### DIFF
--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -34,7 +34,10 @@ export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction =>
   const getMissingSigners = ({
     signers,
     confirmations,
+    confirmationsRequired,
   }: MultisigExecutionDetails): MultisigExecutionInfo['missingSigners'] => {
+    if (confirmations.length >= confirmationsRequired) return
+
     const missingSigners = signers.filter(({ value }) => {
       const hasConfirmed = confirmations?.some(({ signer }) => signer?.value === value)
       return !hasConfirmed


### PR DESCRIPTION
## What it solves

Resolves #930 

This was a general issue and not related to smart contract wallets.

## How this PR fixes it

When building the tx object for the single tx view, `missingSigners` is only added if the transaction still needs confirmations.

## How to test it

1. Open an m/n safe
2. Create and sign a tx
4. Switch to a different owner
5. Open the tx in the detail view
6. If the tx needs more signatures it should display the checkbox
7. If the tx is already fully signed it should hide the checkbox

## Screenshots
<img width="1252" alt="Screenshot 2022-10-21 at 12 42 06" src="https://user-images.githubusercontent.com/5880855/197177681-fda00353-3094-4ab6-a5fd-d44ed31fc793.png">
