### PR TITLE
fix: footer release link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-core",
-  "homepage": "https://github.com/5afe/web-core",
+  "homepage": "https://github.com/safe-global/web-core",
   "license": "MIT",
   "type": "module",
   "version": "1.0.2",

--- a/src/components/common/Footer/index.tsx
+++ b/src/components/common/Footer/index.tsx
@@ -62,7 +62,7 @@ const Footer = (): ReactElement | null => {
           <Link
             rel="noopener noreferrer"
             target="_blank"
-            href={`${packageJson.homepage}/releases/tags/${packageJson.version}`}
+            href={`${packageJson.homepage}/releases/tag/v${packageJson.version}`}
           >
             v{packageJson.version}
           </Link>


### PR DESCRIPTION
## What it solves

Broken footer link

## How this PR fixes it

The `homepage` in `package.json` has been updated to the correct repository, as well as the link corrected to match our release naming format.

## How to test it

Click the version number in the footer and observe the latest release opens.