### PR TITLE
Feat: notify about unsupported Safe versions

### DIFF
--- a/src/hooks/useSafeNotifications.ts
+++ b/src/hooks/useSafeNotifications.ts
@@ -29,9 +29,9 @@ const useSafeNotifications = (): void => {
       return
     }
 
-    const isOldest = isOldestVersion(version)
+    const isOldSafe = isOldestVersion(version)
 
-    const link = isOldest
+    const link = isOldSafe
       ? {
           href: LEGACY_DESKTOP_APP,
           title: 'Desktop app',
@@ -47,8 +47,8 @@ const useSafeNotifications = (): void => {
     const id = dispatch(
       showNotification({
         variant: 'warning',
-        message: isOldest
-          ? `Safe version ${version} not supported. Please use the legacy desktop app.`
+        message: isOldSafe
+          ? `Safe version ${version} is not supported by this web app anymore. Please use the legacy desktop app.`
           : `Your Safe version ${version} is out of date. Please update it.`,
         groupKey: 'safe-outdated-version',
         link,

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -55,7 +55,7 @@ export const getSpecificGnosisSafeContractInstance = (safe: SafeInfo) => {
 }
 
 export const isOldestVersion = (safeVersion: string): boolean => {
-  return semverSatisfies(safeVersion, '<1.0.0')
+  return semverSatisfies(safeVersion, '<=1.0.0')
 }
 
 export const _getSafeContractDeployment = (chain: ChainInfo, safeVersion: string): SingletonDeployment | undefined => {

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -54,9 +54,13 @@ export const getSpecificGnosisSafeContractInstance = (safe: SafeInfo) => {
   })
 }
 
+export const isOldestVersion = (safeVersion: string): boolean => {
+  return semverSatisfies(safeVersion, '<1.0.0')
+}
+
 export const _getSafeContractDeployment = (chain: ChainInfo, safeVersion: string): SingletonDeployment | undefined => {
   // We check if version is prior to v1.0.0 as they are not supported but still we want to keep a minimum compatibility
-  const useOldestContractVersion = semverSatisfies(safeVersion, '<1.0.0')
+  const useOldestContractVersion = isOldestVersion(safeVersion)
 
   // We had L1 contracts in three L2 networks, xDai, EWC and Volta so even if network is L2 we have to check that safe version is after v1.3.0
   const useL2ContractVersion = chain.l2 && semverSatisfies(safeVersion, '>=1.3.0')


### PR DESCRIPTION
## What it solves

We don't support making transactions with <=1.0.0 Safes, so I've added a notification suggesting using the legacy desktop app for these Safes.

<img width="388" alt="Screenshot 2022-10-25 at 16 17 39" src="https://user-images.githubusercontent.com/381895/197798629-b86c0670-1707-40e2-9bd2-133ab8674be8.png">

## How to test
Can be tested on https://legacy-notif.web-core.pages.dev/eth:0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75