### PR TITLE
Fix: switch chain with mobile pairing

### DIFF
--- a/src/services/pairing/module.ts
+++ b/src/services/pairing/module.ts
@@ -207,12 +207,20 @@ const pairingModule = (): WalletInit => {
                 case ProviderMethods.ETH_SIGN_TYPED_DATA_V3:
                 case ProviderMethods.ETH_SIGN_TYPED_DATA_V4:
                 // Not supported by WC
-                case ProviderMethods.ETH_SELECT_ACCOUNTS:
-                case ProviderMethods.WALLET_SWITCH_ETHEREUM_CHAIN: {
+                case ProviderMethods.ETH_SELECT_ACCOUNTS: {
                   throw new ProviderRpcError({
                     code: ProviderRpcErrorCode.UNSUPPORTED_METHOD,
                     message: `The Mobile Safe does not support the requested method: ${method}`,
                   })
+                }
+
+                // Switch wallet chain
+                case ProviderMethods.WALLET_SWITCH_ETHEREUM_CHAIN: {
+                  this.connector.updateSession({
+                    chainId: parseInt((params as [{ chainId: string }])[0].chainId),
+                    accounts: this.connector.accounts,
+                  })
+                  return
                 }
 
                 default: {


### PR DESCRIPTION
## What it solves

Resolves #990

## How this PR fixes it

I've copied the chain switching code from safe-react and put it in the pairing module.

## How to test it
* Connect to the Safe mobile app
* Change the web-app network
* Press the "Switch to chain X" button