### PR TITLE
fix: Dont validate create/add safe form data when going back

### DIFF
--- a/src/components/create-safe/steps/OwnerPolicyStep.tsx
+++ b/src/components/create-safe/steps/OwnerPolicyStep.tsx
@@ -11,6 +11,7 @@ import { OwnerRow } from '@/components/create-safe/steps/OwnerRow'
 import type { NamedAddress, SafeFormData } from '@/components/create-safe/types'
 import { trackEvent, CREATE_SAFE_EVENTS } from '@/services/analytics'
 import AddIcon from '@/public/images/common/add.svg'
+import { useEffect } from 'react'
 
 type Props = {
   params: SafeFormData
@@ -46,7 +47,7 @@ const OwnerPolicyStep = ({ params, onSubmit, setStep, onBack }: Props): ReactEle
       threshold: defaultThreshold,
     },
   })
-  const { register, handleSubmit, control, formState, watch, setValue } = formMethods
+  const { register, handleSubmit, control, formState, watch, setValue, getValues, trigger } = formMethods
   const currentThreshold = watch(FieldName.threshold)
   const isValid = Object.keys(formState.errors).length === 0 // do not use formState.isValid because names can be empty
 
@@ -73,6 +74,11 @@ const OwnerPolicyStep = ({ params, onSubmit, setStep, onBack }: Props): ReactEle
     }
   }
 
+  // Default values can be invalid so we need to trigger validation
+  useEffect(() => {
+    trigger()
+  }, [trigger])
+
   const onFormSubmit = handleSubmit((data: SafeFormData) => {
     onSubmit(data)
 
@@ -87,9 +93,9 @@ const OwnerPolicyStep = ({ params, onSubmit, setStep, onBack }: Props): ReactEle
     })
   })
 
-  const onFormBack = handleSubmit((data: SafeFormData) => {
-    onBack(data)
-  })
+  const onFormBack = () => {
+    onBack(getValues())
+  }
 
   return (
     <Paper>

--- a/src/components/create-safe/steps/OwnerPolicyStep.tsx
+++ b/src/components/create-safe/steps/OwnerPolicyStep.tsx
@@ -11,7 +11,6 @@ import { OwnerRow } from '@/components/create-safe/steps/OwnerRow'
 import type { NamedAddress, SafeFormData } from '@/components/create-safe/types'
 import { trackEvent, CREATE_SAFE_EVENTS } from '@/services/analytics'
 import AddIcon from '@/public/images/common/add.svg'
-import { useEffect } from 'react'
 
 type Props = {
   params: SafeFormData
@@ -47,7 +46,7 @@ const OwnerPolicyStep = ({ params, onSubmit, setStep, onBack }: Props): ReactEle
       threshold: defaultThreshold,
     },
   })
-  const { register, handleSubmit, control, formState, watch, setValue, getValues, trigger } = formMethods
+  const { register, handleSubmit, control, formState, watch, setValue, getValues } = formMethods
   const currentThreshold = watch(FieldName.threshold)
   const isValid = Object.keys(formState.errors).length === 0 // do not use formState.isValid because names can be empty
 
@@ -73,11 +72,6 @@ const OwnerPolicyStep = ({ params, onSubmit, setStep, onBack }: Props): ReactEle
       setValue<'threshold'>(FieldName.threshold, ownerLength - 1)
     }
   }
-
-  // Default values can be invalid so we need to trigger validation
-  useEffect(() => {
-    trigger()
-  }, [trigger])
 
   const onFormSubmit = handleSubmit((data: SafeFormData) => {
     onSubmit(data)

--- a/src/components/create-safe/steps/SetNameStep.tsx
+++ b/src/components/create-safe/steps/SetNameStep.tsx
@@ -31,7 +31,7 @@ const SetNameStep = ({ params, onSubmit, onBack, setStep }: Props) => {
     mode: 'onChange',
   })
 
-  const { handleSubmit } = formMethods
+  const { handleSubmit, getValues } = formMethods
 
   const onFormSubmit = handleSubmit((data: SafeFormData) => {
     onSubmit({
@@ -44,12 +44,12 @@ const SetNameStep = ({ params, onSubmit, onBack, setStep }: Props) => {
     }
   })
 
-  const onFormBack = handleSubmit((data: SafeFormData) => {
+  const onFormBack = () => {
     onBack({
-      ...data,
-      name: data.name || fallbackName,
+      ...getValues(),
+      name: getValues([FormField.name]) || fallbackName,
     })
-  })
+  }
 
   return (
     <Paper>

--- a/src/components/load-safe/steps/SafeOwnersStep.tsx
+++ b/src/components/load-safe/steps/SafeOwnersStep.tsx
@@ -48,9 +48,9 @@ const SafeOwnersStep = ({ params, onSubmit, onBack }: Props): ReactElement => {
     setValue('owners', owners)
   }, [getValues, safeInfo, setValue])
 
-  const onFormBack = handleSubmit((data: SafeFormData) => {
-    onBack(data)
-  })
+  const onFormBack = () => {
+    onBack(getValues())
+  }
 
   return (
     <Paper>

--- a/src/components/load-safe/steps/SetAddressStep.tsx
+++ b/src/components/load-safe/steps/SetAddressStep.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Box, Button, CircularProgress, Divider, Grid, InputAdornment, Link, Paper, Typography } from '@mui/material'
 import { useForm, FormProvider } from 'react-hook-form'
 import type { StepRenderProps } from '@/components/tx/TxStepper/useTxStepper'
@@ -36,7 +36,7 @@ const SetAddressStep = ({ params, onSubmit, onBack }: Props) => {
     },
   })
 
-  const { handleSubmit, watch, formState, getValues, trigger } = formMethods
+  const { handleSubmit, watch, formState, getValues } = formMethods
 
   const safeAddress = watch('address')
 
@@ -57,11 +57,6 @@ const SetAddressStep = ({ params, onSubmit, onBack }: Props) => {
       return 'Address given is not a valid Safe address'
     }
   }
-
-  // Default values can be invalid so we need to trigger validation
-  useEffect(() => {
-    trigger()
-  }, [trigger])
 
   const onFormSubmit = handleSubmit((data: SafeFormData) => {
     onSubmit({

--- a/src/components/load-safe/steps/SetAddressStep.tsx
+++ b/src/components/load-safe/steps/SetAddressStep.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Box, Button, CircularProgress, Divider, Grid, InputAdornment, Link, Paper, Typography } from '@mui/material'
 import { useForm, FormProvider } from 'react-hook-form'
 import type { StepRenderProps } from '@/components/tx/TxStepper/useTxStepper'
@@ -36,7 +36,7 @@ const SetAddressStep = ({ params, onSubmit, onBack }: Props) => {
     },
   })
 
-  const { handleSubmit, watch, formState } = formMethods
+  const { handleSubmit, watch, formState, getValues, trigger } = formMethods
 
   const safeAddress = watch('address')
 
@@ -58,6 +58,11 @@ const SetAddressStep = ({ params, onSubmit, onBack }: Props) => {
     }
   }
 
+  // Default values can be invalid so we need to trigger validation
+  useEffect(() => {
+    trigger()
+  }, [trigger])
+
   const onFormSubmit = handleSubmit((data: SafeFormData) => {
     onSubmit({
       ...data,
@@ -69,12 +74,12 @@ const SetAddressStep = ({ params, onSubmit, onBack }: Props) => {
     }
   })
 
-  const onFormBack = handleSubmit((data: SafeFormData) => {
+  const onFormBack = () => {
     onBack({
-      ...data,
-      [FormField.name]: data[FormField.name] || fallbackName,
+      ...getValues(),
+      [FormField.name]: getValues([FormField.name]) || fallbackName,
     })
-  })
+  }
 
   return (
     <FormProvider {...formMethods}>


### PR DESCRIPTION
## What it solves

Resolves #947 

## How this PR fixes it

As a result of #842 we were validating the form data via the RHF `handleSubmit` call when navigating back. Now, we just get the latest form values and pass them to the `onBack` handler without using RHF `handleSubmit`. This has the side-effect, that default values can now be invalid so we need to trigger the RHF validation on mount for the steps that have required fields.

## How to test it

1. Open the Safe
2. Load an existing safe
3. Change the safe address so the field becomes invalid
4. Observe being able to click Back
5. Observe a validation error when going back to the set address step
6. Create a new safe
7. Change the owner address so it becomes invalid
8. Observe being able to click Back
9. Observe a validation error when going back to the owner step
