### PR TITLE
[Safe Creation] Layout adjustments

### DIFF
--- a/src/components/common/Header/styles.module.css
+++ b/src/components/common/Header/styles.module.css
@@ -37,7 +37,8 @@
 }
 
 .networkSelector {
-  padding-right: var(--space-1);
+  padding-right: 0;
+  padding-left: 0;
   border-right: none;
 }
 

--- a/src/components/common/NetworkSelector/styles.module.css
+++ b/src/components/common/NetworkSelector/styles.module.css
@@ -1,3 +1,7 @@
+.select {
+  height: 100%;
+}
+
 .select:after,
 .select:before {
   display: none;
@@ -5,4 +9,16 @@
 
 .select *:focus {
   background: inherit;
+}
+
+.select :global .MuiSelect-select {
+  padding-right: 40px !important;
+  padding-left: 16px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+}
+
+.select :global .MuiSvgIcon-root {
+  margin-right: var(--space-2);
 }

--- a/src/components/new-safe/CardStepper/styles.module.css
+++ b/src/components/new-safe/CardStepper/styles.module.css
@@ -22,10 +22,18 @@
 }
 
 .content {
-  padding: var(--space-3) 52px;
-  border-bottom: 1px solid var(--color-border-light);
+  padding: 0 !important;
 }
 
 .actions {
   padding: var(--space-3) 52px;
+}
+
+@media (max-width: 600px) {
+  .header {
+    padding: var(--space-2);
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-1);
+  }
 }

--- a/src/components/new-safe/CreateSafe/styles.module.css
+++ b/src/components/new-safe/CreateSafe/styles.module.css
@@ -1,0 +1,10 @@
+.row {
+  width: 100%;
+  padding: var(--space-4) var(--space-7);
+}
+
+@media (max-width: 600px) {
+  .row {
+    padding: var(--space-2);
+  }
+}

--- a/src/components/new-safe/steps/Step0/index.tsx
+++ b/src/components/new-safe/steps/Step0/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Divider, Grid, Paper, Typography } from '@mui/material'
+import { Box, Button, Divider, Grid, Typography } from '@mui/material'
 import useWallet from '@/hooks/wallets/useWallet'
 import ChainSwitcher from '@/components/common/ChainSwitcher'
 import NetworkSelector from '@/components/common/NetworkSelector'
@@ -13,6 +13,7 @@ import PairingDetails from '@/components/common/PairingDetails'
 import type { ConnectedWallet } from '@/services/onboard'
 import useIsConnected from '@/hooks/useIsConnected'
 import useSetCreationStep from '@/components/new-safe/CreateSafe/useSetCreationStep'
+import layoutCss from '@/components/new-safe/CreateSafe/styles.module.css'
 
 export const ConnectWalletContent = ({ onSubmit }: { onSubmit: StepRenderProps<NewSafeFormData>['onSubmit'] }) => {
   const isWrongChain = useIsWrongChain()
@@ -30,7 +31,7 @@ export const ConnectWalletContent = ({ onSubmit }: { onSubmit: StepRenderProps<N
     <>
       {wallet && !isWrongChain && <Typography mb={2}>Wallet connected</Typography>}
       {wallet ? (
-        <Typography mb={2} component="div">
+        <Typography component="div">
           Creating a Safe on <NetworkSelector />
         </Typography>
       ) : (
@@ -49,7 +50,7 @@ export const ConnectWalletContent = ({ onSubmit }: { onSubmit: StepRenderProps<N
         </>
       )}
       {isWrongChain && (
-        <Typography mb={2}>
+        <Typography>
           Your wallet connection must match the selected network. <ChainSwitcher />
         </Typography>
       )}
@@ -62,20 +63,20 @@ const CreateSafeStep0 = ({ onSubmit, onBack, setStep }: StepRenderProps<NewSafeF
   useSetCreationStep(setStep, isConnected)
 
   return (
-    <Paper>
-      <Box>
+    <>
+      <Box className={layoutCss.row}>
         <ConnectWalletContent onSubmit={onSubmit} />
       </Box>
-      <Divider sx={{ ml: '-52px', mr: '-52px', mb: 4, mt: 3, alignSelf: 'normal' }} />
-      <Box display="flex" flexDirection="row" gap={3}>
-        <Button variant="outlined" onClick={() => onBack()}>
+      <Divider />
+      <Box className={layoutCss.row} display="flex" flexDirection="row" justifyContent="space-between" gap={3}>
+        <Button variant="outlined" size="small" onClick={() => onBack()}>
           Cancel
         </Button>
-        <Button variant="contained" onClick={() => onSubmit({})} disabled={!isConnected}>
-          Continue
+        <Button variant="contained" size="stretched" onClick={() => onSubmit({})} disabled={!isConnected}>
+          Next
         </Button>
       </Box>
-    </Paper>
+    </>
   )
 }
 

--- a/src/components/new-safe/steps/Step1/index.tsx
+++ b/src/components/new-safe/steps/Step1/index.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   Grid,
 } from '@mui/material'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import { useForm } from 'react-hook-form'
 import { useMnemonicSafeName } from '@/hooks/useMnemonicName'
 import InfoIcon from '@/public/images/notifications/info.svg'
@@ -20,6 +21,7 @@ import useIsConnected from '@/hooks/useIsConnected'
 import useSetCreationStep from '@/components/new-safe/CreateSafe/useSetCreationStep'
 
 import css from './styles.module.css'
+import layoutCss from '@/components/new-safe/CreateSafe/styles.module.css'
 
 type CreateSafeStep1Form = {
   name: string
@@ -60,67 +62,68 @@ function CreateSafeStep1({
   }
 
   return (
-    <form onSubmit={handleSubmit(onFormSubmit)} id={STEP_1_FORM_ID} className={css.form}>
-      <Grid container spacing={3}>
-        <Grid item>
-          <Box className={css.select}>
-            <Typography color="text.secondary" pl={2}>
-              Network
-            </Typography>
-            <Box className={css.networkSelect}>
+    <form onSubmit={handleSubmit(onFormSubmit)} id={STEP_1_FORM_ID}>
+      <Box className={layoutCss.row}>
+        <Grid container spacing={1}>
+          <Grid item xs={12} md={8}>
+            <TextField
+              fullWidth
+              label={errors?.[CreateSafeStep1Fields.name]?.message || 'Name'}
+              error={!!errors?.[CreateSafeStep1Fields.name]}
+              placeholder={fallbackName}
+              InputProps={{
+                endAdornment: (
+                  <Tooltip
+                    title="This name is stored locally and will never be shared with us or any third parties."
+                    arrow
+                    placement="top"
+                  >
+                    <InputAdornment position="end">
+                      <SvgIcon component={InfoIcon} inheritViewBox />
+                    </InputAdornment>
+                  </Tooltip>
+                ),
+              }}
+              InputLabelProps={{
+                shrink: true,
+              }}
+              {...register(CreateSafeStep1Fields.name)}
+            />
+          </Grid>
+          <Grid item>
+            <Box className={css.select}>
               <NetworkSelector />
             </Box>
-          </Box>
+          </Grid>
         </Grid>
-        <Grid item xs={12}>
-          <TextField
-            fullWidth
-            label={errors?.[CreateSafeStep1Fields.name]?.message || 'Name'}
-            error={!!errors?.[CreateSafeStep1Fields.name]}
-            placeholder={fallbackName}
-            InputProps={{
-              endAdornment: (
-                <Tooltip
-                  title="This name is stored locally and will never be shared with us or any third parties."
-                  arrow
-                  placement="top"
-                >
-                  <InputAdornment position="end">
-                    <SvgIcon component={InfoIcon} inheritViewBox />
-                  </InputAdornment>
-                </Tooltip>
-              ),
-            }}
-            InputLabelProps={{
-              shrink: true,
-            }}
-            {...register(CreateSafeStep1Fields.name)}
-          />
-
-          <Typography variant="body2" mt={3}>
-            By continuing, you agree to our{' '}
-            <Link href="https://gnosis-safe.io/terms" target="_blank" rel="noopener noreferrer" fontWeight={700}>
-              terms of use
-            </Link>{' '}
-            and{' '}
-            <Link href="https://gnosis-safe.io/privacy" target="_blank" rel="noopener noreferrer" fontWeight={700}>
-              privacy policy
-            </Link>
-            .
-          </Typography>
-        </Grid>
-        <Grid item xs={12}>
-          <Divider sx={{ ml: '-52px', mr: '-52px', mb: 4, mt: 3, alignSelf: 'normal' }} />
-          <Box display="flex" flexDirection="row" gap={3}>
-            <Button variant="outlined" onClick={() => onBack()}>
-              Back
-            </Button>
-            <Button type="submit" variant="contained" disabled={!isConnected}>
-              Continue
-            </Button>
-          </Box>
-        </Grid>
-      </Grid>
+        <Typography variant="body2" mt={2}>
+          By continuing, you agree to our{' '}
+          <Link href="https://gnosis-safe.io/terms" target="_blank" rel="noopener noreferrer" fontWeight={700}>
+            terms of use
+          </Link>{' '}
+          and{' '}
+          <Link href="https://gnosis-safe.io/privacy" target="_blank" rel="noopener noreferrer" fontWeight={700}>
+            privacy policy
+          </Link>
+          .
+        </Typography>
+      </Box>
+      <Divider />
+      <Box className={layoutCss.row}>
+        <Box display="flex" flexDirection="row" justifyContent="space-between" gap={3}>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={() => onBack()}
+            startIcon={<ArrowBackIcon fontSize="small" />}
+          >
+            Back
+          </Button>
+          <Button type="submit" variant="contained" size="stretched" disabled={!isConnected}>
+            Next
+          </Button>
+        </Box>
+      </Box>
     </form>
   )
 }

--- a/src/components/new-safe/steps/Step1/styles.module.css
+++ b/src/components/new-safe/steps/Step1/styles.module.css
@@ -2,18 +2,12 @@
   border: none;
 }
 
-.form {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  align-items: flex-start;
-}
-
 .select {
   display: flex;
   align-items: center;
   border-radius: 8px;
   border: 1px solid var(--color-border-light);
+  height: 56px;
 }
 
 .select:hover,

--- a/src/components/new-safe/steps/Step2/index.tsx
+++ b/src/components/new-safe/steps/Step2/index.tsx
@@ -107,14 +107,16 @@ const CreateSafeStep2 = ({
           <Typography variant="body2" mb={2}>
             Any transaction requires the confirmation of:
           </Typography>
-          <Select {...register(CreateSafeStep2Fields.threshold)} defaultValue={data.threshold} className={css.select}>
-            {ownerFields.map((_, i) => (
-              <MenuItem key={i} value={i + 1}>
-                {i + 1}
-              </MenuItem>
-            ))}
-          </Select>{' '}
-          out of {ownerFields.length} owner(s).
+          <Box display="flex" alignItems="center">
+            <Select {...register(CreateSafeStep2Fields.threshold)} defaultValue={data.threshold} className={css.select}>
+              {ownerFields.map((_, i) => (
+                <MenuItem key={i} value={i + 1}>
+                  {i + 1}
+                </MenuItem>
+              ))}
+            </Select>{' '}
+            out of {ownerFields.length} owner(s).
+          </Box>
         </Box>
         <Divider />
         <Box className={layoutCss.row}>

--- a/src/components/new-safe/steps/Step2/index.tsx
+++ b/src/components/new-safe/steps/Step2/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Grid, SvgIcon, MenuItem, Select, Tooltip, Typography, Divider, Box } from '@mui/material'
+import { Button, SvgIcon, MenuItem, Select, Tooltip, Typography, Divider, Box } from '@mui/material'
 import { FormProvider, useFieldArray, useForm } from 'react-hook-form'
 import type { ReactElement } from 'react'
 
@@ -12,6 +12,9 @@ import type { CreateSafeInfoItem } from '../../CreateSafeInfos'
 import { useSafeSetupHints } from './useSafeSetupHints'
 import useIsConnected from '@/hooks/useIsConnected'
 import useSetCreationStep from '@/components/new-safe/CreateSafe/useSetCreationStep'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import css from './styles.module.css'
+import layoutCss from '@/components/new-safe/CreateSafe/styles.module.css'
 
 export type CreateSafeStep2Form = {
   owners: NamedAddress[]
@@ -60,74 +63,70 @@ const CreateSafeStep2 = ({
   return (
     <form onSubmit={handleSubmit(onSubmit)} id={STEP_2_FORM_ID}>
       <FormProvider {...formMethods}>
-        <Grid container spacing={3}>
-          <Grid item xs={12}>
-            {ownerFields.map((field, i) => (
-              <OwnerRow
-                key={field.id}
-                index={i}
-                removable={i > 0}
-                groupName={CreateSafeStep2Fields.owners}
-                remove={removeOwner}
-              />
-            ))}
-            <Button
-              variant="text"
-              onClick={() => appendOwner({ name: '', address: '' }, { shouldFocus: true })}
-              startIcon={<SvgIcon component={AddIcon} inheritViewBox fontSize="small" />}
-              size="large"
-            >
-              Add new owner
-            </Button>
-          </Grid>
-          <Grid item xs={12}>
-            <Box p={2} sx={{ backgroundColor: 'background.main', borderRadius: '8px' }}>
-              <Typography variant="subtitle1" fontWeight={700} display="inline-flex" alignItems="center" gap={1}>
-                Safe Mobile owner key (optional){' '}
-                <Tooltip title="TODO: Add tooltip" arrow placement="top">
-                  <span style={{ display: 'flex' }}>
-                    <SvgIcon component={InfoIcon} inheritViewBox color="border" fontSize="small" />
-                  </span>
-                </Tooltip>
-              </Typography>
-              <Typography variant="body2">Use your mobile phone as your additional owner key</Typography>
-            </Box>
-          </Grid>
-
-          <Grid item xs={12}>
-            <Divider sx={{ ml: '-52px', mr: '-52px', mb: 4, mt: 3 }} />
-            <Typography variant="h4" fontWeight={700} display="inline-flex" alignItems="center" gap={1}>
-              Threshold
+        <Box className={layoutCss.row}>
+          {ownerFields.map((field, i) => (
+            <OwnerRow
+              key={field.id}
+              index={i}
+              removable={i > 0}
+              groupName={CreateSafeStep2Fields.owners}
+              remove={removeOwner}
+            />
+          ))}
+          <Button
+            variant="text"
+            onClick={() => appendOwner({ name: '', address: '' }, { shouldFocus: true })}
+            startIcon={<SvgIcon component={AddIcon} inheritViewBox fontSize="small" />}
+            size="large"
+          >
+            Add new owner
+          </Button>
+          <Box p={2} mt={3} sx={{ backgroundColor: 'background.main', borderRadius: '8px' }}>
+            <Typography variant="subtitle1" fontWeight={700} display="inline-flex" alignItems="center" gap={1}>
+              Safe Mobile owner key (optional){' '}
               <Tooltip title="TODO: Add tooltip" arrow placement="top">
                 <span style={{ display: 'flex' }}>
                   <SvgIcon component={InfoIcon} inheritViewBox color="border" fontSize="small" />
                 </span>
               </Tooltip>
             </Typography>
-            <Typography variant="body2" mb={2}>
-              Any transaction requires the confirmation of:
-            </Typography>
-            <Select {...register(CreateSafeStep2Fields.threshold)} defaultValue={data.threshold}>
-              {ownerFields.map((_, i) => (
-                <MenuItem key={i} value={i + 1}>
-                  {i + 1}
-                </MenuItem>
-              ))}
-            </Select>{' '}
-            out of {ownerFields.length} owner(s).
-          </Grid>
-          <Grid item xs={12}>
-            <Divider sx={{ ml: '-52px', mr: '-52px', mb: 4, mt: 3, alignSelf: 'normal' }} />
-            <Box display="flex" flexDirection="row" gap={3}>
-              <Button variant="outlined" onClick={handleBack}>
-                Back
-              </Button>
-              <Button type="submit" variant="contained" disabled={!isConnected}>
-                Continue
-              </Button>
-            </Box>
-          </Grid>
-        </Grid>
+            <Typography variant="body2">Use your mobile phone as your additional owner key</Typography>
+          </Box>
+        </Box>
+
+        <Divider />
+        <Box className={layoutCss.row}>
+          <Typography variant="h4" fontWeight={700} display="inline-flex" alignItems="center" gap={1}>
+            Threshold
+            <Tooltip title="TODO: Add tooltip" arrow placement="top">
+              <span style={{ display: 'flex' }}>
+                <SvgIcon component={InfoIcon} inheritViewBox color="border" fontSize="small" />
+              </span>
+            </Tooltip>
+          </Typography>
+          <Typography variant="body2" mb={2}>
+            Any transaction requires the confirmation of:
+          </Typography>
+          <Select {...register(CreateSafeStep2Fields.threshold)} defaultValue={data.threshold} className={css.select}>
+            {ownerFields.map((_, i) => (
+              <MenuItem key={i} value={i + 1}>
+                {i + 1}
+              </MenuItem>
+            ))}
+          </Select>{' '}
+          out of {ownerFields.length} owner(s).
+        </Box>
+        <Divider />
+        <Box className={layoutCss.row}>
+          <Box display="flex" flexDirection="row" justifyContent="space-between" gap={3}>
+            <Button variant="outlined" size="small" onClick={handleBack} startIcon={<ArrowBackIcon fontSize="small" />}>
+              Back
+            </Button>
+            <Button type="submit" variant="contained" size="stretched" disabled={!isConnected}>
+              Next
+            </Button>
+          </Box>
+        </Box>
       </FormProvider>
     </form>
   )

--- a/src/components/new-safe/steps/Step2/styles.module.css
+++ b/src/components/new-safe/steps/Step2/styles.module.css
@@ -1,0 +1,12 @@
+.select {
+  margin-right: var(--space-1);
+}
+
+.select :global .MuiOutlinedInput-notchedOutline {
+  border-color: var(--color-border-light);
+  border-width: 2px;
+}
+
+.select :global .MuiSelect-select {
+  padding: 12px 14px;
+}

--- a/src/components/new-safe/steps/Step3/index.tsx
+++ b/src/components/new-safe/steps/Step3/index.tsx
@@ -11,6 +11,7 @@ import { formatVisualAmount } from '@/utils/formatters'
 import type { StepRenderProps } from '@/components/new-safe/CardStepper/useCardStepper'
 import type { NewSafeFormData } from '@/components/new-safe/CreateSafe'
 import css from './styles.module.css'
+import layoutCss from '@/components/new-safe/CreateSafe/styles.module.css'
 import { getFallbackHandlerContractInstance } from '@/services/contracts/safeContracts'
 import { computeNewSafeAddress } from '@/components/create-safe/logic'
 import useWallet from '@/hooks/wallets/useWallet'
@@ -19,6 +20,7 @@ import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import { type PendingSafeData, SAFE_PENDING_CREATION_STORAGE_KEY } from '@/components/new-safe/steps/Step4'
 import useIsConnected from '@/hooks/useIsConnected'
 import useSetCreationStep from '@/components/new-safe/CreateSafe/useSetCreationStep'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 
 enum CreateSafeStep3Fields {
   name = 'name',
@@ -110,8 +112,8 @@ const CreateSafeStep3 = ({ data, onSubmit, onBack, setStep }: StepRenderProps<Ne
   }
 
   return (
-    <Grid container spacing={3}>
-      <Grid item>
+    <>
+      <Box className={layoutCss.row}>
         <Grid container spacing={3}>
           <ReviewRow name="Network" value={<ChainIndicator chainId={chain?.chainId} inline />} />
           <ReviewRow name="Name" value={<Typography>{data.name}</Typography>} />
@@ -141,10 +143,10 @@ const CreateSafeStep3 = ({ data, onSubmit, onBack, setStep }: StepRenderProps<Ne
             }
           />
         </Grid>
-      </Grid>
+      </Box>
 
-      <Grid item xs={12}>
-        <Divider sx={{ ml: '-52px', mr: '-52px', mb: 4, mt: 3 }} />
+      <Divider />
+      <Box className={layoutCss.row}>
         <Grid item xs={12}>
           <Grid container spacing={3}>
             <ReviewRow
@@ -161,25 +163,25 @@ const CreateSafeStep3 = ({ data, onSubmit, onBack, setStep }: StepRenderProps<Ne
             />
             <Grid xs={3} />
             <Grid xs={9} pt={1} pl={3}>
-              <Typography color="text.secondary">
+              <Typography variant="body2" color="text.secondary">
                 You will have to confirm a transaction with your currently connected wallet.
               </Typography>
             </Grid>
           </Grid>
         </Grid>
-      </Grid>
-      <Grid item xs={12}>
-        <Divider sx={{ ml: '-52px', mr: '-52px', mb: 4, mt: 3, alignSelf: 'normal' }} />
-        <Box display="flex" flexDirection="row" gap={3}>
-          <Button variant="outlined" onClick={handleBack}>
+      </Box>
+      <Divider />
+      <Box className={layoutCss.row}>
+        <Box display="flex" flexDirection="row" justifyContent="space-between" gap={3}>
+          <Button variant="outlined" size="small" onClick={handleBack} startIcon={<ArrowBackIcon fontSize="small" />}>
             Back
           </Button>
-          <Button variant="contained" onClick={createSafe} disabled={!isConnected}>
-            Continue
+          <Button onClick={createSafe} variant="contained" size="stretched" disabled={!isConnected}>
+            Next
           </Button>
         </Box>
-      </Grid>
-    </Grid>
+      </Box>
+    </>
   )
 }
 

--- a/src/components/new-safe/steps/Step4/StatusMessage.tsx
+++ b/src/components/new-safe/steps/Step4/StatusMessage.tsx
@@ -68,7 +68,8 @@ const StatusMessage = ({ status }: { status: SafeCreationStatus }) => {
         <Box
           sx={({ palette }) => ({ backgroundColor: palette.warning.background, borderRadius: '6px' })}
           padding={3}
-          my={3}
+          mt={4}
+          mb={0}
         >
           <Typography variant="body2">{stepInfo.instruction}</Typography>
         </Box>

--- a/src/components/new-safe/steps/Step4/index.tsx
+++ b/src/components/new-safe/steps/Step4/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react'
-import { Box, Button, Divider, Grid, Paper, Tooltip } from '@mui/material'
+import { Box, Button, Divider, Grid, Paper, Tooltip, Typography } from '@mui/material'
 import { useRouter } from 'next/router'
 
 import Track from '@/components/common/Track'
@@ -17,6 +17,7 @@ import StatusStepper from '@/components/new-safe/steps/Step4/StatusStepper'
 import { trackEvent } from '@/services/analytics'
 import useChainId from '@/hooks/useChainId'
 import { getRedirect } from '@/components/new-safe/steps/Step4/logic'
+import layoutCss from '@/components/new-safe/CreateSafe/styles.module.css'
 
 export const SAFE_PENDING_CREATION_STORAGE_KEY = 'pendingSafe'
 
@@ -75,19 +76,23 @@ export const CreateSafeStatus = ({ setStep }: StepRenderProps<NewSafeFormData>) 
         textAlign: 'center',
       }}
     >
-      <StatusMessage status={status} />
+      <Box className={layoutCss.row}>
+        <StatusMessage status={status} />
+      </Box>
 
       {!displayActions && pendingSafe && (
         <>
-          <Divider sx={{ ml: '-52px', mr: '-52px', mb: 4, mt: 4, alignSelf: 'normal' }} />
-          <StatusStepper pendingSafe={pendingSafe} status={status} />
+          <Divider />
+          <Box className={layoutCss.row}>
+            <StatusStepper pendingSafe={pendingSafe} status={status} />
+          </Box>
         </>
       )}
 
       {displaySafeLink && (
         <>
-          <Divider sx={{ ml: '-52px', mr: '-52px', mb: 3, mt: 3, alignSelf: 'normal' }} />
-          <Box mt={3}>
+          <Divider />
+          <Box className={layoutCss.row}>
             <Track {...CREATE_SAFE_EVENTS.GO_TO_SAFE}>
               <Button variant="contained" onClick={onFinish}>
                 Start using Safe
@@ -99,21 +104,27 @@ export const CreateSafeStatus = ({ setStep }: StepRenderProps<NewSafeFormData>) 
 
       {displayActions && (
         <>
-          <Divider sx={{ ml: '-52px', mr: '-52px', mb: 3, mt: 3, alignSelf: 'normal' }} />
-          <Grid container justifyContent="center" gap={2}>
-            <Track {...CREATE_SAFE_EVENTS.CANCEL_CREATE_SAFE}>
-              <Button onClick={onClose}>Cancel</Button>
-            </Track>
-            <Track {...CREATE_SAFE_EVENTS.RETRY_CREATE_SAFE}>
-              <Tooltip title={!isConnected ? 'Please make sure your wallet is connected on the correct network.' : ''}>
-                <span>
-                  <Button onClick={onCreate} variant="contained" disabled={!isConnected}>
-                    Retry
-                  </Button>
-                </span>
-              </Tooltip>
-            </Track>
-          </Grid>
+          <Divider />
+          <Box className={layoutCss.row}>
+            <Grid container justifyContent="center" gap={2}>
+              <Track {...CREATE_SAFE_EVENTS.CANCEL_CREATE_SAFE}>
+                <Button onClick={onClose} variant="outlined">
+                  Cancel
+                </Button>
+              </Track>
+              <Track {...CREATE_SAFE_EVENTS.RETRY_CREATE_SAFE}>
+                <Tooltip
+                  title={!isConnected ? 'Please make sure your wallet is connected on the correct network.' : ''}
+                >
+                  <Typography display="flex" height={1}>
+                    <Button onClick={onCreate} variant="contained" disabled={!isConnected}>
+                      Retry
+                    </Button>
+                  </Typography>
+                </Tooltip>
+              </Track>
+            </Grid>
+          </Box>
         </>
       )}
     </Paper>


### PR DESCRIPTION
## What it solves

- Adjust button layout for safe creation steps
- Remove padding from Stepper and instead handle row spacing of each view with a single css class and optimize it for smaller screens
- Remove negative margins from `Divider` elements
- Improve `NetworkSelector` clickable area
- Adjust Threshold select size and color

## How to test it

- Click through each create safe step on `/new-safe/create` and compare with Design

## Screenshots

<img width="791" alt="Screenshot 2022-11-04 at 15 43 46" src="https://user-images.githubusercontent.com/5880855/200003183-bb49d842-f6ee-4930-b655-e7a138715451.png">

<img width="794" alt="Screenshot 2022-11-04 at 15 44 56" src="https://user-images.githubusercontent.com/5880855/200003421-e9e80180-6d9a-4d92-b950-9c383ac78e67.png">
<img width="798" alt="Screenshot 2022-11-04 at 15 45 15" src="https://user-images.githubusercontent.com/5880855/200003496-fd15eadc-ed18-4d05-9dac-3acfdfb005e7.png">
<img width="483" alt="Screenshot 2022-11-04 at 15 45 37" src="https://user-images.githubusercontent.com/5880855/200003628-21cd8b21-029f-4ef1-a832-5ebaa1da4f87.png">
