### PR TITLE
fix: Reword transaction guards description

### DIFF
--- a/src/components/settings/TransactionGuards/index.tsx
+++ b/src/components/settings/TransactionGuards/index.tsx
@@ -50,8 +50,8 @@ const TransactionGuards = () => {
           <Box>
             <Typography>
               Transaction guards impose additional constraints that are checked prior to executing a Safe transaction.
-              Transaction guards are potentially risky, so make sure to only use modules from trusted sources. Learn
-              more about transaction guards{' '}
+              Transaction guards are potentially risky, so make sure to only use transaction guards from trusted
+              sources. Learn more about transaction guards{' '}
               <Link
                 href="https://help.gnosis-safe.io/en/articles/5324092-what-is-a-transaction-guard"
                 rel="noreferrer noopener"


### PR DESCRIPTION
Replaces the word "modules" with "transaction guards" in the transaction guards description:

![Captura de pantalla de 2022-11-04 20-18-42](https://user-images.githubusercontent.com/6764315/200058088-618e3aba-5090-4b7a-9609-57d7e58e3d74.png)
