### PR TITLE
fix: add investor allocation to total

### DIFF
--- a/src/hooks/useSafeTokenAllocation.ts
+++ b/src/hooks/useSafeTokenAllocation.ts
@@ -5,14 +5,8 @@ import useSafeInfo from './useSafeInfo'
 
 export const VESTING_URL = 'https://safe-claiming-app-data.gnosis-safe.io/allocations/'
 
-enum VestingTag {
-  USER = 'user',
-  ECOSYSTEM = 'ecosystem',
-  INVESTOR = 'investor',
-}
-
 type VestingData = {
-  tag: VestingTag
+  tag: 'user' | 'ecosystem' | 'investor'
   account: string
   chainId: number
   contract: string
@@ -45,10 +39,6 @@ const fetchAllocation = async (chainId: string, safeAddress: string): Promise<Ve
   }
 }
 
-const getAllocationAmount = (allocation: VestingData[], tag: VestingTag): string => {
-  return allocation.find((data) => data.tag === tag)?.amount || '0'
-}
-
 const useSafeTokenAllocation = (): BigNumber | undefined => {
   const [allocation, setAllocation] = useState<BigNumber>()
   const { safe, safeAddress } = useSafeInfo()
@@ -62,11 +52,7 @@ const useSafeTokenAllocation = (): BigNumber | undefined => {
   useEffect(() => {
     if (!allocationData) return
 
-    const userAllocation = getAllocationAmount(allocationData, VestingTag.USER)
-    const ecosystemAllocation = getAllocationAmount(allocationData, VestingTag.ECOSYSTEM)
-    const investorAllocation = getAllocationAmount(allocationData, VestingTag.INVESTOR)
-
-    const totalAllocation = BigNumber.from(userAllocation).add(ecosystemAllocation).add(investorAllocation)
+    const totalAllocation = allocationData.reduce((acc, data) => acc.add(data.amount), BigNumber.from(0))
 
     setAllocation(totalAllocation)
   }, [allocationData])

--- a/src/hooks/useSafeTokenAllocation.ts
+++ b/src/hooks/useSafeTokenAllocation.ts
@@ -5,8 +5,14 @@ import useSafeInfo from './useSafeInfo'
 
 export const VESTING_URL = 'https://safe-claiming-app-data.gnosis-safe.io/allocations/'
 
-export type VestingData = {
-  tag: 'user' | 'ecosystem'
+enum VestingTag {
+  USER = 'user',
+  ECOSYSTEM = 'ecosystem',
+  INVESTOR = 'investor',
+}
+
+type VestingData = {
+  tag: VestingTag
   account: string
   chainId: number
   contract: string
@@ -39,6 +45,10 @@ const fetchAllocation = async (chainId: string, safeAddress: string): Promise<Ve
   }
 }
 
+const getAllocationAmount = (allocation: VestingData[], tag: VestingTag): string => {
+  return allocation.find((data) => data.tag === tag)?.amount || '0'
+}
+
 const useSafeTokenAllocation = (): BigNumber | undefined => {
   const [allocation, setAllocation] = useState<BigNumber>()
   const { safe, safeAddress } = useSafeInfo()
@@ -52,9 +62,11 @@ const useSafeTokenAllocation = (): BigNumber | undefined => {
   useEffect(() => {
     if (!allocationData) return
 
-    const userAllocation = allocationData.find((data) => data.tag === 'user')
-    const ecosystemAllocation = allocationData.find((data) => data.tag === 'ecosystem')
-    const totalAllocation = BigNumber.from(userAllocation?.amount || '0').add(ecosystemAllocation?.amount || '0')
+    const userAllocation = getAllocationAmount(allocationData, VestingTag.USER)
+    const ecosystemAllocation = getAllocationAmount(allocationData, VestingTag.ECOSYSTEM)
+    const investorAllocation = getAllocationAmount(allocationData, VestingTag.INVESTOR)
+
+    const totalAllocation = BigNumber.from(userAllocation).add(ecosystemAllocation).add(investorAllocation)
 
     setAllocation(totalAllocation)
   }, [allocationData])


### PR DESCRIPTION
## What it solves

Resolves #1004

## How this PR fixes it

All allocation `amount`s are added together.

## How to test it

Open an [investor Safe](https://github.com/safe-global/claiming-app-data/blob/main/vestings/assets/1/investor_vestings.csv), e.g. `eth:0xfB2aD9007F2D62a973f71Af206242eE4bD790b2C` and observe the amount shown in the header now includes their vested amounts as well.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/199211881-2e8d9c1f-6007-4bbc-bb7a-b6b39e949647.png)