### PR TITLE
fix: execution from non-owner wallets

### DIFF
--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -187,6 +187,7 @@ const SignOrExecuteForm = ({
     cannotPropose ||
     isExecutionLoop ||
     isValidExecutionLoading
+
   const error = props.error || (willExecute ? gasLimitError || executionValidationError : undefined)
 
   return (

--- a/src/hooks/__tests__/useIsValidExecution.test.ts
+++ b/src/hooks/__tests__/useIsValidExecution.test.ts
@@ -1,9 +1,11 @@
 import { ethers } from 'ethers'
 import { BigNumber } from '@ethersproject/bignumber'
 import type { SafeTransaction, SafeSignature } from '@gnosis.pm/safe-core-sdk-types'
+import { type SafeInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import * as safeContracts from '@/services/contracts/safeContracts'
 import * as useWalletHook from '@/hooks/wallets/useWallet'
+import * as useSafeInfoHook from '@/hooks/useSafeInfo'
 import { act, renderHook } from '@/tests/test-utils'
 import useIsValidExecution from '../useIsValidExecution'
 import type { EthersError } from '@/utils/ethers-utils'
@@ -33,7 +35,8 @@ const createSafeTx = (data = '0x'): SafeTransaction => {
   } as SafeTransaction
 }
 
-const mockTx = createSafeTx()
+let mockTx: SafeTransaction
+
 const mockGas = BigNumber.from(1000)
 
 describe('useIsValidExecution', () => {
@@ -43,16 +46,79 @@ describe('useIsValidExecution', () => {
     jest.spyOn(useWalletHook, 'default').mockReturnValue({
       address: ethers.utils.hexZeroPad('0x123', 20),
     } as ConnectedWallet)
+
+    jest.spyOn(useSafeInfoHook, 'default').mockReturnValue({
+      safe: {
+        owners: [
+          {
+            value: ethers.utils.hexZeroPad('0x123', 20),
+          },
+        ],
+      } as SafeInfo,
+      safeAddress: ethers.utils.hexZeroPad('0x456', 20),
+      safeLoaded: true,
+      safeLoading: false,
+    })
+
+    // Create a new tx for each test case
+    mockTx = createSafeTx()
   })
 
-  it('should return a boolean if the transaction is valid', async () => {
+  it('should add a missing signature and return a boolean if the transaction is valid', async () => {
     jest.spyOn(safeContracts, 'getSpecificGnosisSafeContractInstance').mockReturnValue({
       contract: {
         // @ts-expect-error
         callStatic: {
-          execTransaction: jest.fn(() => Promise.resolve(true)),
+          execTransaction: jest.fn((_1, _2, _3, _4, _5, _6, _7, _8, _9, signatures: string) =>
+            Promise.resolve(signatures.includes(ethers.utils.hexZeroPad('0x123', 20))),
+          ),
         },
       },
+    })
+
+    const { result } = renderHook(() => useIsValidExecution(mockTx, mockGas))
+
+    let { isValidExecution, executionValidationError, isValidExecutionLoading } = result.current
+
+    expect(isValidExecution).toEqual(undefined)
+    expect(executionValidationError).toBe(undefined)
+    expect(isValidExecutionLoading).toBe(true)
+
+    await act(async () => {
+      await new Promise(process.nextTick)
+    })
+    ;({ isValidExecution, executionValidationError, isValidExecutionLoading } = result.current)
+
+    expect(isValidExecution).toBe(true)
+    expect(executionValidationError).toBe(undefined)
+    expect(isValidExecutionLoading).toBe(false)
+  })
+
+  it('should not add a signature if no owner is connected and return a boolean if the transaction is valid', async () => {
+    // Connect a different owner and add a different sig
+    jest.spyOn(useWalletHook, 'default').mockReturnValue({
+      address: ethers.utils.hexZeroPad('0xabc', 20),
+    } as ConnectedWallet)
+
+    jest.spyOn(safeContracts, 'getSpecificGnosisSafeContractInstance').mockReturnValue({
+      contract: {
+        // @ts-expect-error
+        callStatic: {
+          execTransaction: jest.fn((_1, _2, _3, _4, _5, _6, _7, _8, _9, signatures: string) =>
+            Promise.resolve(
+              signatures.includes(ethers.utils.hexZeroPad('0x123', 20)) &&
+                !signatures.includes(ethers.utils.hexZeroPad('0xabc', 20)),
+            ),
+          ),
+        },
+      },
+    })
+
+    mockTx.addSignature({
+      signer: ethers.utils.hexZeroPad('0x123', 20),
+      data: '0xEEE',
+      staticPart: () => '0xEEE',
+      dynamicPart: () => '',
     })
 
     const { result } = renderHook(() => useIsValidExecution(mockTx, mockGas))

--- a/src/hooks/useIsValidExecution.ts
+++ b/src/hooks/useIsValidExecution.ts
@@ -8,6 +8,7 @@ import useSafeInfo from './useSafeInfo'
 import useWallet from './wallets/useWallet'
 import { encodeSignatures } from '@/services/tx/encodeSignatures'
 import ContractErrorCodes from '@/services/contracts/ContractErrorCodes'
+import { sameAddress } from '@/utils/addresses'
 
 const isContractError = <T extends EthersError>(error: T): error is T & { reason: keyof typeof ContractErrorCodes } => {
   return Object.keys(ContractErrorCodes).includes(error.reason)
@@ -29,6 +30,8 @@ const useIsValidExecution = (
       return
     }
 
+    const isSafeOwnerConnected = safe.owners.some((owner) => sameAddress(owner.value, wallet.address))
+
     const { contract } = getSpecificGnosisSafeContractInstance(safe)
 
     try {
@@ -42,7 +45,7 @@ const useIsValidExecution = (
         safeTx.data.gasPrice,
         safeTx.data.gasToken,
         safeTx.data.refundReceiver,
-        encodeSignatures(safeTx, wallet.address),
+        encodeSignatures(safeTx, isSafeOwnerConnected ? wallet.address : undefined),
         { from: wallet.address, gasLimit: gasLimit.toString() },
       )
     } catch (_err) {


### PR DESCRIPTION
## What it solves
Fixes the validation error when executing txs from non-owner wallets.

Resolves #1057

## How this PR fixes it
Does not add signature of executing wallet if it is not an owner

## How to test it
Execute a queued txs that is fully signed from a non-owner connected wallet. 

## Analytics changes
None
