### PR TITLE
fix: propose transaction with `origin`

### DIFF
--- a/src/components/safe-apps/SafeAppsTxModal/ReviewSafeAppsTx.tsx
+++ b/src/components/safe-apps/SafeAppsTxModal/ReviewSafeAppsTx.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import type { ReactElement } from 'react'
 import type { DecodedDataResponse } from '@gnosis.pm/safe-react-gateway-sdk'
 import { getDecodedData, Operation } from '@gnosis.pm/safe-react-gateway-sdk'
@@ -19,12 +20,15 @@ import type { SafeAppsTxParams } from '.'
 import { isEmptyHexData } from '@/utils/hex'
 import { dispatchSafeAppsTx } from '@/services/tx/txSender'
 import { trackSafeAppTxCount } from '@/services/safe-apps/track-app-usage-count'
+import { getTxOrigin } from '@/utils/transactions'
 
 type ReviewSafeAppsTxProps = {
   safeAppsTx: SafeAppsTxParams
 }
 
-const ReviewSafeAppsTx = ({ safeAppsTx: { txs, requestId, params, appId } }: ReviewSafeAppsTxProps): ReactElement => {
+const ReviewSafeAppsTx = ({
+  safeAppsTx: { txs, requestId, params, appId, app },
+}: ReviewSafeAppsTxProps): ReactElement => {
   const chainId = useChainId()
   const chain = useCurrentChain()
 
@@ -53,8 +57,10 @@ const ReviewSafeAppsTx = ({ safeAppsTx: { txs, requestId, params, appId } }: Rev
     dispatchSafeAppsTx(txId, requestId)
   }
 
+  const origin = useMemo(() => getTxOrigin(app), [app])
+
   return (
-    <SignOrExecuteForm safeTx={safeTx} onSubmit={handleSubmit} error={safeTxError}>
+    <SignOrExecuteForm safeTx={safeTx} onSubmit={handleSubmit} error={safeTxError} origin={origin}>
       <>
         <SendFromBlock />
 

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -39,6 +39,7 @@ type SignOrExecuteProps = {
   isRejection?: boolean
   onlyExecute?: boolean
   disableSubmit?: boolean
+  origin?: string
 }
 
 const SignOrExecuteForm = ({
@@ -50,6 +51,7 @@ const SignOrExecuteForm = ({
   isExecutable = false,
   isRejection = false,
   disableSubmit = false,
+  origin,
   ...props
 }: SignOrExecuteProps): ReactElement => {
   //
@@ -108,7 +110,14 @@ const SignOrExecuteForm = ({
 
   // Propose transaction if no txId
   const proposeTx = async (newTx: SafeTransaction): Promise<string> => {
-    const proposedTx = await dispatchTxProposal(safe.chainId, safeAddress, wallet!.address, newTx, txId)
+    const proposedTx = await dispatchTxProposal({
+      chainId: safe.chainId,
+      safeAddress,
+      sender: wallet!.address,
+      safeTx: newTx,
+      txId,
+      origin,
+    })
     return proposedTx.txId
   }
 

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -38,6 +38,7 @@ enum ErrorCodes {
   _804 = '804: Error processing a transaction',
   _806 = '806: Failed to remove module',
   _807 = '807: Failed to remove guard',
+  _808 = '808: Failed to get transaction origin',
 
   _900 = '900: Error loading Safe App',
   _901 = '901: Error processing Safe Apps SDK request',

--- a/src/services/tx/__tests__/txSender.test.ts
+++ b/src/services/tx/__tests__/txSender.test.ts
@@ -164,9 +164,9 @@ describe('txSender', () => {
         data: '0x0',
       })
 
-      const proposedTx = await dispatchTxProposal('4', '0x123', '0x456', tx)
+      const proposedTx = await dispatchTxProposal({ chainId: '4', safeAddress: '0x123', sender: '0x456', safeTx: tx })
 
-      expect(proposeTx).toHaveBeenCalledWith('4', '0x123', '0x456', tx, '0x1234567890')
+      expect(proposeTx).toHaveBeenCalledWith('4', '0x123', '0x456', tx, '0x1234567890', undefined)
       expect(proposedTx).toEqual({ txId: '123' })
 
       expect(txEvents.txDispatch).toHaveBeenCalledWith('PROPOSED', { txId: '123' })
@@ -179,9 +179,15 @@ describe('txSender', () => {
         data: '0x0',
       })
 
-      const proposedTx = await dispatchTxProposal('4', '0x123', '0x456', tx, '345')
+      const proposedTx = await dispatchTxProposal({
+        chainId: '4',
+        safeAddress: '0x123',
+        sender: '0x456',
+        safeTx: tx,
+        txId: '345',
+      })
 
-      expect(proposeTx).toHaveBeenCalledWith('4', '0x123', '0x456', tx, '0x1234567890')
+      expect(proposeTx).toHaveBeenCalledWith('4', '0x123', '0x456', tx, '0x1234567890', undefined)
       expect(proposedTx).toEqual({ txId: '123' })
 
       expect(txEvents.txDispatch).toHaveBeenCalledWith('SIGNATURE_PROPOSED', { txId: '123', signerAddress: '0x456' })
@@ -196,7 +202,9 @@ describe('txSender', () => {
         data: '0x0',
       })
 
-      await expect(dispatchTxProposal('4', '0x123', '0x456', tx, '345')).rejects.toThrow('error')
+      await expect(
+        dispatchTxProposal({ chainId: '4', safeAddress: '0x123', sender: '0x456', safeTx: tx, txId: '345' }),
+      ).rejects.toThrow('error')
 
       expect(txEvents.txDispatch).toHaveBeenCalledWith('SIGNATURE_PROPOSE_FAILED', {
         txId: '345',
@@ -213,7 +221,9 @@ describe('txSender', () => {
         data: '0x0',
       })
 
-      await expect(dispatchTxProposal('4', '0x123', '0x456', tx)).rejects.toThrow('error')
+      await expect(
+        dispatchTxProposal({ chainId: '4', safeAddress: '0x123', sender: '0x456', safeTx: tx }),
+      ).rejects.toThrow('error')
 
       expect(txEvents.txDispatch).toHaveBeenCalledWith('PROPOSE_FAILED', {
         error: new Error('error'),

--- a/src/services/tx/proposeTransaction.ts
+++ b/src/services/tx/proposeTransaction.ts
@@ -8,6 +8,7 @@ const proposeTx = async (
   sender: string,
   tx: SafeTransaction,
   safeTxHash: string,
+  origin?: string,
 ): Promise<TransactionDetails> => {
   const signatures = tx.signatures.size ? tx.encodedSignatures() : undefined
 
@@ -22,6 +23,7 @@ const proposeTx = async (
     baseGas: tx.data.baseGas.toString(),
     gasPrice: tx.data.gasPrice.toString(),
     signature: signatures,
+    origin,
   })
 }
 

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -195,19 +195,27 @@ export const createExistingTx = async (
  * Propose a transaction
  * If txId is passed, it's an existing tx being signed
  */
-export const dispatchTxProposal = async (
-  chainId: string,
-  safeAddress: string,
-  sender: string,
-  safeTx: SafeTransaction,
-  txId?: string,
-): Promise<TransactionDetails> => {
+export const dispatchTxProposal = async ({
+  chainId,
+  safeAddress,
+  sender,
+  safeTx,
+  txId,
+  origin,
+}: {
+  chainId: string
+  safeAddress: string
+  sender: string
+  safeTx: SafeTransaction
+  txId?: string
+  origin?: string
+}): Promise<TransactionDetails> => {
   const safeSDK = getAndValidateSafeSDK()
   const safeTxHash = await safeSDK.getTransactionHash(safeTx)
 
   let proposedTx: TransactionDetails | undefined
   try {
-    proposedTx = await proposeTx(chainId, safeAddress, sender, safeTx, safeTxHash)
+    proposedTx = await proposeTx(chainId, safeAddress, sender, safeTx, safeTxHash, origin)
   } catch (error) {
     if (txId) {
       txDispatch(TxEvent.SIGNATURE_PROPOSE_FAILED, { txId, error: error as Error })

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -3,6 +3,7 @@ import type {
   ExecutionInfo,
   MultisigExecutionDetails,
   MultisigExecutionInfo,
+  SafeAppData,
   Transaction,
   TransactionDetails,
   TransactionListPage,
@@ -29,6 +30,7 @@ import type { AdvancedParameters } from '@/components/tx/AdvancedParams'
 import type { TransactionOptions } from '@gnosis.pm/safe-core-sdk-types'
 import { hasFeature } from '@/utils/chains'
 import uniqBy from 'lodash/uniqBy'
+import { Errors, logError } from '@/services/exceptions'
 
 export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction => {
   const getMissingSigners = ({
@@ -183,4 +185,20 @@ export const getQueuedTransactionCount = (txPage?: TransactionListPage): string 
   }
 
   return queuedTxsByNonce.length.toString()
+}
+
+export const getTxOrigin = (app?: SafeAppData): string | undefined => {
+  if (!app) {
+    return undefined
+  }
+
+  let origin: string | undefined
+
+  try {
+    origin = JSON.stringify({ name: app.name, url: app.url })
+  } catch (e) {
+    logError(Errors._808, (e as Error).message)
+  }
+
+  return origin
 }

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -189,7 +189,7 @@ export const getQueuedTransactionCount = (txPage?: TransactionListPage): string 
 
 export const getTxOrigin = (app?: SafeAppData): string | undefined => {
   if (!app) {
-    return undefined
+    return
   }
 
   let origin: string | undefined


### PR DESCRIPTION
## What it solves

Resolves #1035 

## How this PR fixes it

The `origin` is now proposed with transactions when created via a Safe App.

## How to test it

Create a transaction via the Transaction Builder and observe the logo/name in the transaction list.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/199544166-9ef7509f-21b0-4d7b-8ecc-e0232694fd77.png)