### PR TITLE
refactor: GTM

### DIFF
--- a/src/services/analytics/TagManager.ts
+++ b/src/services/analytics/TagManager.ts
@@ -48,11 +48,6 @@ export const _getGtmScript = ({ gtmId, auth, preview }: TagManagerArgs) => {
 // Data layer scripts
 
 const TagManager = {
-  dataLayer: (dataLayer: DataLayer) => {
-    window[DATA_LAYER_NAME] ||= []
-
-    return window[DATA_LAYER_NAME].push(dataLayer)
-  },
   initialize: ({ dataLayer, ...args }: TagManagerArgs) => {
     if (dataLayer) {
       TagManager.dataLayer(dataLayer)
@@ -60,6 +55,11 @@ const TagManager = {
 
     const gtmScript = _getGtmScript(args)
     document.head.insertBefore(gtmScript, document.head.childNodes[0])
+  },
+  dataLayer: (dataLayer: DataLayer) => {
+    window[DATA_LAYER_NAME] ||= []
+
+    return window[DATA_LAYER_NAME].push(dataLayer)
   },
 }
 

--- a/src/services/analytics/TagManager.ts
+++ b/src/services/analytics/TagManager.ts
@@ -21,7 +21,7 @@ export type TagManagerArgs = {
   dataLayer?: DataLayer
 }
 
-export const DATA_LAYER_NAME = 'dataLayer'
+const DATA_LAYER_NAME = 'dataLayer'
 
 // Initialization scripts
 

--- a/src/services/analytics/__tests__/TagManager.test.ts
+++ b/src/services/analytics/__tests__/TagManager.test.ts
@@ -14,8 +14,8 @@ describe('TagManager', () => {
       const script1 = _getGtmScript({ gtmId: MOCK_ID, auth: MOCK_AUTH, preview: MOCK_PREVIEW })
 
       expect(script1.innerHTML).toContain(MOCK_ID)
-      expect(script1.innerHTML).not.toContain(`&gtm_auth=${MOCK_AUTH}`)
-      expect(script1.innerHTML).not.toContain(`&gtm_auth=${MOCK_PREVIEW}`)
+      expect(script1.innerHTML).toContain(`&gtm_auth=${MOCK_AUTH}`)
+      expect(script1.innerHTML).toContain(`&gtm_preview=${MOCK_PREVIEW}`)
       expect(script1.innerHTML).toContain('dataLayer')
     })
   })

--- a/src/services/analytics/__tests__/TagManager.test.ts
+++ b/src/services/analytics/__tests__/TagManager.test.ts
@@ -1,77 +1,39 @@
-import TagManager, { _getGtmDataLayerScript, _getGtmScript, _getRequiredGtmArgs } from '../TagManager'
+import TagManager, { _getGtmScript } from '../TagManager'
 
 const MOCK_ID = 'GTM-123456'
+const MOCK_AUTH = 'key123'
+const MOCK_PREVIEW = 'env-0'
 
 describe('TagManager', () => {
   beforeEach(() => {
     delete window.dataLayer
   })
 
-  describe('getRequiredGtmArgs', () => {
-    it('should assign default arguments', () => {
-      const result1 = _getRequiredGtmArgs({ gtmId: MOCK_ID })
-
-      expect(result1).toStrictEqual({
-        gtmId: MOCK_ID,
-        dataLayer: undefined,
-        auth: '',
-        preview: '',
-      })
-
-      const result2 = _getRequiredGtmArgs({ gtmId: MOCK_ID, auth: 'abcdefg', preview: 'env-1' })
-
-      expect(result2).toStrictEqual({
-        gtmId: MOCK_ID,
-        dataLayer: undefined,
-        auth: '&gtm_auth=abcdefg',
-        preview: '&gtm_preview=env-1',
-      })
-    })
-  })
-
   describe('getGtmScript', () => {
-    it('should use the id', () => {
-      const script1 = _getGtmScript({ gtmId: MOCK_ID })
+    it('should use the id, auth and preview', () => {
+      const script1 = _getGtmScript({ gtmId: MOCK_ID, auth: MOCK_AUTH, preview: MOCK_PREVIEW })
 
       expect(script1.innerHTML).toContain(MOCK_ID)
+      expect(script1.innerHTML).not.toContain(`&gtm_auth=${MOCK_AUTH}`)
+      expect(script1.innerHTML).not.toContain(`&gtm_auth=${MOCK_PREVIEW}`)
       expect(script1.innerHTML).toContain('dataLayer')
-    })
-
-    it('should use the auth and preview if present', () => {
-      const script1 = _getGtmScript({
-        gtmId: MOCK_ID,
-      })
-
-      expect(script1.innerHTML).not.toContain('&gtm_auth')
-      expect(script1.innerHTML).not.toContain('&gtm_preview')
-
-      const script2 = _getGtmScript({
-        gtmId: MOCK_ID,
-        auth: 'abcdefg',
-        preview: 'env-1',
-      })
-
-      expect(script2.innerHTML).toContain('&gtm_auth=abcdefg&gtm_preview=env-1')
-    })
-  })
-
-  describe('getGtmDataLayerScript', () => {
-    it('should use the `dataLayer` for the script', () => {
-      const dataLayerScript = _getGtmDataLayerScript({
-        gtmId: MOCK_ID,
-        dataLayer: { foo: 'bar' },
-      })
-
-      expect(dataLayerScript.innerHTML).toContain('{"foo":"bar"}')
     })
   })
 
   describe('TagManager.initialize', () => {
     it('should initialize TagManager', () => {
-      TagManager.initialize({ gtmId: MOCK_ID })
+      TagManager.initialize({ gtmId: MOCK_ID, auth: MOCK_AUTH, preview: MOCK_PREVIEW })
 
       expect(window.dataLayer).toHaveLength(1)
       expect(window.dataLayer[0]).toStrictEqual({ event: 'gtm.js', 'gtm.start': expect.any(Number) })
+    })
+
+    it('should push to the dataLayer if povided', () => {
+      TagManager.initialize({ gtmId: MOCK_ID, auth: MOCK_AUTH, preview: MOCK_PREVIEW, dataLayer: { test: '456' } })
+
+      expect(window.dataLayer).toHaveLength(2)
+      expect(window.dataLayer[0]).toStrictEqual({ test: '456' })
+      expect(window.dataLayer[1]).toStrictEqual({ event: 'gtm.js', 'gtm.start': expect.any(Number) })
     })
   })
 

--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -84,8 +84,6 @@ type PageviewGtmEvent = GtmEvent & {
 }
 
 const gtmSend = (event: GtmEvent): void => {
-  console.info('[Analytics]', event)
-
   TagManager.dataLayer(event)
 }
 

--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -9,7 +9,6 @@
 
 import type { TagManagerArgs } from './TagManager'
 import TagManager from './TagManager'
-import Cookies from 'js-cookie'
 import type { SafeAppData } from '@gnosis.pm/safe-react-gateway-sdk'
 import {
   IS_PRODUCTION,
@@ -23,9 +22,6 @@ import { EventType } from './types'
 
 type GTMEnvironment = 'LIVE' | 'LATEST' | 'DEVELOPMENT'
 type GTMEnvironmentArgs = Required<Pick<TagManagerArgs, 'auth' | 'preview'>>
-
-const GOOGLE_ANALYTICS_COOKIE_LIST = ['_ga', '_gat', '_gid']
-const EMPTY_SAFE_APP = 'unknown'
 
 const GTM_ENV_AUTH: Record<GTMEnvironment, GTMEnvironmentArgs> = {
   LIVE: {
@@ -68,12 +64,7 @@ export const gtmInit = (): void => {
 }
 
 export const gtmClear = (): void => {
-  // Delete GA cookies
-  const path = '/'
-  const domain = `.${location.host.split('.').slice(-2).join('.')}`
-  GOOGLE_ANALYTICS_COOKIE_LIST.forEach((cookie) => {
-    Cookies.remove(cookie, { path, domain })
-  })
+  TagManager.destroy()
 }
 
 type GtmEvent = {
@@ -135,6 +126,8 @@ export const gtmTrackSafeAppMessage = ({
   params?: any
   sdkVersion?: string
 }): void => {
+  const EMPTY_SAFE_APP = 'unknown'
+
   const gtmEvent: SafeAppEvent = {
     event: EventType.SAFE_APP,
     chainId: _chainId,

--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -8,7 +8,7 @@
  */
 
 import type { TagManagerArgs } from './TagManager'
-import TagManager, { DATA_LAYER_NAME } from './TagManager'
+import TagManager from './TagManager'
 import Cookies from 'js-cookie'
 import type { SafeAppData } from '@gnosis.pm/safe-react-gateway-sdk'
 import {
@@ -67,13 +67,7 @@ export const gtmInit = (): void => {
   })
 }
 
-const isGtmLoaded = (): boolean => {
-  return typeof window !== 'undefined' && !!window[DATA_LAYER_NAME]
-}
-
 export const gtmClear = (): void => {
-  if (!isGtmLoaded()) return
-
   // Delete GA cookies
   const path = '/'
   const domain = `.${location.host.split('.').slice(-2).join('.')}`
@@ -100,8 +94,6 @@ type PageviewGtmEvent = GtmEvent & {
 
 const gtmSend = (event: GtmEvent): void => {
   console.info('[Analytics]', event)
-
-  if (!isGtmLoaded()) return
 
   TagManager.dataLayer(event)
 }


### PR DESCRIPTION
## What it solves

Simplifies GTM loading and adds event stacking.

## How this PR fixes it

- `TagManager.initialize` and `TagManager.dataLayer` have been simplified. Most notably, the `dataLayer` is **always** pushed to as GTM will send these events after initialisation.
- GTM is now fully removed on `destroy` as well as cookies being removed. (Before it was not unmounted).
- Logging now reflects what is being sent to GTM.
- An unnecessary `isGtmLoaded` flag was also removed.

## How to test it

### Refactor

- GTM should initialise and events should be sent as before. (make sure the intial `pageview` works especially)
- No errors/warnings should be shown in the console if the cookie preferences are changed,
- When disabling "Analytics" preferences, the GTM tag should be removed. (no tracking visible in Network tab)

### Event stacking

Note: ensure this is being tested on a cold cache. (We need to check the legality of this).

1. Open the Safe and DO NOT agree to "Analytics" cookies but keep the banner open.
2. Click around the Safe, navigate to different pages, etc. Observe no events in GTM.
3. Accept the "Analytics" cookies and observe all of the events that _should've_ been sent now appear in GTM.

## Analytics changes

Events are now stacked regardless of cookie policy. They are NOT sent to GTM unless agreed to.