### PR TITLE
fix: Keep accordion details mounted for transition

### DIFF
--- a/src/components/safe-apps/AppFrame/TransactionQueueBar/index.tsx
+++ b/src/components/safe-apps/AppFrame/TransactionQueueBar/index.tsx
@@ -49,7 +49,6 @@ const TransactionQueueBar = ({
                 enter: 0,
                 exit: 500,
               },
-              unmountOnExit: true,
               mountOnEnter: true,
             }}
             sx={{

--- a/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
+++ b/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
@@ -29,10 +29,6 @@ export const ExpandableTransactionItem = ({
   return (
     <Accordion
       disableGutters
-      TransitionProps={{
-        mountOnEnter: false,
-        unmountOnExit: true,
-      }}
       elevation={0}
       defaultExpanded={!!txDetails}
       className={classNames(css.accordion, { [css.batched]: isBatched })}


### PR DESCRIPTION
For some reason we had the `unmountOnExit` prop set for the accordions which made the animation look choppy.

Before:

https://user-images.githubusercontent.com/5880855/200006728-112dabed-4663-4dbb-bb0f-1648907e4a18.mov



After:


https://user-images.githubusercontent.com/5880855/200006743-fe18f28c-eeaf-40df-b1cd-afb1e331725e.mov


