### PR TITLE
feat: replace specific transactions

### DIFF
--- a/src/components/transactions/RejectTxButton/index.tsx
+++ b/src/components/transactions/RejectTxButton/index.tsx
@@ -1,17 +1,19 @@
 import type { TransactionSummary } from '@gnosis.pm/safe-react-gateway-sdk'
 import { Button, Tooltip, SvgIcon } from '@mui/material'
 
-import type { SyntheticEvent } from 'react'
-import { useState, type ReactElement } from 'react'
+import type { SyntheticEvent, ReactElement } from 'react'
+import { useState, Suspense } from 'react'
 import { useQueuedTxByNonce } from '@/hooks/useTxQueue'
 import { isCustomTxInfo, isMultisigExecutionInfo } from '@/utils/transaction-guards'
-import RejectTxModal from '@/components/tx/modals/RejectTxModal'
+import dynamic from 'next/dynamic'
 import useIsPending from '@/hooks/useIsPending'
 import IconButton from '@mui/material/IconButton'
 import ErrorIcon from '@/public/images/notifications/error.svg'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import Track from '@/components/common/Track'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
+
+const NewTxModal = dynamic(() => import('@/components/tx/modals/NewTxModal'))
 
 const RejectTxButton = ({
   txSummary,
@@ -42,7 +44,7 @@ const RejectTxButton = ({
     <>
       <Track {...TX_LIST_EVENTS.REJECT}>
         {compact ? (
-          <Tooltip title="Reject" arrow placement="top">
+          <Tooltip title="Replace" arrow placement="top">
             <span>
               <IconButton onClick={onClick} color="error" size="small" disabled={isDisabled}>
                 <SvgIcon component={ErrorIcon} inheritViewBox fontSize="small" />
@@ -51,12 +53,16 @@ const RejectTxButton = ({
           </Tooltip>
         ) : (
           <Button onClick={onClick} variant="danger" disabled={isDisabled} size="stretched">
-            Reject
+            Replace
           </Button>
         )}
       </Track>
 
-      {open && <RejectTxModal onClose={() => setOpen(false)} initialData={[txSummary]} />}
+      {open && (
+        <Suspense>
+          <NewTxModal onClose={() => setOpen(false)} nonce={txNonce} />
+        </Suspense>
+      )}
     </>
   )
 }

--- a/src/components/transactions/RejectTxButton/index.tsx
+++ b/src/components/transactions/RejectTxButton/index.tsx
@@ -60,7 +60,7 @@ const RejectTxButton = ({
 
       {open && (
         <Suspense>
-          <NewTxModal onClose={() => setOpen(false)} nonce={txNonce} />
+          <NewTxModal onClose={() => setOpen(false)} txNonce={txNonce} />
         </Suspense>
       )}
     </>

--- a/src/components/tx/modals/NewTxModal/index.tsx
+++ b/src/components/tx/modals/NewTxModal/index.tsx
@@ -108,8 +108,8 @@ const NewTxModal = ({
             </TxButton>
 
             {txNonce && (
-              <TxButton onClick={onRejectModalOpen} variant="danger">
-                Rejection transaction
+              <TxButton onClick={onRejectModalOpen} variant="outlined">
+                Empty transaction
               </TxButton>
             )}
 

--- a/src/components/tx/modals/NewTxModal/index.tsx
+++ b/src/components/tx/modals/NewTxModal/index.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactElement } from 'react'
-import { Box, Button, type ButtonProps, DialogContent, SvgIcon } from '@mui/material'
+import { Box, Button, type ButtonProps, DialogContent, SvgIcon, Tooltip } from '@mui/material'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import type { UrlObject } from 'url'
@@ -15,6 +15,7 @@ import { SendAssetsField } from '../TokenTransferModal/SendAssetsForm'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
 import { AppRoutes } from '@/config/routes'
 import { SafeAppsTag } from '@/config/constants'
+import InfoIcon from '@/public/images/notifications/info.svg'
 
 const TxButton = (props: ButtonProps) => (
   <Button variant="contained" sx={{ '& svg path': { fill: 'currentColor' } }} fullWidth {...props} />
@@ -69,7 +70,29 @@ const NewTxModal = ({
     onClose()
   }
 
-  const dialogTitle = txNonce ? `Replace transaction #${txNonce}` : 'New transaction'
+  const dialogTitle = txNonce ? (
+    <>
+      Replace transaction with nonce {txNonce}
+      <Tooltip
+        title="Replacing a transaction will create a new one with the same nonce. Execution of this will replace the
+                previous one."
+        placement="top"
+        arrow
+      >
+        <span>
+          <SvgIcon
+            component={InfoIcon}
+            inheritViewBox
+            color="border"
+            fontSize="small"
+            sx={{ verticalAlign: 'middle', marginLeft: 0.5 }}
+          />
+        </span>
+      </Tooltip>
+    </>
+  ) : (
+    'New transaction'
+  )
 
   return (
     <>

--- a/src/components/tx/modals/NewTxModal/index.tsx
+++ b/src/components/tx/modals/NewTxModal/index.tsx
@@ -37,11 +37,11 @@ const useTxBuilderApp = (): { app?: SafeAppData; link: UrlObject } => {
 const NewTxModal = ({
   onClose,
   recipient,
-  nonce,
+  txNonce,
 }: {
   onClose: () => void
   recipient?: string
-  nonce?: number
+  txNonce?: number
 }): ReactElement => {
   const [tokenModalOpen, setTokenModalOpen] = useState<boolean>(false)
   const [nftsModalOpen, setNftModalOpen] = useState<boolean>(false)
@@ -69,7 +69,7 @@ const NewTxModal = ({
     onClose()
   }
 
-  const dialogTitle = nonce ? `Replace transaction #${nonce}` : 'New transaction'
+  const dialogTitle = txNonce ? `Replace transaction #${txNonce}` : 'New transaction'
 
   return (
     <>
@@ -84,14 +84,14 @@ const NewTxModal = ({
               Send NFTs
             </TxButton>
 
-            {nonce && (
+            {txNonce && (
               <TxButton onClick={onRejectModalOpen} variant="danger">
                 Rejection transaction
               </TxButton>
             )}
 
             {/* Contract interaction via Transaction Builder */}
-            {txBuilder.app && !recipient && !nonce && (
+            {txBuilder.app && !recipient && !txNonce && (
               <Link href={txBuilder.link} passHref>
                 <TxButton
                   startIcon={<img src={txBuilder.app.iconUrl} height={20} width="auto" alt={txBuilder.app.name} />}
@@ -107,12 +107,12 @@ const NewTxModal = ({
       </ModalDialog>
 
       {tokenModalOpen && (
-        <TokenTransferModal onClose={onClose} initialData={[{ [SendAssetsField.recipient]: recipient }, { nonce }]} />
+        <TokenTransferModal onClose={onClose} initialData={[{ [SendAssetsField.recipient]: recipient }, { txNonce }]} />
       )}
 
-      {nftsModalOpen && <NftTransferModal onClose={onClose} initialData={[{ recipient }, { nonce }]} />}
+      {nftsModalOpen && <NftTransferModal onClose={onClose} initialData={[{ recipient }, { txNonce }]} />}
 
-      {rejectModalOpen && nonce && <RejectTxModal onClose={onClose} initialData={[nonce]} />}
+      {rejectModalOpen && txNonce && <RejectTxModal onClose={onClose} initialData={[txNonce]} />}
     </>
   )
 }

--- a/src/components/tx/modals/NewTxModal/index.tsx
+++ b/src/components/tx/modals/NewTxModal/index.tsx
@@ -48,6 +48,7 @@ const NewTxModal = ({
   const [nftsModalOpen, setNftModalOpen] = useState<boolean>(false)
   const [rejectModalOpen, setRejectModalOpen] = useState<boolean>(false)
   const txBuilder = useTxBuilderApp()
+  const isReplacement = txNonce !== undefined
 
   // These cannot be Track components as they intefere with styling
   const onTokenModalOpen = () => {
@@ -70,7 +71,7 @@ const NewTxModal = ({
     onClose()
   }
 
-  const dialogTitle = txNonce ? (
+  const dialogTitle = isReplacement ? (
     <>
       Replace transaction with nonce {txNonce}
       <Tooltip
@@ -107,14 +108,14 @@ const NewTxModal = ({
               Send NFTs
             </TxButton>
 
-            {txNonce && (
+            {isReplacement && (
               <TxButton onClick={onRejectModalOpen} variant="outlined">
                 Empty transaction
               </TxButton>
             )}
 
             {/* Contract interaction via Transaction Builder */}
-            {txBuilder.app && !recipient && !txNonce && (
+            {txBuilder.app && !recipient && !isReplacement && (
               <Link href={txBuilder.link} passHref>
                 <TxButton
                   startIcon={<img src={txBuilder.app.iconUrl} height={20} width="auto" alt={txBuilder.app.name} />}

--- a/src/components/tx/modals/NftTransferModal/ReviewNftTx.tsx
+++ b/src/components/tx/modals/NftTransferModal/ReviewNftTx.tsx
@@ -22,7 +22,7 @@ const ReviewNftTx = ({ params, onSubmit }: ReviewNftTxProps): ReactElement => {
 
   const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
     const transferParams = createNftTransferParams(safeAddress, params.recipient, params.token.id, params.token.address)
-    return createTx(transferParams)
+    return createTx(transferParams, params.nonce)
   }, [safeAddress, params])
 
   return (

--- a/src/components/tx/modals/NftTransferModal/ReviewNftTx.tsx
+++ b/src/components/tx/modals/NftTransferModal/ReviewNftTx.tsx
@@ -22,7 +22,7 @@ const ReviewNftTx = ({ params, onSubmit }: ReviewNftTxProps): ReactElement => {
 
   const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
     const transferParams = createNftTransferParams(safeAddress, params.recipient, params.token.id, params.token.address)
-    return createTx(transferParams, params.nonce)
+    return createTx(transferParams, params.txNonce)
   }, [safeAddress, params])
 
   return (

--- a/src/components/tx/modals/NftTransferModal/index.tsx
+++ b/src/components/tx/modals/NftTransferModal/index.tsx
@@ -9,7 +9,7 @@ import ReviewNftTx from './ReviewNftTx'
 export type NftTransferParams = {
   recipient: string
   token: SafeCollectibleResponse
-  nonce?: number
+  txNonce?: number
 }
 
 export const NftTransferSteps: TxStepperProps['steps'] = [

--- a/src/components/tx/modals/NftTransferModal/index.tsx
+++ b/src/components/tx/modals/NftTransferModal/index.tsx
@@ -9,6 +9,7 @@ import ReviewNftTx from './ReviewNftTx'
 export type NftTransferParams = {
   recipient: string
   token: SafeCollectibleResponse
+  nonce?: number
 }
 
 export const NftTransferSteps: TxStepperProps['steps'] = [

--- a/src/components/tx/modals/RejectTxModal/RejectTx.tsx
+++ b/src/components/tx/modals/RejectTxModal/RejectTx.tsx
@@ -1,23 +1,19 @@
 import type { ReactElement } from 'react'
 import { Typography } from '@mui/material'
 import type { SafeTransaction } from '@gnosis.pm/safe-core-sdk-types'
-import type { TransactionSummary } from '@gnosis.pm/safe-react-gateway-sdk'
 
-import { isMultisigExecutionInfo } from '@/utils/transaction-guards'
 import { createRejectTx } from '@/services/tx/txSender'
 import useAsync from '@/hooks/useAsync'
 import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 
 type RejectTxProps = {
-  txSummary: TransactionSummary
+  txNonce: number
   onSubmit: (txId: string) => void
 }
 
-const RejectTx = ({ txSummary, onSubmit }: RejectTxProps): ReactElement => {
-  const txNonce = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo.nonce : undefined
-
+const RejectTx = ({ txNonce, onSubmit }: RejectTxProps): ReactElement => {
   const [rejectTx, rejectError] = useAsync<SafeTransaction>(() => {
-    if (txNonce != undefined) return createRejectTx(txNonce)
+    return createRejectTx(txNonce)
   }, [txNonce])
 
   return (

--- a/src/components/tx/modals/RejectTxModal/index.tsx
+++ b/src/components/tx/modals/RejectTxModal/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import type { TransactionSummary } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import type { TxStepperProps } from '@/components/tx/TxStepper/useTxStepper'
 import type { TxModalProps } from '@/components/tx/TxModal'
@@ -9,7 +8,7 @@ import RejectTx from '@/components/tx/modals/RejectTxModal/RejectTx'
 export const RejectTxSteps: TxStepperProps['steps'] = [
   {
     label: 'Reject transaction',
-    render: (data, onSubmit) => <RejectTx txSummary={data as TransactionSummary} onSubmit={onSubmit} />,
+    render: (data, onSubmit) => <RejectTx txNonce={data as number} onSubmit={onSubmit} />,
   },
 ]
 

--- a/src/components/tx/modals/TokenTransferModal/ReviewMultisigTx.tsx
+++ b/src/components/tx/modals/TokenTransferModal/ReviewMultisigTx.tsx
@@ -9,10 +9,10 @@ import useAsync from '@/hooks/useAsync'
 import { createTx } from '@/services/tx/txSender'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import SendFromBlock from '../../SendFromBlock'
-import type { ReviewTokenTxProps } from '@/components/tx/modals/TokenTransferModal/ReviewTokenTx'
+import type { TokenTransferModalProps } from '.'
 import { TokenTransferReview } from '@/components/tx/modals/TokenTransferModal/ReviewTokenTx'
 
-const ReviewMultisigTx = ({ params, onSubmit }: ReviewTokenTxProps): ReactElement => {
+const ReviewMultisigTx = ({ params, onSubmit }: TokenTransferModalProps): ReactElement => {
   const { balances } = useBalances()
 
   const token = balances.items.find((item) => item.tokenInfo.address === params.tokenAddress)
@@ -22,7 +22,7 @@ const ReviewMultisigTx = ({ params, onSubmit }: ReviewTokenTxProps): ReactElemen
   const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
     if (!address || !decimals) return
     const txParams = createTokenTransferParams(params.recipient, params.amount, decimals, address)
-    return createTx(txParams)
+    return createTx(txParams, params.nonce)
   }, [params, decimals, address])
 
   return (

--- a/src/components/tx/modals/TokenTransferModal/ReviewMultisigTx.tsx
+++ b/src/components/tx/modals/TokenTransferModal/ReviewMultisigTx.tsx
@@ -22,7 +22,7 @@ const ReviewMultisigTx = ({ params, onSubmit }: TokenTransferModalProps): ReactE
   const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
     if (!address || !decimals) return
     const txParams = createTokenTransferParams(params.recipient, params.amount, decimals, address)
-    return createTx(txParams, params.nonce)
+    return createTx(txParams, params.txNonce)
   }, [params, decimals, address])
 
   return (

--- a/src/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx.tsx
+++ b/src/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx.tsx
@@ -69,7 +69,7 @@ const ReviewSpendingLimitTx = ({ params, onSubmit }: TokenTransferModalProps): R
 
   const [advancedParams, setManualParams] = useAdvancedParams({
     gasLimit,
-    nonce: params.nonce,
+    nonce: params.txNonce,
   })
 
   const handleSubmit = async (e: SyntheticEvent) => {

--- a/src/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx.tsx
+++ b/src/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx.tsx
@@ -4,7 +4,7 @@ import type { BigNumberish, BytesLike } from 'ethers'
 import { Box, Button, DialogContent, Typography } from '@mui/material'
 import SendFromBlock from '@/components/tx/SendFromBlock'
 import EthHashInfo from '@/components/common/EthHashInfo'
-import type { ReviewTokenTxProps } from '@/components/tx/modals/TokenTransferModal/ReviewTokenTx'
+import type { TokenTransferModalProps } from '.'
 import { TokenTransferReview } from '@/components/tx/modals/TokenTransferModal/ReviewTokenTx'
 import useBalances from '@/hooks/useBalances'
 import useSpendingLimit from '@/hooks/useSpendingLimit'
@@ -33,7 +33,7 @@ export type SpendingLimitTxParams = {
   signature: BytesLike
 }
 
-const ReviewSpendingLimitTx = ({ params, onSubmit }: ReviewTokenTxProps): ReactElement => {
+const ReviewSpendingLimitTx = ({ params, onSubmit }: TokenTransferModalProps): ReactElement => {
   const [isSubmittable, setIsSubmittable] = useState<boolean>(true)
   const [submitError, setSubmitError] = useState<Error | undefined>()
   const chainId = useChainId()
@@ -67,7 +67,10 @@ const ReviewSpendingLimitTx = ({ params, onSubmit }: ReviewTokenTxProps): ReactE
 
   const { gasLimit, gasLimitLoading } = useSpendingLimitGas(txParams)
 
-  const [advancedParams, setManualParams] = useAdvancedParams({ gasLimit })
+  const [advancedParams, setManualParams] = useAdvancedParams({
+    gasLimit,
+    nonce: params.nonce,
+  })
 
   const handleSubmit = async (e: SyntheticEvent) => {
     e.preventDefault()

--- a/src/components/tx/modals/TokenTransferModal/ReviewTokenTx.tsx
+++ b/src/components/tx/modals/TokenTransferModal/ReviewTokenTx.tsx
@@ -3,7 +3,7 @@ import { Box } from '@mui/material'
 import type { TokenInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import css from './styles.module.css'
-import type { SendAssetsFormData } from '@/components/tx/modals/TokenTransferModal/SendAssetsForm'
+import type { TokenTransferModalProps } from '.'
 import { SendTxType } from '@/components/tx/modals/TokenTransferModal/SendAssetsForm'
 import TokenIcon from '@/components/common/TokenIcon'
 import ReviewSpendingLimitTx from '@/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx'
@@ -32,12 +32,7 @@ export const TokenTransferReview = ({
   )
 }
 
-export type ReviewTokenTxProps = {
-  params: SendAssetsFormData
-  onSubmit: (txId: string) => void
-}
-
-const ReviewTokenTx = ({ params, onSubmit }: ReviewTokenTxProps): ReactElement => {
+const ReviewTokenTx = ({ params, onSubmit }: TokenTransferModalProps): ReactElement => {
   const isSpendingLimitTx = params.type === SendTxType.spendingLimit
 
   return isSpendingLimitTx ? (

--- a/src/components/tx/modals/TokenTransferModal/index.tsx
+++ b/src/components/tx/modals/TokenTransferModal/index.tsx
@@ -7,6 +7,11 @@ import ReviewTokenTx from '@/components/tx/modals/TokenTransferModal/ReviewToken
 import type { TxModalProps } from '@/components/tx/TxModal'
 import TxModal from '@/components/tx/TxModal'
 
+export type TokenTransferModalProps = {
+  params: SendAssetsFormData & { nonce?: number }
+  onSubmit: (txId: string) => void
+}
+
 export const TokenTransferSteps: TxStepperProps['steps'] = [
   {
     label: 'Send tokens',
@@ -14,7 +19,9 @@ export const TokenTransferSteps: TxStepperProps['steps'] = [
   },
   {
     label: 'Review transaction',
-    render: (data, onSubmit) => <ReviewTokenTx onSubmit={onSubmit} params={data as SendAssetsFormData} />,
+    render: (data, onSubmit) => (
+      <ReviewTokenTx onSubmit={onSubmit} params={data as TokenTransferModalProps['params']} />
+    ),
   },
 ]
 

--- a/src/components/tx/modals/TokenTransferModal/index.tsx
+++ b/src/components/tx/modals/TokenTransferModal/index.tsx
@@ -8,7 +8,7 @@ import type { TxModalProps } from '@/components/tx/TxModal'
 import TxModal from '@/components/tx/TxModal'
 
 export type TokenTransferModalProps = {
-  params: SendAssetsFormData & { nonce?: number }
+  params: SendAssetsFormData & { txNonce?: number }
   onSubmit: (txId: string) => void
 }
 

--- a/src/services/analytics/events/modals.ts
+++ b/src/services/analytics/events/modals.ts
@@ -40,4 +40,8 @@ export const MODALS_EVENTS = {
     action: 'Simulate transaction',
     category: MODALS_CATEGORY,
   },
+  REJECT_TX: {
+    action: 'Reject transaction',
+    category: MODALS_CATEGORY,
+  },
 }


### PR DESCRIPTION
## What it solves

Resolves #972

## How this PR fixes it

Clicking "Replace" now opens the transaction creation modal in "replacement mode". It is possible to create an asset/NFT transfer with the nonce of the chosen transaction, or alternatively a rejection transaction.

## How to test it

Queue a transaction then click "Replace". Observe that the transaction-to-be-created will be of the same nonce as that which will be replaced.

## Analytics changes

Clicking "Rejection transaction" in the creation modal emits:

```ts
  {
    event: "customClick",
    chainId: "",
    eventCategory: "modals",
    eventAction: "Reject transaction"
  }
```

## Screenshots

Note: the button style has changed since recording this GIF.

![replacement](https://user-images.githubusercontent.com/20442784/199784336-d60811c9-8954-4095-9ed4-c56a11a139c7.gif)

New variant:

![image](https://user-images.githubusercontent.com/20442784/199948866-f4f8332e-af3b-45ac-b4b2-7609a3f847b0.png)