### PR TITLE
fix: selected sidebar item

### DIFF
--- a/src/components/sidebar/SidebarNavigation/index.tsx
+++ b/src/components/sidebar/SidebarNavigation/index.tsx
@@ -13,9 +13,14 @@ import { navItems } from './config'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { AppRoutes } from '@/config/routes'
 
+const getSubdirectory = (pathname: string): string => {
+  return pathname.split('/')[1]
+}
+
 const Navigation = (): ReactElement => {
   const router = useRouter()
   const { safe } = useSafeInfo()
+  const currentSubdirectory = getSubdirectory(router.pathname)
 
   // Indicate whether the current Safe needs an upgrade
   const setupItem = navItems.find((item) => item.href === AppRoutes.settings.setup)
@@ -26,8 +31,7 @@ const Navigation = (): ReactElement => {
   return (
     <SidebarList>
       {navItems.map((item) => {
-        const subdirectory = item.href.split('/')[1]
-        const isSelected = router.pathname.includes(subdirectory)
+        const isSelected = currentSubdirectory === getSubdirectory(item.href)
 
         return (
           <ListItem key={item.href} disablePadding selected={isSelected}>


### PR DESCRIPTION
## What it solves

Resolves #1020

## How this PR fixes it

Sidebar links are not strictly compared to the current `pathname`.

## How to test it

Open "Safe Apps permissions" in settings and observe that only "Settings" are selected in the sidebar.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/199239626-4799f827-b7c4-4237-b478-0e343b62ec86.png)