### PR TITLE
[Safe creation] Creation links tooltips

### DIFF
--- a/src/components/new-safe/CreateSafe/index.tsx
+++ b/src/components/new-safe/CreateSafe/index.tsx
@@ -1,4 +1,4 @@
-import { Container, Typography, Grid, Link } from '@mui/material'
+import { Container, Typography, Grid, SvgIcon, IconButton } from '@mui/material'
 import { useRouter } from 'next/router'
 
 import useWallet from '@/hooks/wallets/useWallet'
@@ -18,6 +18,7 @@ import type { AlertColor } from '@mui/material'
 import type { CreateSafeInfoItem } from '../CreateSafeInfos'
 import CreateSafeInfos from '../CreateSafeInfos'
 import { type ReactElement, useMemo, useState } from 'react'
+import LinkIcon from '@/public/images/sidebar/link.svg'
 
 export type NewSafeFormData = {
   name: string
@@ -56,15 +57,17 @@ const staticHints: Record<
         title: 'Safe Setup',
         text: (
           <>
-            Not sure how many owners and confirmations you need for your Safe?{' '}
-            <Link
-              sx={{ textDecoration: 'underline' }}
+            Not sure how many owners and confirmations you need for your Safe?
+            <br />
+            <b>Learn more about setting up your Safe.</b>
+            <IconButton
               href="https://help.gnosis-safe.io/en/articles/4772567-what-safe-setup-should-i-use"
               target="_blank"
               rel="noopener noreferrer"
+              size="small"
             >
-              Learn more about setting up your Safe.
-            </Link>
+              <SvgIcon component={LinkIcon} inheritViewBox />
+            </IconButton>
           </>
         ),
       },

--- a/src/components/new-safe/steps/Step2/index.tsx
+++ b/src/components/new-safe/steps/Step2/index.tsx
@@ -81,7 +81,11 @@ const CreateSafeStep2 = ({
             <Box p={2} sx={{ backgroundColor: 'background.main', borderRadius: '8px' }}>
               <Typography variant="subtitle1" fontWeight={700} display="inline-flex" alignItems="center" gap={1}>
                 Safe Mobile owner key (optional){' '}
-                <Tooltip title="TODO: Add tooltip" arrow placement="top">
+                <Tooltip
+                  title="The Safe Mobile allows generating new signer keys so you can use them as a signer in a new or existing Safe."
+                  arrow
+                  placement="top"
+                >
                   <span style={{ display: 'flex' }}>
                     <SvgIcon component={InfoIcon} inheritViewBox color="border" fontSize="small" />
                   </span>
@@ -95,7 +99,11 @@ const CreateSafeStep2 = ({
             <Divider sx={{ ml: '-52px', mr: '-52px', mb: 4, mt: 3 }} />
             <Typography variant="h4" fontWeight={700} display="inline-flex" alignItems="center" gap={1}>
               Threshold
-              <Tooltip title="TODO: Add tooltip" arrow placement="top">
+              <Tooltip
+                title="The threshold of a Safe specifies, how many owner accounts need to confirm a Safe transaction before it can be executed."
+                arrow
+                placement="top"
+              >
                 <span style={{ display: 'flex' }}>
                   <SvgIcon component={InfoIcon} inheritViewBox color="border" fontSize="small" />
                 </span>


### PR DESCRIPTION
## What it solves
Adds the missing links in the Tip and the tooltips on the "Add owners" step

## How this PR fixes it
Adds a link to the help center article in the Safe Setup tip.
Adds the tooltips text in "Add owners" step

## How to test it
1. On /new-safe/create navigate until the step "Owners and confirmations"
2. Hover the two tooltips
3. Expand the "Safe Setup" tip and verify the external link.

## Screenshots
<img width="382" alt="Screenshot 2022-11-04 at 12 09 06" src="https://user-images.githubusercontent.com/32431609/199960863-69f84ce7-96aa-4657-9074-9d71db78fef0.png">
<img width="635" alt="Screenshot 2022-11-04 at 12 15 44" src="https://user-images.githubusercontent.com/32431609/199960877-36666e38-9613-43ca-9f36-19608eb34a08.png">
<img width="462" alt="Screenshot 2022-11-04 at 12 15 40" src="https://user-images.githubusercontent.com/32431609/199960901-e431cef8-8b5d-4d44-b342-02f2ad3a1037.png">
