### PR TITLE
fix: initial pageview event

### DIFF
--- a/src/services/analytics/useGtm.ts
+++ b/src/services/analytics/useGtm.ts
@@ -30,10 +30,10 @@ const useGtm = () => {
   // Track page views – anononimized by default.
   // Sensitive info, like the safe address or tx id, is always in the query string, which we DO NOT track.
   useEffect(() => {
-    if (router.pathname !== AppRoutes['404']) {
+    if (isAnalyticsEnabled && router.pathname !== AppRoutes['404']) {
       gtmTrackPageview(router.pathname)
     }
-  }, [router.pathname])
+  }, [isAnalyticsEnabled, router.pathname])
 }
 
 export default useGtm


### PR DESCRIPTION
## What it solves

Resolves initial pageviews not being tracked.

## How this PR fixes it

The cookie policy is checked before attempting to dispatch a pageview (which ensures GTM is enabled).

## How to test it

Open the Safe in GTM debug view and refresh. Observe the intial pageview being tracked.

## Analytics changes

Intial pageview is now successfully tracked.