### PR TITLE
fix: Anonymize safe address on gtm init

### DIFF
--- a/src/hooks/useChainId.ts
+++ b/src/hooks/useChainId.ts
@@ -5,6 +5,7 @@ import chains from '@/config/chains'
 import { useAppSelector } from '@/store'
 import { selectSession } from '@/store/sessionSlice'
 import { parsePrefixedAddress } from '@/utils/addresses'
+import { prefixedAddressRe } from '@/utils/url'
 
 const defaultChainId = IS_PRODUCTION ? chains.eth : chains.gor
 
@@ -15,7 +16,6 @@ const getLocationQuery = (): ParsedUrlQuery => {
   const query = parse(location.search.slice(1))
 
   if (!query.safe) {
-    const prefixedAddressRe = /[a-z0-9-]+\:0x[a-f0-9]{40}/i
     const pathParam = location.pathname.split('/')[1]
     const safeParam = prefixedAddressRe.test(pathParam) ? pathParam : ''
 

--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -20,7 +20,6 @@ import {
 } from '@/config/constants'
 import type { AnalyticsEvent, EventLabel, SafeAppEvent } from './types'
 import { EventType } from './types'
-import { addressRe, prefixedAddressRe } from '@/utils/url'
 
 type GTMEnvironment = 'LIVE' | 'LATEST' | 'DEVELOPMENT'
 type GTMEnvironmentArgs = Required<Pick<TagManagerArgs, 'auth' | 'preview'>>
@@ -49,34 +48,13 @@ export const gtmSetChainId = (chainId: string): void => {
   _chainId = chainId
 }
 
-export const getAnonymizedPathname = (pathname: string = location.pathname): string => {
-  const ANON_SAFE_ADDRESS = 'SAFE_ADDRESS'
-
-  let anonPathname = pathname
-
-  // Anonymize safe address
-  const prefixedSafeAddressMatch = prefixedAddressRe.test(pathname)
-  if (prefixedSafeAddressMatch) {
-    anonPathname = anonPathname.replace(prefixedAddressRe, ANON_SAFE_ADDRESS)
-  }
-
-  const safeAddressMatch = addressRe.test(pathname)
-  if (safeAddressMatch) {
-    anonPathname = anonPathname.replace(addressRe, ANON_SAFE_ADDRESS)
-  }
-
-  return anonPathname
-}
-
-export const gtmInit = (): void => {
+export const gtmInit = (pagePath: string): void => {
   const GTM_ENVIRONMENT = IS_PRODUCTION ? GTM_ENV_AUTH.LIVE : GTM_ENV_AUTH.DEVELOPMENT
 
   if (!GOOGLE_TAG_MANAGER_ID || !GTM_ENVIRONMENT.auth) {
     console.warn('[GTM] - Unable to initialize Google Tag Manager. `id` or `gtm_auth` missing.')
     return
   }
-
-  const pagePath = getAnonymizedPathname()
 
   TagManager.initialize({
     gtmId: GOOGLE_TAG_MANAGER_ID,

--- a/src/services/analytics/useGtm.ts
+++ b/src/services/analytics/useGtm.ts
@@ -19,7 +19,8 @@ const useGtm = () => {
 
   // Initialize GTM, or clear it if analytics is disabled
   useEffect(() => {
-    isAnalyticsEnabled ? gtmInit() : gtmClear()
+    isAnalyticsEnabled ? gtmInit(router.pathname) : gtmClear()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAnalyticsEnabled])
 
   // Set the chain ID for GTM

--- a/src/services/analytics/useGtm.ts
+++ b/src/services/analytics/useGtm.ts
@@ -19,6 +19,8 @@ const useGtm = () => {
 
   // Initialize GTM, or clear it if analytics is disabled
   useEffect(() => {
+    // router.pathname doesn't contain the safe address
+    // so we can override the initial dataLayer
     isAnalyticsEnabled ? gtmInit(router.pathname) : gtmClear()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAnalyticsEnabled])

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -5,7 +5,8 @@ const trimTrailingSlash = (url: string): string => {
 const isSameUrl = (url1: string, url2: string): boolean => {
   return trimTrailingSlash(url1) === trimTrailingSlash(url2)
 }
-
+export const prefixedAddressRe = /[a-z0-9-]+\:0x[a-f0-9]{40}/i
+export const addressRe = /0x[a-f0-9]{40}/i
 const invalidProtocolRegex = /^(\W*)(javascript|data|vbscript)/im
 const ctrlCharactersRegex = /[\u0000-\u001F\u007F-\u009F\u2000-\u200D\uFEFF]/gim
 const urlSchemeRegex = /^([^:]+):/gm

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -6,7 +6,6 @@ const isSameUrl = (url1: string, url2: string): boolean => {
   return trimTrailingSlash(url1) === trimTrailingSlash(url2)
 }
 export const prefixedAddressRe = /[a-z0-9-]+\:0x[a-f0-9]{40}/i
-export const addressRe = /0x[a-f0-9]{40}/i
 const invalidProtocolRegex = /^(\W*)(javascript|data|vbscript)/im
 const ctrlCharactersRegex = /[\u0000-\u001F\u007F-\u009F\u2000-\u200D\uFEFF]/gim
 const urlSchemeRegex = /^([^:]+):/gm


### PR DESCRIPTION
## What it solves

Resolves #1034 

## How this PR fixes it

Sets anonymized path and location in dataLayer when initializing GTM

## How to test it

1. Open the Safe with DebugView
2. Reload the page
3. Scroll around
4. Observe a `user_engagement` event with anonymized path and location values

## Screenshots
<img width="343" alt="Screenshot 2022-11-03 at 09 10 30" src="https://user-images.githubusercontent.com/5880855/199677378-d13089ef-c53e-4b2a-a8c7-2b99a13228aa.png">
<img width="346" alt="Screenshot 2022-11-03 at 09 10 33" src="https://user-images.githubusercontent.com/5880855/199677383-3ba929ef-a55a-4055-8ef4-d4dfdecc3341.png">


