### PR TITLE
feat: add `SIGNING` event + `safeTxHash` details

### DIFF
--- a/src/components/common/Notifications/index.tsx
+++ b/src/components/common/Notifications/index.tsx
@@ -67,7 +67,7 @@ const Toast = ({
     onClose()
   }
 
-  const autoHideDuration = variant === 'info' || variant === 'success' ? 5000 : undefined
+  const autoHideDuration = (variant === 'info' || variant === 'success') && !detailedMessage ? 5000 : undefined
 
   return (
     <Snackbar open onClose={handleClose} sx={toastStyle} autoHideDuration={autoHideDuration}>

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -62,7 +62,7 @@ const useTxNotifications = (): void => {
         const isError = 'error' in detail
         const isSuccess = event === TxEvent.SUCCESS || event === TxEvent.PROPOSED
         const message = isError ? `${baseMessage} ${formatError(detail.error)}` : baseMessage
-        const hasSafeTxHash = 'safeTxHash' in detail
+        const hasSafeTxHash = 'safeTxHash' in detail && !!detail.safeTxHash
 
         const txId = 'txId' in detail ? detail.txId : undefined
         const groupKey = 'groupKey' in detail && detail.groupKey ? detail.groupKey : txId || ''

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -14,6 +14,7 @@ import useIsGranted from './useIsGranted'
 import useWallet from './wallets/useWallet'
 
 const TxNotifications = {
+  [TxEvent.SIGNING]: 'Please sign the transaction with your wallet.',
   [TxEvent.SIGN_FAILED]: 'Signature failed. Please try again.',
   [TxEvent.PROPOSED]: 'Your transaction was successfully proposed.',
   [TxEvent.PROPOSE_FAILED]: 'Failed proposing the transaction. Please try again.',
@@ -61,6 +62,7 @@ const useTxNotifications = (): void => {
         const isError = 'error' in detail
         const isSuccess = event === TxEvent.SUCCESS || event === TxEvent.PROPOSED
         const message = isError ? `${baseMessage} ${formatError(detail.error)}` : baseMessage
+        const hasSafeTxHash = 'safeTxHash' in detail
 
         const txId = 'txId' in detail ? detail.txId : undefined
         const groupKey = 'groupKey' in detail && detail.groupKey ? detail.groupKey : txId || ''
@@ -70,7 +72,11 @@ const useTxNotifications = (): void => {
         dispatch(
           showNotification({
             message,
-            detailedMessage: isError ? detail.error.message : undefined,
+            detailedMessage: isError
+              ? detail.error.message
+              : hasSafeTxHash
+              ? `safeTxHash: ${detail.safeTxHash}`
+              : undefined,
             groupKey,
             variant: isError ? Variant.ERROR : isSuccess ? Variant.SUCCESS : Variant.INFO,
             ...(shouldShowLink && {

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -39,6 +39,7 @@ enum ErrorCodes {
   _806 = '806: Failed to remove module',
   _807 = '807: Failed to remove guard',
   _808 = '808: Failed to get transaction origin',
+  _809 = '809: Error generating safeTxHash',
 
   _900 = '900: Error loading Safe App',
   _901 = '901: Error processing Safe Apps SDK request',

--- a/src/services/tx/__tests__/generateSafeTxHash.test.ts
+++ b/src/services/tx/__tests__/generateSafeTxHash.test.ts
@@ -1,0 +1,54 @@
+import * as logErrorModule from '@/services/exceptions'
+import ErrorCodes from '@/services/exceptions/ErrorCodes'
+import { utils } from 'ethers'
+import type { SafeInfo } from '@gnosis.pm/safe-react-gateway-sdk'
+
+import { generateSafeTxHash } from '../generateSafeTxHash'
+
+const typedData = {
+  to: '0x65c57CC1317a1f728E921Cbf7bC08b3894196D29',
+  value: '100000000000000000',
+  data: '0x',
+  operation: 0,
+  baseGas: 0,
+  gasPrice: 0,
+  gasToken: '0x0000000000000000000000000000000000000000',
+  refundReceiver: '0x0000000000000000000000000000000000000000',
+  nonce: 25,
+  safeTxGas: 0,
+}
+
+const safe = {
+  address: {
+    value: '0x65c57CC1317a1f728E921Cbf7bC08b3894196D29',
+  },
+  chainId: '5',
+  version: '1.3.0',
+} as SafeInfo
+
+describe('generateSafeTxHash', () => {
+  it('generates a safeTxHash', () => {
+    const safeTxHash = '0x4ba8d2add3f0b6fa20382255f88c53c349e5d6585af61549458d0a74372d2ddf'
+
+    expect(generateSafeTxHash(safe, typedData)).toEqual(safeTxHash)
+  })
+
+  it('returns undefined if the safe version is not valid', () => {
+    expect(generateSafeTxHash({ ...safe, version: '1.0.0' }, typedData)).toBeUndefined()
+  })
+
+  it('logs an error if the safeTxHash cannot be generated', () => {
+    const logErrorSpy = jest.spyOn(logErrorModule, 'logError')
+    jest.spyOn(utils, '_TypedDataEncoder').mockImplementation({
+      encode: () => {
+        throw new Error()
+      },
+      // @ts-expect-error
+    } as ReturnType<typeof utils['_TypedDataEncoder']>)
+
+    generateSafeTxHash(safe, typedData)
+
+    expect(logErrorSpy).toHaveBeenCalledWith(ErrorCodes._809, expect.any(String))
+    expect(generateSafeTxHash(safe, typedData)).toBeUndefined()
+  })
+})

--- a/src/services/tx/generateSafeTxHash.ts
+++ b/src/services/tx/generateSafeTxHash.ts
@@ -7,9 +7,9 @@ import { isValidSafeVersion } from '@/hooks/coreSDK/safeCoreSDK'
 import ErrorCodes from '../exceptions/ErrorCodes'
 import { logError } from '../exceptions'
 
-export const generateSafeTxHash = (safe: SafeInfo, data: SafeTransactionData): string => {
+export const generateSafeTxHash = (safe: SafeInfo, data: SafeTransactionData): string | undefined => {
   if (!isValidSafeVersion(safe.version)) {
-    return ''
+    return
   }
 
   const typedData = generateTypedData({
@@ -22,7 +22,7 @@ export const generateSafeTxHash = (safe: SafeInfo, data: SafeTransactionData): s
   // `ethers` generates `EIP712Domain` automatically
   const { EIP712Domain: _, ...types } = typedData.types
 
-  let safeTxHash = ''
+  let safeTxHash: string | undefined
 
   try {
     const typedDataHash = utils._TypedDataEncoder.encode(

--- a/src/services/tx/generateSafeTxHash.ts
+++ b/src/services/tx/generateSafeTxHash.ts
@@ -19,6 +19,7 @@ export const generateSafeTxHash = (safe: SafeInfo, data: SafeTransactionData): s
     safeTransactionData: data,
   })
 
+  // `ethers` generates `EIP712Domain` automatically
   const { EIP712Domain: _, ...types } = typedData.types
 
   let safeTxHash = ''
@@ -26,7 +27,7 @@ export const generateSafeTxHash = (safe: SafeInfo, data: SafeTransactionData): s
   try {
     const typedDataHash = utils._TypedDataEncoder.encode(
       typedData.domain,
-      // @ts-ignore - typedData.types.SafeTxData key is not recognised as a string
+      // @ts-ignore - the typedData.types.SafeTxData key is not recognised as a string
       types,
       typedData.message,
     )

--- a/src/services/tx/generateSafeTxHash.ts
+++ b/src/services/tx/generateSafeTxHash.ts
@@ -1,0 +1,39 @@
+import { utils } from 'ethers'
+import { generateTypedData } from '@gnosis.pm/safe-core-sdk-utils'
+import type { SafeTransactionData } from '@gnosis.pm/safe-core-sdk-types'
+import type { SafeInfo } from '@gnosis.pm/safe-react-gateway-sdk'
+
+import { isValidSafeVersion } from '@/hooks/coreSDK/safeCoreSDK'
+import ErrorCodes from '../exceptions/ErrorCodes'
+import { logError } from '../exceptions'
+
+export const generateSafeTxHash = (safe: SafeInfo, data: SafeTransactionData): string => {
+  if (!isValidSafeVersion(safe.version)) {
+    return ''
+  }
+
+  const typedData = generateTypedData({
+    safeAddress: safe.address.value,
+    safeVersion: safe.version,
+    chainId: Number(safe.chainId),
+    safeTransactionData: data,
+  })
+
+  const { EIP712Domain: _, ...types } = typedData.types
+
+  let safeTxHash = ''
+
+  try {
+    const typedDataHash = utils._TypedDataEncoder.encode(
+      typedData.domain,
+      // @ts-ignore - typedData.types.SafeTxData key is not recognised as a string
+      types,
+      typedData.message,
+    )
+    safeTxHash = utils.keccak256(typedDataHash)
+  } catch (err) {
+    logError(ErrorCodes._809, (err as Error).message)
+  }
+
+  return safeTxHash
+}

--- a/src/services/tx/txEvents.ts
+++ b/src/services/tx/txEvents.ts
@@ -3,6 +3,7 @@ import EventBus from '@/services/EventBus'
 import type { RequestId } from '@gnosis.pm/safe-apps-sdk'
 
 export enum TxEvent {
+  SIGNING = 'SIGNING',
   SIGNED = 'SIGNED',
   SIGN_FAILED = 'SIGN_FAILED',
   PROPOSED = 'PROPOSED',
@@ -24,6 +25,7 @@ export enum TxEvent {
 type Id = { txId: string; groupKey?: string } | { txId?: string; groupKey: string }
 
 interface TxEvents {
+  [TxEvent.SIGNING]: { txId?: string; safeTxHash?: string }
   [TxEvent.SIGNED]: { txId?: string }
   [TxEvent.SIGN_FAILED]: { txId?: string; error: Error }
   [TxEvent.PROPOSE_FAILED]: { error: Error }
@@ -32,7 +34,7 @@ interface TxEvents {
   [TxEvent.SIGNATURE_PROPOSED]: { txId: string; signerAddress: string }
   [TxEvent.SIGNATURE_INDEXED]: { txId: string }
   [TxEvent.AWAITING_ON_CHAIN_SIGNATURE]: Id
-  [TxEvent.EXECUTING]: Id
+  [TxEvent.EXECUTING]: Id & { safeTxHash?: string }
   [TxEvent.PROCESSING]: Id & { txHash: string }
   [TxEvent.PROCESSING_MODULE]: Id & { txHash: string }
   [TxEvent.PROCESSED]: Id & { receipt: ContractReceipt }

--- a/src/services/tx/txSender.ts
+++ b/src/services/tx/txSender.ts
@@ -240,9 +240,12 @@ export const dispatchTxSigning = async (
   safeTx: SafeTransaction,
   shouldEthSign: boolean,
   txId?: string,
+  safeTxHash?: string,
 ): Promise<SafeTransaction> => {
   const sdk = getAndValidateSafeSDK()
   const signingMethod = shouldEthSign ? 'eth_sign' : 'eth_signTypedData'
+
+  txDispatch(TxEvent.SIGNING, { txId, safeTxHash })
 
   let signedTx: SafeTransaction | undefined
   try {
@@ -287,10 +290,11 @@ export const dispatchTxExecution = async (
   provider: Web3Provider,
   txOptions: TransactionOptions,
   txId: string,
+  safeTxHash?: string,
 ): Promise<string> => {
   const sdkUnchecked = await getUncheckedSafeSDK(provider)
 
-  txDispatch(TxEvent.EXECUTING, { txId })
+  txDispatch(TxEvent.EXECUTING, { txId, safeTxHash })
 
   // Execute the tx
   let result: TransactionResult | undefined


### PR DESCRIPTION
## What it solves

Resolves #704

## How this PR fixes it

- A new `TxEvent.SIGNING` event is now dispatched before signing a transaction (mirroring `safe-react`).
- The `generateSafeTxHash` function allows for hash generation from transaction data. It is passed to `TxEvent.SIGNING`/`TxEvent.EXECUTING` events and displayed in notification `"Details"` (if present).
- Notifications with `"Details"` now persist

## How to test it

Observe that when signing/executing a transaction, `"Details"` now exist in the dispatched notifications with the `safeTxHash`. Both notifications persist.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/199989259-824fd303-7e0d-4096-bee0-dd15ad5e8b3a.png)

![image](https://user-images.githubusercontent.com/20442784/199989173-a739c574-1bb0-4a3b-a5d1-a9cb22899641.png)
