### PR TITLE
fix: use declarative warnings instead of symbols

### DIFF
--- a/src/components/tx/NonceForm/index.tsx
+++ b/src/components/tx/NonceForm/index.tsx
@@ -59,7 +59,7 @@ const NonceForm = ({ name, nonce, recommendedNonce, readonly }: NonceFormProps):
           if (!Number.isInteger(val)) {
             return 'Nonce must be an integer'
           } else if (val < safeNonce) {
-            return `Nonce must be >= ${safeNonce}`
+            return `Nonce can't be lower than ${safeNonce}`
           }
         },
       })}

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -30,7 +30,7 @@ import { EMPTY_DATA } from '@gnosis.pm/safe-core-sdk/dist/src/utils/constants'
 const getAndValidateSafeSDK = (): Safe => {
   const safeSDK = getSafeSDK()
   if (!safeSDK) {
-    throw new Error('The Safe SDK could not be initialized. Please be aware that we only support >= v1.1.1 Safes.')
+    throw new Error('The Safe SDK could not be initialized. Please be aware that we only support v1.1.1 Safes and up.')
   }
   return safeSDK
 }


### PR DESCRIPTION
## What it solves

Removes use of `>=` in warnings

## How this PR fixes it

- `Nonce must be >= ${safeNonce}` ->`Nonce can't be lower than ${safeNonce}`
- `The Safe SDK could not be initialized. Please be aware that we only support >= v1.1.1 Safes.` -> `The Safe SDK could not be initialized. Please be aware that we only support v1.1.1 Safes and up.`

## How to test it

- Create a transaction and edit the nonce to be below that of the Safe nonce. Observe the new warning.
- Open a v1.0.0 Safe and try to create a transaction. Observe the new warning.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/197479856-6fd0b06f-e136-4a9d-a7fe-23c79d945dad.png)

![image](https://user-images.githubusercontent.com/20442784/197479970-bd82f8f9-2967-44f2-8448-dfba535e6514.png)