### PR TITLE
feat: add `TagManager.destroy` functionilty

### DIFF
--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -9,7 +9,6 @@
 
 import type { TagManagerArgs } from './TagManager'
 import TagManager, { DATA_LAYER_NAME } from './TagManager'
-import Cookies from 'js-cookie'
 import type { SafeAppData } from '@gnosis.pm/safe-react-gateway-sdk'
 import {
   IS_PRODUCTION,
@@ -24,7 +23,6 @@ import { EventType } from './types'
 type GTMEnvironment = 'LIVE' | 'LATEST' | 'DEVELOPMENT'
 type GTMEnvironmentArgs = Required<Pick<TagManagerArgs, 'auth' | 'preview'>>
 
-const GOOGLE_ANALYTICS_COOKIE_LIST = ['_ga', '_gat', '_gid']
 const EMPTY_SAFE_APP = 'unknown'
 
 const GTM_ENV_AUTH: Record<GTMEnvironment, GTMEnvironmentArgs> = {
@@ -74,12 +72,7 @@ const isGtmLoaded = (): boolean => {
 export const gtmClear = (): void => {
   if (!isGtmLoaded()) return
 
-  // Delete GA cookies
-  const path = '/'
-  const domain = `.${location.host.split('.').slice(-2).join('.')}`
-  GOOGLE_ANALYTICS_COOKIE_LIST.forEach((cookie) => {
-    Cookies.remove(cookie, { path, domain })
-  })
+  TagManager.destroy()
 }
 
 type GtmEvent = {


### PR DESCRIPTION
## What it solves

GTM not unmounting on approval revoke.

## How this PR fixes it

Both GTM scripts are now stored in singleton variables and their `remove` method is called inside `TagManager.destroy`, alongside cookies removed. It is called inside `gtmClear`.

## How to test it

1. Open the Safe, accepting Analytics. Observe it working as usual.
2. Revoke "Analytics" approval and observe no tracking activity in the Network tab.

## Analytics changes

GTM is completely unmounted on approval revocation.