### PR TITLE
test: queue transaction with recommended nonce

### DIFF
--- a/cypress/e2e/smoke/create_tx.cy.js
+++ b/cypress/e2e/smoke/create_tx.cy.js
@@ -41,9 +41,54 @@ describe('Queue a transaction on 1/N', () => {
     // Estimation is loaded
     cy.get('button[type="submit"]').should('not.be.disabled')
 
+    // Gets the recommended nonce
     cy.contains('Signing the transaction with nonce').should(($div) => {
       // get the number in the string
       recommendedNonce = $div.text().match(/\d+$/)[0]
+    })
+
+    // Changes nonce to next one
+    cy.contains('Signing the transaction with nonce').click()
+    cy.contains('button', 'Edit').click()
+    cy.get('label').contains('Safe transaction nonce').next().clear().type('3')
+    cy.contains('Confirm').click()
+
+    // Asserts the execute checkbox exists and is checkable
+    cy.get('@modal').within(() => {
+      cy.get('input[type="checkbox"]')
+        .parent('span')
+        .should(($div) => {
+          // Turn the classList into a string
+          const classListString = Array.from($div[0].classList).join()
+          // Check if it contains the error class
+          expect(classListString).to.include('checked')
+        })
+    })
+    cy.contains('Estimated fee').should('exist')
+
+    cy.contains('Execute transaction').click()
+    cy.get('@modal').within(() => {
+      cy.get('input[type="checkbox"]')
+        .parent('span')
+        .should(($div) => {
+          // Turn the classList into a string
+          const classListString = Array.from($div[0].classList).join()
+          // Check if it contains the error class
+          expect(classListString).not.to.include('checked')
+        })
+    })
+    cy.contains('Signing the transaction with nonce').should('exist')
+
+    // Changes back to recommended nonce
+    cy.contains('Signing the transaction with nonce').click()
+    cy.contains('Edit').click()
+    cy.get('button[aria-label="Reset to recommended nonce"]').click()
+
+    // Accepts the values
+    cy.contains('Confirm').click()
+
+    cy.get('@modal').within(() => {
+      cy.get('input[type="checkbox"]').should('not.exist')
     })
 
     cy.contains('Submit').click()

--- a/cypress/e2e/smoke/create_tx.cy.js
+++ b/cypress/e2e/smoke/create_tx.cy.js
@@ -3,6 +3,7 @@ const EOA = '0xE297437d6b53890cbf004e401F3acc67c8b39665'
 
 // generate number between 0.00001 and 0.00020
 const sendValue = Math.floor(Math.random() * 20 + 1) / 100000
+let recommendedNonce
 
 describe('Queue a transaction on 1/N', () => {
   before(() => {
@@ -37,54 +38,28 @@ describe('Queue a transaction on 1/N', () => {
     // Alias for New transaction modal
     cy.contains('h2', 'Review transaction').parents('div').as('modal')
 
-    cy.contains('Signing the transaction with nonce 4').click()
-    cy.contains('button', 'Edit').click()
+    // Estimation is loaded
+    cy.get('button[type="submit"]').should('not.be.disabled')
 
-    cy.get('label').contains('Safe transaction nonce').next().clear().type('3')
-
-    // Accepts the values
-    cy.contains('Confirm').click()
-
-    // Asserts the execute checkbox is checked
-    cy.get('@modal').within(() => {
-      cy.get('input[type="checkbox"]')
-        .parent('span')
-        .should(($div) => {
-          // Turn the classList into a string
-          const classListString = Array.from($div[0].classList).join()
-          // Check if it contains the error class
-          expect(classListString).to.include('checked')
-        })
-    })
-
-    // Open the new transaction modal
-    cy.contains('Execute transaction').click()
-
-    cy.get('@modal').within(() => {
-      cy.get('input[type="checkbox"]')
-        .parent('span')
-        .should(($div) => {
-          // Turn the classList into a string
-          const classListString = Array.from($div[0].classList).join()
-          // Check if it contains the error class
-          expect(classListString).not.to.include('checked')
-        })
+    cy.contains('Signing the transaction with nonce').should(($div) => {
+      // get the number in the string
+      recommendedNonce = $div.text().match(/\d+$/)[0]
     })
 
     cy.contains('Submit').click()
   })
 
-  it('should display the queued tx on Dashboard', () => {
-    cy.contains('h2', 'Transaction queue').parents('section').as('txQueueSection')
+  it('should click the notification and see the transaction queued', () => {
+    // Click on the notification
+    cy.contains('View transaction').click()
 
-    cy.get('@txQueueSection').within(() => {
-      // There should be queued transactions
-      cy.contains('This Safe has no queued transactions').should('not.exist')
+    // Single Tx page
+    cy.contains('h3', 'Transaction details').should('be.visible')
 
-      // Created transaction should be queued
-      cy.contains(`a[href="/transactions/queue?safe=${SAFE}"]`, '3' + 'Send' + '-' + `${sendValue} GOR` + '1/1').should(
-        'exist',
-      )
-    })
+    // Queue label
+    cy.contains('Queued - transaction with nonce 3 needs to be executed first').should('be.visible')
+
+    // Transaction summary
+    cy.contains(`${recommendedNonce}` + 'Send' + '-' + `${sendValue} GOR`).should('exist')
   })
 })


### PR DESCRIPTION
## What it solves
After investigation on the failing E2E tests
What's happening is that a transaction was already queued with the same data, thus it won't be duplicated and consequently it won't appear in the Dashboard as the most recent transaction with that nonce. (That's why it start failing out of the sudden - we are only randomizing 20 possible values in the test)

## How this PR fixes it
We stop queuing transactions with the same nonce and instead queue transactions with the recommended nonce and verify the transaction is queued in the Single Tx details page instead of the Dashboard.
After signing the transaction, we follow to the SingleTx page by clicking the notification where we can see the newly queued transaction.
