### PR TITLE
fix: hide widget when no Safe address exists

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -13,6 +13,7 @@ import { AppRoutes } from '@/config/routes'
 import useChainId from '@/hooks/useChainId'
 import SafeLogo from '@/public/images/logo.svg'
 import Link from 'next/link'
+import useSafeAddress from '@/hooks/useSafeAddress'
 
 type HeaderProps = {
   onMenuToggle: () => void
@@ -20,7 +21,8 @@ type HeaderProps = {
 
 const Header = ({ onMenuToggle }: HeaderProps): ReactElement => {
   const chainId = useChainId()
-  const showSafeToken = !!getSafeTokenAddress(chainId)
+  const safeAddress = useSafeAddress()
+  const showSafeToken = safeAddress && !!getSafeTokenAddress(chainId)
   const router = useRouter()
 
   // Logo link: if on Dashboard, link to Welcome, otherwise to the root (which redirects to either Dashboard or Welcome)


### PR DESCRIPTION
## What it solves

Resolves empty widget container in header.

## How this PR fixes it

If no Safe address exists, the widget is not rendered.

## How to test it

Open Safe creation and observe no empty widget container:

![image](https://user-images.githubusercontent.com/20442784/199221807-00a90714-83de-4c1a-8f93-1025cea9bc4b.png)