### PR TITLE
feat: unsigned warning

### DIFF
--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -27,7 +27,7 @@ import SignTxButton from '@/components/transactions/SignTxButton'
 import RejectTxButton from '@/components/transactions/RejectTxButton'
 import useWallet from '@/hooks/wallets/useWallet'
 import useIsWrongChain from '@/hooks/useIsWrongChain'
-import { DelegateCallWarning } from '@/components/transactions/Warning'
+import { DelegateCallWarning, UnsignedWarning } from '@/components/transactions/Warning'
 import Multisend from '@/components/transactions/TxDetails/TxData/DecodedData/Multisend'
 
 export const NOT_AVAILABLE = 'n/a'
@@ -43,13 +43,13 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
   const isWrongChain = useIsWrongChain()
   const isQueue = isTxQueued(txSummary.txStatus)
   const awaitingExecution = isAwaitingExecution(txSummary.txStatus)
-  // confirmations are in detailedExecutionInfo
-  const hasSigners = isMultisigExecutionInfo(txSummary.executionInfo) && txSummary.executionInfo.confirmationsRequired
+  const isUnsigned =
+    isMultisigExecutionInfo(txSummary.executionInfo) && txSummary.executionInfo.confirmationsSubmitted === 0
 
   return (
     <>
       {/* /Details */}
-      <div className={`${css.details} ${!hasSigners ? css.noSigners : ''}`}>
+      <div className={`${css.details} ${isUnsigned ? css.noSigners : ''}`}>
         <div className={css.shareLink}>
           <TxShareLink id={txSummary.id} />
         </div>
@@ -75,6 +75,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
         )}
 
         <div className={css.txSummary}>
+          {isUnsigned && <UnsignedWarning />}
           {txDetails.txData?.operation === Operation.DELEGATE && (
             <div className={css.delegateCall}>
               <DelegateCallWarning showWarning={!txDetails.txData.trustedDelegateCallTarget} />
@@ -93,7 +94,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
       </div>
 
       {/* Signers */}
-      {hasSigners && (
+      {!isUnsigned && (
         <div className={css.txSigners}>
           <TxSigners txDetails={txDetails} txSummary={txSummary} />
           {wallet && !isWrongChain && isQueue && (

--- a/src/components/transactions/Warning/index.tsx
+++ b/src/components/transactions/Warning/index.tsx
@@ -64,7 +64,7 @@ export const ThresholdWarning = (): ReactElement => (
 
 export const UnsignedWarning = (): ReactElement => (
   <Warning
-    title="This transaction was proposed without an owner's signature."
+    title="This transaction is unsigned and could have been created by anyone. To avoid phishing, only sign it if you trust the source of the link."
     severity="error"
     text="Untrusted transaction"
   />

--- a/src/components/transactions/Warning/index.tsx
+++ b/src/components/transactions/Warning/index.tsx
@@ -1,8 +1,32 @@
 import type { ReactElement } from 'react'
 import { Alert, Link, SvgIcon, Tooltip } from '@mui/material'
-import { tooltipClasses } from '@mui/material/Tooltip'
+import type { AlertColor } from '@mui/material'
+
 import InfoOutlinedIcon from '@/public/images/notifications/info.svg'
 import css from './styles.module.css'
+
+const Warning = ({
+  title,
+  text,
+  severity,
+}: {
+  title: string | ReactElement
+  text: string
+  severity: AlertColor
+}): ReactElement => {
+  return (
+    <Tooltip title={title} placement="top-start" arrow>
+      <Alert
+        className={css.alert}
+        sx={{ borderLeft: ({ palette }) => `3px solid ${palette[severity].main} !important` }}
+        severity={severity}
+        icon={<SvgIcon component={InfoOutlinedIcon} inheritViewBox color={severity} />}
+      >
+        <b>{text}</b>
+      </Alert>
+    </Tooltip>
+  )
+}
 
 const UNEXPECTED_DELEGATE_ARTICLE =
   'https://help.gnosis-safe.io/en/articles/6302452-why-do-i-see-an-unexpected-delegate-call-warning-in-my-transaction'
@@ -10,12 +34,7 @@ const UNEXPECTED_DELEGATE_ARTICLE =
 export const DelegateCallWarning = ({ showWarning }: { showWarning: boolean }): ReactElement => {
   const severity = showWarning ? 'warning' : 'success'
   return (
-    <Tooltip
-      sx={{
-        [`& .${tooltipClasses.arrow}`]: {
-          left: '-46px !important', // place the arrow over the Alert icon
-        },
-      }}
+    <Warning
       title={
         <>
           This transaction calls a smart contract that will be able to modify your Safe.
@@ -29,39 +48,24 @@ export const DelegateCallWarning = ({ showWarning }: { showWarning: boolean }): 
           )}
         </>
       }
-      placement="top-start"
-      arrow
-    >
-      <Alert
-        className={css.alert}
-        sx={{ borderLeft: ({ palette }) => `3px solid ${palette[severity].main}` }}
-        severity={severity}
-        icon={<SvgIcon component={InfoOutlinedIcon} inheritViewBox color={severity} />}
-      >
-        <b>{showWarning ? 'Unexpected delegate call' : 'Delegate call'}</b>
-      </Alert>
-    </Tooltip>
+      severity={severity}
+      text={showWarning ? 'Unexpected delegate call' : 'Delegate call'}
+    />
   )
 }
 
 export const ThresholdWarning = (): ReactElement => (
-  <Tooltip
-    sx={{
-      [`& .${tooltipClasses.arrow}`]: {
-        left: '-93px !important', // place the arrow over the Alert icon
-      },
-    }}
+  <Warning
     title="This transaction potentially alters the number of confirmations required to execute a transaction."
-    placement="top-start"
-    arrow
-  >
-    <Alert
-      className={css.alert}
-      sx={{ borderLeft: ({ palette }) => `3px solid ${palette.warning.main}` }}
-      severity="warning"
-      icon={<SvgIcon component={InfoOutlinedIcon} inheritViewBox color="warning" />}
-    >
-      <b>Confirmation policy change</b>
-    </Alert>
-  </Tooltip>
+    severity="warning"
+    text="Confirmation policy change"
+  />
+)
+
+export const UnsignedWarning = (): ReactElement => (
+  <Warning
+    title="This transaction was proposed without an owner's signature."
+    severity="error"
+    text="Untrusted transaction"
+  />
 )


### PR DESCRIPTION
## What it solves

Resolves #898

## How this PR fixes it

A new warning is shown when a proposed transaction has no signatures.

## How to test it

Open `/gor:0xF3E977e7Eea1A91ce5B2d5077e5A7195Ae18b722/transactions/tx?id=multisig_0xF3E977e7Eea1A91ce5B2d5077e5A7195Ae18b722_0xc0c5380e113ecff6054c69d02fe7d5ee753db29635548c80794bd028cf614bb5` and observe the warning.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/200259791-c6bbce84-afcc-4e15-98a8-5a14226b1dfb.png)