### PR TITLE
feat: add autocomplete to `NonceForm` nonce

### DIFF
--- a/src/components/dashboard/PendingTxs/PendingTxsList.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxsList.tsx
@@ -1,12 +1,11 @@
 import type { ReactElement } from 'react'
 import { useMemo } from 'react'
 import { useRouter } from 'next/router'
-import { groupConflictingTxs } from '@/utils/tx-list'
+import { getLatestTransactions } from '@/utils/tx-list'
 import styled from '@emotion/styled'
 import { Box, Skeleton, Typography } from '@mui/material'
 import { Card, ViewAllLink, WidgetBody, WidgetContainer } from '../styled'
 import PendingTxListItem from './PendingTxListItem'
-import { isTransactionListItem } from '@/utils/transaction-guards'
 import useTxQueue from '@/hooks/useTxQueue'
 import { AppRoutes } from '@/config/routes'
 import NoTransactionsIcon from '@/public/images/transactions/no-transactions.svg'
@@ -48,14 +47,7 @@ const PendingTxsList = ({ size = 4 }: { size?: number }): ReactElement | null =>
   const router = useRouter()
   const url = `${AppRoutes.transactions.queue}?safe=${router.query.safe}`
 
-  const queuedTxns = useMemo(() => {
-    return (
-      groupConflictingTxs(page?.results || [])
-        // Get latest transaction if there are conflicting ones
-        .map((group) => (Array.isArray(group) ? group[0] : group))
-        .filter(isTransactionListItem)
-    )
-  }, [page?.results])
+  const queuedTxns = useMemo(() => getLatestTransactions(page?.results), [page?.results])
 
   const queuedTxsToDisplay = queuedTxns.slice(0, size)
 

--- a/src/components/tx/NonceForm/index.tsx
+++ b/src/components/tx/NonceForm/index.tsx
@@ -1,8 +1,16 @@
+import { memo, useMemo } from 'react'
 import type { ReactElement } from 'react'
-import { useFormContext } from 'react-hook-form'
-import { IconButton, TextField, Tooltip } from '@mui/material'
+import { useController, useFormContext, useWatch } from 'react-hook-form'
+import { Autocomplete, IconButton, InputAdornment, MenuItem, TextField, Tooltip } from '@mui/material'
 import RotateLeftIcon from '@mui/icons-material/RotateLeft'
 import useSafeInfo from '@/hooks/useSafeInfo'
+import useTxQueue, { useQueuedTxByNonce } from '@/hooks/useTxQueue'
+import { isMultisigExecutionInfo, isTransactionListItem } from '@/utils/transaction-guards'
+import { uniqBy } from 'lodash'
+import { getTransactionType } from '@/hooks/useTransactionType'
+import useAddressBook from '@/hooks/useAddressBook'
+import type { MenuItemProps } from '@mui/material'
+import { getLatestTransactions } from '@/utils/tx-list'
 
 type NonceFormProps = {
   name: string
@@ -11,58 +19,124 @@ type NonceFormProps = {
   readonly?: boolean
 }
 
+// eslint-disable-next-line react/display-name
+const NonceFormOption = memo(({ nonce, ...props }: { nonce: number } & MenuItemProps): ReactElement => {
+  const addressBook = useAddressBook()
+  const transactions = useQueuedTxByNonce(nonce)
+
+  const label = useMemo(() => {
+    const [{ transaction }] = getLatestTransactions(transactions)
+    return getTransactionType(transaction, addressBook).text
+  }, [addressBook, transactions])
+
+  return (
+    <MenuItem key={nonce} {...props}>
+      {nonce} - {label}
+    </MenuItem>
+  )
+})
+
 const NonceForm = ({ name, nonce, recommendedNonce, readonly }: NonceFormProps): ReactElement => {
   const { safe } = useSafeInfo()
   const safeNonce = safe.nonce || 0
 
-  const { register, watch, setValue, trigger, formState } = useFormContext() || {}
-  const currentNonce = watch(name)
+  // Initialise form field
+  const { setValue, control } = useFormContext() || {}
+  const {
+    field: { ref, onBlur, onChange, value },
+    fieldState,
+  } = useController({
+    name,
+    control,
+    defaultValue: nonce,
+    rules: {
+      required: true,
+      validate: (val: number) => {
+        if (!Number.isInteger(val)) {
+          return 'Nonce must be an integer'
+        } else if (val < safeNonce) {
+          return `Nonce can't be lower than ${safeNonce}`
+        }
+      },
+    },
+  })
+
+  // Autocomplete options
+  const { page } = useTxQueue()
+  const queuedTxs = useMemo(() => {
+    if (!page || page.results.length === 0) {
+      return []
+    }
+
+    const txs = page.results.filter(isTransactionListItem).map((item) => item.transaction)
+
+    return uniqBy(txs, (tx) => {
+      return isMultisigExecutionInfo(tx.executionInfo) ? tx.executionInfo.nonce : ''
+    })
+  }, [page])
+
+  const options = useMemo(() => {
+    return queuedTxs
+      .map((tx) => (isMultisigExecutionInfo(tx.executionInfo) ? tx.executionInfo.nonce : undefined))
+      .filter(Boolean)
+  }, [queuedTxs])
 
   // Warn about a higher nonce
-  const editableNonce = watch(name)
+  const editableNonce = useWatch({ name, control, exact: true })
   const nonceWarning =
     recommendedNonce != null && editableNonce > recommendedNonce ? `Recommended nonce is ${recommendedNonce}` : ''
+  const label = fieldState.error?.message || nonceWarning || 'Safe transaction nonce'
 
   const onResetNonce = () => {
     if (recommendedNonce) {
-      setValue(name, recommendedNonce)
-      trigger(name)
+      setValue(name, recommendedNonce, { shouldValidate: true })
     }
   }
 
   return (
-    <TextField
-      type="number"
-      autoComplete="off"
-      defaultValue={nonce || ''}
+    <Autocomplete
+      value={value}
+      freeSolo
+      // On option select or free text entry
+      onInputChange={(_, value) => {
+        onChange(value ? Number(value) : '')
+      }}
+      options={options}
       disabled={nonce == null || readonly}
-      error={!!formState?.errors[name]}
-      label={<>{formState?.errors[name]?.message || nonceWarning || 'Safe transaction nonce'}</>}
-      InputProps={{
-        endAdornment: !readonly && recommendedNonce !== undefined && recommendedNonce !== currentNonce && (
-          <Tooltip title="Reset to recommended nonce">
-            <IconButton onClick={onResetNonce} size="small" color="primary">
-              <RotateLeftIcon />
-            </IconButton>
-          </Tooltip>
-        ),
-      }}
-      // @see https://github.com/react-hook-form/react-hook-form/issues/220
-      InputLabelProps={{
-        shrink: currentNonce !== undefined,
-      }}
-      required
-      {...register(name, {
-        required: true,
-        valueAsNumber: true,
-        validate: (val: number) => {
-          if (!Number.isInteger(val)) {
-            return 'Nonce must be an integer'
-          } else if (val < safeNonce) {
-            return `Nonce can't be lower than ${safeNonce}`
-          }
-        },
-      })}
+      getOptionLabel={(option) => option.toString()}
+      renderOption={(props, option) => <NonceFormOption nonce={option} {...props} />}
+      disableClearable
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          name={name}
+          onBlur={onBlur}
+          inputRef={ref}
+          type="number"
+          autoComplete="off"
+          error={!!fieldState.error}
+          label={label}
+          InputProps={{
+            ...params.InputProps,
+            endAdornment: !readonly &&
+              recommendedNonce !== undefined &&
+              recommendedNonce !== params.inputProps.value && (
+                <InputAdornment position="end">
+                  <Tooltip title="Reset to recommended nonce">
+                    <IconButton onClick={onResetNonce} size="small" color="primary">
+                      <RotateLeftIcon />
+                    </IconButton>
+                  </Tooltip>
+                </InputAdornment>
+              ),
+            readOnly: readonly,
+          }}
+          InputLabelProps={{
+            ...params.InputLabelProps,
+            shrink: true,
+          }}
+        />
+      )}
     />
   )
 }

--- a/src/hooks/useTransactionType.ts
+++ b/src/hooks/useTransactionType.ts
@@ -9,6 +9,7 @@ import {
 
 import { isCancellationTxInfo, isModuleExecutionInfo, isTxQueued } from '@/utils/transaction-guards'
 import useAddressBook from './useAddressBook'
+import type { AddressBook } from '@/store/addressBookSlice'
 
 const getTxTo = ({ txInfo }: Pick<TransactionSummary, 'txInfo'>): AddressEx | undefined => {
   switch (txInfo.type) {
@@ -32,70 +33,75 @@ type TxType = {
   text: string
 }
 
-export const useTransactionType = (tx: TransactionSummary): TxType => {
+export const getTransactionType = (tx: TransactionSummary, addressBook: AddressBook): TxType => {
   const toAddress = getTxTo(tx)
-  const addressBook = useAddressBook()
   const addressBookName = toAddress?.value ? addressBook[toAddress.value] : undefined
 
-  return useMemo(() => {
-    switch (tx.txInfo.type) {
-      case TransactionInfoType.CREATION: {
-        return {
-          icon: toAddress?.logoUri || '/images/transactions/settings.svg',
-          text: 'Safe created',
-        }
-      }
-      case TransactionInfoType.TRANSFER: {
-        const isSendTx = tx.txInfo.direction === TransferDirection.OUTGOING
-
-        return {
-          icon: isSendTx ? '/images/transactions/outgoing.svg' : '/images/transactions/incoming.svg',
-          text: isSendTx ? (isTxQueued(tx.txStatus) ? 'Send' : 'Sent') : 'Received',
-        }
-      }
-      case TransactionInfoType.SETTINGS_CHANGE: {
-        // deleteGuard doesn't exist in Solidity
-        // It is decoded as 'setGuard' with a settingsInfo.type of 'DELETE_GUARD'
-        const isDeleteGuard = tx.txInfo.settingsInfo?.type === SettingsInfoType.DELETE_GUARD
-
-        return {
-          icon: '/images/transactions/settings.svg',
-          text: isDeleteGuard ? 'deleteGuard' : tx.txInfo.dataDecoded.method,
-        }
-      }
-      case TransactionInfoType.CUSTOM: {
-        if (isModuleExecutionInfo(tx.executionInfo)) {
-          return {
-            icon: toAddress?.logoUri || '/images/transactions/settings.svg',
-            text: toAddress?.name || '',
-          }
-        }
-
-        if (isCancellationTxInfo(tx.txInfo)) {
-          return {
-            icon: '/images/transactions/circle-cross-red.svg',
-            text: 'On-chain rejection',
-          }
-        }
-
-        if (tx.safeAppInfo) {
-          return {
-            icon: tx.safeAppInfo.logoUri,
-            text: tx.safeAppInfo.name,
-          }
-        }
-
-        return {
-          icon: toAddress?.logoUri || '/images/transactions/custom.svg',
-          text: addressBookName || toAddress?.name || 'Contract interaction',
-        }
-      }
-      default: {
-        return {
-          icon: '/images/transactions/custom.svg',
-          text: addressBookName || 'Contract interaction',
-        }
+  switch (tx.txInfo.type) {
+    case TransactionInfoType.CREATION: {
+      return {
+        icon: toAddress?.logoUri || '/images/transactions/settings.svg',
+        text: 'Safe created',
       }
     }
-  }, [tx, addressBookName, toAddress])
+    case TransactionInfoType.TRANSFER: {
+      const isSendTx = tx.txInfo.direction === TransferDirection.OUTGOING
+
+      return {
+        icon: isSendTx ? '/images/transactions/outgoing.svg' : '/images/transactions/incoming.svg',
+        text: isSendTx ? (isTxQueued(tx.txStatus) ? 'Send' : 'Sent') : 'Received',
+      }
+    }
+    case TransactionInfoType.SETTINGS_CHANGE: {
+      // deleteGuard doesn't exist in Solidity
+      // It is decoded as 'setGuard' with a settingsInfo.type of 'DELETE_GUARD'
+      const isDeleteGuard = tx.txInfo.settingsInfo?.type === SettingsInfoType.DELETE_GUARD
+
+      return {
+        icon: '/images/transactions/settings.svg',
+        text: isDeleteGuard ? 'deleteGuard' : tx.txInfo.dataDecoded.method,
+      }
+    }
+    case TransactionInfoType.CUSTOM: {
+      if (isModuleExecutionInfo(tx.executionInfo)) {
+        return {
+          icon: toAddress?.logoUri || '/images/transactions/settings.svg',
+          text: toAddress?.name || '',
+        }
+      }
+
+      if (isCancellationTxInfo(tx.txInfo)) {
+        return {
+          icon: '/images/transactions/circle-cross-red.svg',
+          text: 'On-chain rejection',
+        }
+      }
+
+      if (tx.safeAppInfo) {
+        return {
+          icon: tx.safeAppInfo.logoUri,
+          text: tx.safeAppInfo.name,
+        }
+      }
+
+      return {
+        icon: toAddress?.logoUri || '/images/transactions/custom.svg',
+        text: addressBookName || toAddress?.name || 'Contract interaction',
+      }
+    }
+    default: {
+      return {
+        icon: '/images/transactions/custom.svg',
+        text: addressBookName || 'Contract interaction',
+      }
+    }
+  }
+}
+
+export const useTransactionType = (tx: TransactionSummary): TxType => {
+  const addressBook = useAddressBook()
+
+  return useMemo(() => {
+    return getTransactionType(tx, addressBook)
+  }, [tx, addressBook])
 }

--- a/src/utils/tx-list.ts
+++ b/src/utils/tx-list.ts
@@ -28,3 +28,12 @@ export const groupConflictingTxs = (list: TransactionListItem[]): GroupedTxs => 
       return item
     })
 }
+
+export const getLatestTransactions = (list: TransactionListItem[] = []): Transaction[] => {
+  return (
+    groupConflictingTxs(list)
+      // Get latest transaction if there are conflicting ones
+      .map((group) => (Array.isArray(group) ? group[0] : group))
+      .filter(isTransactionListItem)
+  )
+}


### PR DESCRIPTION
## What it solves

Resolves #973

## How this PR fixes it

When creating a transaction, the Safe nonce field now shows autocomplete options with the transaction type which sets the associated nonce on click. Conflicting transactions show the type of the most recently queued one (as we do in the dashboard).

Note: the transaction "info", e.g "withdraw", "n action(s)" is not implemented as it would require a big refactor of `TxInfo` to extract component logic into functions. Should we want to include this, we should include it in a separate PR. After discussion with the team, we think the current implementation is a sufficient MVP.

## How to test it

Ensure transactions are already queued and create a new transaction. When editing the nonce an autocomplete dropdown should allow selection of previous nonces, as well as allowing manual entry. All validation should work as before.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/199943537-f7550024-fe85-4180-ae86-497b578bc353.png)