### PR TITLE
Fix: show a disabled Execute checkbox in the Execute modal

### DIFF
--- a/src/components/tx/ExecuteCheckbox/index.tsx
+++ b/src/components/tx/ExecuteCheckbox/index.tsx
@@ -3,7 +3,7 @@ import { Checkbox, FormControlLabel, Tooltip } from '@mui/material'
 import InfoIcon from '@mui/icons-material/Info'
 import { trackEvent, MODALS_EVENTS } from '@/services/analytics'
 
-const ExecuteToggle = ({
+const ExecuteCheckbox = ({
   checked,
   onChange,
   disabled = false,
@@ -38,4 +38,4 @@ const ExecuteToggle = ({
   )
 }
 
-export default ExecuteToggle
+export default ExecuteCheckbox

--- a/src/components/tx/ExecuteCheckbox/index.tsx
+++ b/src/components/tx/ExecuteCheckbox/index.tsx
@@ -6,9 +6,11 @@ import { trackEvent, MODALS_EVENTS } from '@/services/analytics'
 const ExecuteToggle = ({
   checked,
   onChange,
+  disabled = false,
 }: {
   checked: boolean
   onChange: (checked: boolean) => void
+  disabled?: boolean
 }): ReactElement => {
   const handleChange = (_: ChangeEvent<HTMLInputElement>, checked: boolean) => {
     trackEvent({ ...MODALS_EVENTS.EXECUTE_TX, label: checked })
@@ -16,14 +18,20 @@ const ExecuteToggle = ({
   }
 
   const infoIcon = (
-    <Tooltip title="If you want to sign the transaction now but manually execute it later, uncheck this box.">
+    <Tooltip
+      title={
+        disabled
+          ? 'This transaction is fully signed and will be executed.'
+          : 'If you want to sign the transaction now but manually execute it later, uncheck this box.'
+      }
+    >
       <InfoIcon fontSize="small" sx={{ verticalAlign: 'middle', marginLeft: 0.5 }} />
     </Tooltip>
   )
 
   return (
     <FormControlLabel
-      control={<Checkbox checked={checked} onChange={handleChange} />}
+      control={<Checkbox checked={checked} onChange={handleChange} disabled={disabled} />}
       label={<>Execute transaction {infoIcon}</>}
       sx={{ mb: 1 }}
     />

--- a/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.test.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.test.tsx
@@ -115,13 +115,13 @@ describe('SignOrExecuteForm', () => {
     expect(result.getByText('Execute transaction')).toBeInTheDocument()
   })
 
-  it("doesn't display an execute checkbox if execution is the only option", () => {
+  it('the execute checkbox is disabled if execution is the only option', () => {
     const mockTx = createSafeTx()
     const result = render(
       <SignOrExecuteForm isExecutable={true} onSubmit={jest.fn} safeTx={mockTx} onlyExecute={true} />,
     )
 
-    expect(result.queryByText('Execute transaction')).not.toBeInTheDocument()
+    expect((result.getByRole('checkbox') as HTMLInputElement).disabled).toBe(true)
   })
 
   it("doesn't display an execute checkbox if nonce is incorrect", () => {

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -196,7 +196,7 @@ const SignOrExecuteForm = ({
 
         <DecodedTx tx={tx} txId={txId} />
 
-        {canExecute && !onlyExecute && <ExecuteCheckbox checked={shouldExecute} onChange={setShouldExecute} />}
+        {canExecute && <ExecuteCheckbox checked={shouldExecute} onChange={setShouldExecute} disabled={onlyExecute} />}
 
         <AdvancedParams
           params={advancedParams}


### PR DESCRIPTION
## What it solves

A small UX improvement.

When executing a transaction, a checked Execute checkbox signals that it's an execution, not a signature.

In the "Execute" modal, the checkbox was completely hidden because it's the only option, but with this, we're losing this UI signal. So I made it a disabled checkbox instead of completely hiding it.

<img width="671" alt="Screenshot 2022-10-31 at 09 05 43" src="https://user-images.githubusercontent.com/381895/198961177-860135ee-4f13-451d-a86d-ebbad2ed1c6c.png">
