### PR TITLE
fix: add refresh to pairing modal QR code

### DIFF
--- a/src/components/common/PairingDetails/PairingQRCode.tsx
+++ b/src/components/common/PairingDetails/PairingQRCode.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react'
+import { IconButton, Box } from '@mui/material'
+import RefreshIcon from '@mui/icons-material/Refresh'
+import type { ReactElement } from 'react'
+
+import { getPairingConnector, usePairingConnector, WalletConnectEvents } from '@/services/pairing/connector'
+import usePairingUri from '@/services/pairing/hooks'
+import useChainId from '@/hooks/useChainId'
+import QRCode from '@/components/common/QRCode'
+
+const QR_CODE_SIZE = 100
+
+const PairingQRCode = ({ size = QR_CODE_SIZE }: { size?: number }): ReactElement => {
+  const chainId = useChainId()
+  const uri = usePairingUri()
+  const connector = usePairingConnector()
+  const [displayRefresh, setDisplayRefresh] = useState<boolean>(false)
+
+  // Workaround because the disconnect listener in useInitPairing is not picking up the event
+  useEffect(() => {
+    connector?.on(WalletConnectEvents.DISCONNECT, () => {
+      setDisplayRefresh(true)
+    })
+  }, [connector])
+
+  const handleRefresh = () => {
+    setDisplayRefresh(false)
+    getPairingConnector()?.createSession({ chainId: +chainId })
+  }
+
+  if (displayRefresh || (connector && !connector.handshakeTopic)) {
+    return (
+      <Box
+        sx={{
+          width: size,
+          height: size,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: (theme) => theme.palette.background.main,
+        }}
+      >
+        <IconButton onClick={handleRefresh}>
+          <RefreshIcon fontSize="large" />
+        </IconButton>
+      </Box>
+    )
+  }
+
+  return <QRCode value={uri} size={size} />
+}
+
+export default PairingQRCode

--- a/src/components/common/PairingDetails/index.tsx
+++ b/src/components/common/PairingDetails/index.tsx
@@ -1,58 +1,15 @@
-import { IconButton, Typography } from '@mui/material'
+import { Typography } from '@mui/material'
 import type { ReactElement } from 'react'
 
-import usePairingUri from '@/services/pairing/hooks'
-import QRCode from '@/components/common/QRCode'
+import PairingQRCode from './PairingQRCode'
 import PairingDescription from './PairingDescription'
-import { getPairingConnector, usePairingConnector, WalletConnectEvents } from '@/services/pairing/connector'
-import useChainId from '@/hooks/useChainId'
-import { useEffect, useState } from 'react'
-import Box from '@mui/material/Box'
-import RefreshIcon from '@mui/icons-material/Refresh'
-
-const QR_CODE_SIZE = 100
 
 const PairingDetails = ({ vertical = false }: { vertical?: boolean }): ReactElement => {
-  const [displayRefresh, setDisplayRefresh] = useState<boolean>(false)
-  const chainId = useChainId()
-  const uri = usePairingUri()
-  const connector = usePairingConnector()
-
-  // Workaround because the disconnect listener in useInitPairing is not picking up the event
-  useEffect(() => {
-    connector?.on(WalletConnectEvents.DISCONNECT, () => {
-      setDisplayRefresh(true)
-    })
-  }, [connector])
-
-  const handleRefresh = () => {
-    setDisplayRefresh(false)
-    getPairingConnector()?.createSession({ chainId: +chainId })
-  }
-
   const title = <Typography variant="h5">Connect to mobile</Typography>
 
-  const qr =
-    displayRefresh || (connector && !connector.handshakeTopic) ? (
-      <Box
-        sx={{
-          width: 100,
-          height: 100,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          backgroundColor: (theme) => theme.palette.background.main,
-        }}
-      >
-        <IconButton onClick={handleRefresh}>
-          <RefreshIcon fontSize="large" />
-        </IconButton>
-      </Box>
-    ) : (
-      <QRCode value={uri} size={QR_CODE_SIZE} />
-    )
-
   const description = <PairingDescription />
+
+  const qr = <PairingQRCode />
 
   return (
     <>

--- a/src/hooks/useChainId.ts
+++ b/src/hooks/useChainId.ts
@@ -31,7 +31,7 @@ const getLocationQuery = (): ParsedUrlQuery => {
 export const useUrlChainId = (): string | undefined => {
   const router = useRouter()
   // Dynamic query params are available only in an effect
-  const query = router.query.safe || router.query.chain ? router.query : getLocationQuery()
+  const query = router && (router.query.safe || router.query.chain) ? router.query : getLocationQuery()
   const chain = query.chain?.toString() || ''
   const safe = query.safe?.toString() || ''
 

--- a/src/services/pairing/QRModal.tsx
+++ b/src/services/pairing/QRModal.tsx
@@ -2,8 +2,7 @@ import { Dialog, DialogContent, DialogTitle, IconButton } from '@mui/material'
 import { createRoot } from 'react-dom/client'
 import CloseIcon from '@mui/icons-material/Close'
 
-import QRCode from '@/components/common/QRCode'
-import { formatPairingUri } from '@/services/pairing/utils'
+import PairingQRCode from '@/components/common/PairingDetails/PairingQRCode'
 import PairingDescription from '@/components/common/PairingDetails/PairingDescription'
 import { StoreHydrator } from '@/store'
 import { AppProviders } from '@/pages/_app'
@@ -71,7 +70,7 @@ const Modal = ({ uri, cb }: { uri: string; cb: () => void }) => {
             </IconButton>
           </DialogTitle>
           <DialogContent sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
-            <QRCode value={formatPairingUri(uri)} size={QR_CODE_SIZE} />
+            <PairingQRCode size={QR_CODE_SIZE} />
             <br />
             <PairingDescription />
           </DialogContent>


### PR DESCRIPTION
## What it solves

Resolves #936

## How this PR fixes it

The pairing QR code has been extracted to a `PairingQRCode` component, which includes the refresh functionality. This is now used in the `QRModal`, allowing for refreshing of the QR code.

## How to test it

1. Open the pairing QR modal and scan the QR, refusing the connection.
2. Observe the refresh button, which refreshes the QR on click.

## Screenshots

![qr code](https://user-images.githubusercontent.com/20442784/197192869-375776ba-4fea-42ad-b3fc-6e9b3029e46c.gif)