### PR TITLE
[PoC] Reusable RHF inputs

### DIFF
--- a/src/components/common/inputs/SafeRadioGroup/index.tsx
+++ b/src/components/common/inputs/SafeRadioGroup/index.tsx
@@ -1,0 +1,24 @@
+import { FormControl, RadioGroup, FormLabel } from '@mui/material'
+import type { RadioGroupProps, FormLabelProps } from '@mui/material'
+import type { FieldValues } from 'react-hook-form'
+
+import { useSafeController } from '../useSafeController'
+import type { RHFInput } from '../types'
+
+export const SafeRadioGroup = <TFieldValues extends FieldValues>(
+  props: RHFInput<RadioGroupProps, TFieldValues> & { label?: FormLabelProps['children']; required?: boolean },
+) => {
+  const {
+    field: { ref, ...field },
+    error,
+    required,
+    label,
+  } = useSafeController<TFieldValues>(props)
+
+  return (
+    <FormControl required={required} error={!!error}>
+      {label && <FormLabel>{label}</FormLabel>}
+      <RadioGroup {...props} {...field} />
+    </FormControl>
+  )
+}

--- a/src/components/common/inputs/SafeSelect/index.tsx
+++ b/src/components/common/inputs/SafeSelect/index.tsx
@@ -1,0 +1,27 @@
+import { FormControl, FormHelperText, InputLabel, Select } from '@mui/material'
+import type { SelectProps, FormHelperTextProps } from '@mui/material'
+import type { FieldValues } from 'react-hook-form'
+
+import { useSafeController } from '../useSafeController'
+import type { RHFInput } from '../types'
+
+export const SafeSelect = <TFieldValues extends FieldValues>({
+  fullWidth,
+  helperText,
+  ...props
+}: RHFInput<SelectProps, TFieldValues> & { helperText?: FormHelperTextProps['children'] }) => {
+  const {
+    field: { ref, ...field },
+    error,
+    required,
+    label,
+  } = useSafeController<TFieldValues>(props)
+
+  return (
+    <FormControl required={required} error={!!error} disabled={props.disabled} fullWidth={fullWidth}>
+      {label && <InputLabel>{label}</InputLabel>}
+      <Select error={!!error} required={required} inputRef={ref} {...props} {...field} />
+      {helperText && <FormHelperText>{helperText}</FormHelperText>}
+    </FormControl>
+  )
+}

--- a/src/components/common/inputs/SafeSwitch/index.tsx
+++ b/src/components/common/inputs/SafeSwitch/index.tsx
@@ -1,0 +1,25 @@
+import { FormControl, FormControlLabel, Switch } from '@mui/material'
+import type { FormControlLabelProps, SwitchProps } from '@mui/material'
+import type { FieldValues } from 'react-hook-form'
+
+import { useSafeController } from '../useSafeController'
+import type { RHFInput } from '../types'
+
+export const SafeSwitch = <TFieldValues extends FieldValues>(
+  props: RHFInput<SwitchProps, TFieldValues> & { label?: FormControlLabelProps['label'] },
+) => {
+  const {
+    field: { ref, value, ...field },
+    error,
+    required,
+    label,
+  } = useSafeController<TFieldValues>(props)
+
+  const input = <Switch inputRef={ref} checked={value} {...props} {...field} />
+
+  return (
+    <FormControl required={required} error={!!error} disabled={props.disabled}>
+      {label ? <FormControlLabel control={input} label={label} /> : input}
+    </FormControl>
+  )
+}

--- a/src/components/common/inputs/SafeTextField/index.tsx
+++ b/src/components/common/inputs/SafeTextField/index.tsx
@@ -1,0 +1,17 @@
+import { TextField } from '@mui/material'
+import type { TextFieldProps } from '@mui/material'
+import type { FieldValues } from 'react-hook-form'
+
+import { useSafeController } from '../useSafeController'
+import type { RHFInput } from '../types'
+
+export const SafeTextField = <TFieldValues extends FieldValues>(props: RHFInput<TextFieldProps, TFieldValues>) => {
+  const {
+    field: { ref, ...field },
+    error,
+    required,
+    label,
+  } = useSafeController<TFieldValues>(props)
+
+  return <TextField label={label} error={!!error} required={required} inputRef={ref} {...props} {...field} />
+}

--- a/src/components/common/inputs/index.ts
+++ b/src/components/common/inputs/index.ts
@@ -1,0 +1,4 @@
+export * from './SafeTextField'
+export * from './SafeSelect'
+export * from './SafeRadioGroup'
+export * from './SafeSwitch'

--- a/src/components/common/inputs/types.ts
+++ b/src/components/common/inputs/types.ts
@@ -1,0 +1,7 @@
+import type { ControllerProps } from './useSafeController'
+
+// Remove props added to inputs by `useController`
+type WithoutRHFProps<TInputType> = Omit<TInputType, 'value' | 'error' | 'inputRef' | 'onChange' | 'onBlur'>
+
+// Props for a custom RHF input
+export type RHFInput<TInputType, TFieldValues> = WithoutRHFProps<TInputType> & ControllerProps<TFieldValues>

--- a/src/components/common/inputs/useSafeController/index.ts
+++ b/src/components/common/inputs/useSafeController/index.ts
@@ -1,0 +1,29 @@
+import { useController } from 'react-hook-form'
+import type { UseControllerProps, FieldValues } from 'react-hook-form'
+import type { ReactNode } from 'react'
+
+type WithRequiredProperty<Type, Key extends keyof Type> = Type & {
+  [Property in Key]-?: Type[Property]
+}
+
+// `useController` props, with a required `control`
+// If we want to use a context, this need not be required
+export type ControllerProps<TFieldValues> = WithRequiredProperty<UseControllerProps<TFieldValues>, 'control'>
+
+export const useSafeController = <TFieldValues extends FieldValues>({
+  rules,
+  label,
+  ...props
+}: ControllerProps<TFieldValues> & { required?: boolean; label?: ReactNode }) => {
+  const required = props.required || !!rules?.required
+
+  const {
+    field,
+    fieldState: { error },
+  } = useController({
+    rules: { required, ...rules },
+    ...props,
+  })
+
+  return { field, error, required, label: error?.message || label }
+}

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -5,6 +5,7 @@ export const AppRoutes = {
   load: '/load',
   index: '/',
   home: '/home',
+  demo: '/demo',
   apps: '/apps',
   addressBook: '/address-book',
   balances: {

--- a/src/pages/demo.tsx
+++ b/src/pages/demo.tsx
@@ -1,0 +1,82 @@
+import { FormControlLabel, MenuItem, Radio, Grid, Button } from '@mui/material'
+import { useForm } from 'react-hook-form'
+import type { NextPage } from 'next'
+
+import { SafeRadioGroup, SafeSelect, SafeSwitch, SafeTextField } from '@/components/common/inputs'
+
+type DemoForm = {
+  text: string
+  select: number
+  radio: boolean
+  switch: boolean
+}
+
+const Demo: NextPage = () => {
+  const { control, handleSubmit, setValue } = useForm<DemoForm>({
+    defaultValues: { text: 'Test', select: 10, radio: true, switch: true },
+  })
+
+  const onSubmit = (data: DemoForm) => {
+    console.log(data)
+  }
+
+  return (
+    <main>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Grid container spacing={3}>
+          <Grid item xs={6}>
+            <SafeTextField<DemoForm> label="Text field" name="text" control={control} required fullWidth />
+          </Grid>
+
+          <Grid item xs={6}>
+            <SafeSelect<DemoForm>
+              label="Select"
+              name="select"
+              control={control}
+              required
+              fullWidth
+              rules={{
+                validate: (val) => {
+                  return val > 10 || 'Invalid amount'
+                },
+              }}
+              helperText="Must be greater than 10"
+            >
+              <MenuItem value={10}>Ten</MenuItem>
+              <MenuItem value={20}>Twenty</MenuItem>
+              <MenuItem value={30}>Thirty</MenuItem>
+            </SafeSelect>
+          </Grid>
+
+          <Grid item xs={6}>
+            <SafeRadioGroup<DemoForm>
+              label="Radio group"
+              name="radio"
+              control={control}
+              rules={{
+                onChange: (e) => {
+                  setValue(e.target.name, JSON.parse(e.target.value))
+                },
+              }}
+            >
+              <FormControlLabel value="true" label="Yes" control={<Radio />} />
+              <FormControlLabel value="false" label="No" control={<Radio />} />
+            </SafeRadioGroup>
+          </Grid>
+
+          <Grid item xs={6}>
+            <SafeSwitch<DemoForm> label="Switch" name="switch" control={control} />
+          </Grid>
+
+          <Grid item>
+            <Button type="submit" variant="contained">
+              Submit
+            </Button>
+          </Grid>
+        </Grid>
+      </form>
+    </main>
+  )
+}
+
+export default Demo


### PR DESCRIPTION
## What it solves

Simplified RHF inputs

## How this PR fixes it

Custom input components have been made that follow MUI/RHF APIs as purely/closely as possible. View `/pages/demo.tsx` as an example.

Note: `AddressInput`, `AddressBookInput`, `NameInput` and `DatePickerInput` would still need to be migrated if we like this implementation (although we can continue using them as is for now).

## How to test it

Open '/demo' for a preview of each element.