### PR TITLE
PoC: timelocked transactions

### DIFF
--- a/src/components/common/DatePickerInput/index.tsx
+++ b/src/components/common/DatePickerInput/index.tsx
@@ -1,21 +1,23 @@
 import { useFormContext, Controller } from 'react-hook-form'
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
-import { DatePicker } from '@mui/x-date-pickers/DatePicker'
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 import TextField from '@mui/material/TextField'
-import { isFuture, isValid, startOfDay } from 'date-fns'
+import { isFuture, isPast, isValid, startOfDay } from 'date-fns'
+import { DateTimePicker } from '@mui/x-date-pickers'
 
 const DatePickerInput = ({
   name,
   label,
   deps,
   disableFuture = true,
+  disablePast = false,
   validate,
 }: {
   name: string
   label: string
   deps?: string[]
   disableFuture?: boolean
+  disablePast?: boolean
   validate?: (value: Date | null) => string | undefined
 }) => {
   const { control } = useFormContext()
@@ -40,16 +42,22 @@ const DatePickerInput = ({
             return 'Date cannot be in the future'
           }
 
+          // Compare days using `startOfDay` to ignore timezone offset
+          if (disablePast && isPast(val)) {
+            return 'Date cannot be in the past'
+          }
+
           return validate?.(val)
         },
       }}
       render={({ field, fieldState }) => (
         <LocalizationProvider dateAdapter={AdapterDateFns}>
-          <DatePicker
+          <DateTimePicker
             label={label}
-            inputFormat="dd/MM/yyyy"
+            inputFormat="dd/MM/yyyy hh:mm:ss"
             {...field}
             disableFuture={disableFuture}
+            disablePast={disablePast}
             renderInput={({ label, error: _, ...params }) => (
               <TextField label={fieldState.error?.message || label} {...params} fullWidth error={!!fieldState.error} />
             )}

--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -16,6 +16,7 @@ import TxType from '@/components/transactions/TxType'
 import OwnersIcon from '@/public/images/common/owners.svg'
 import useIsWrongChain from '@/hooks/useIsWrongChain'
 import useIsPending from '@/hooks/useIsPending'
+import TxTimingInfo from '../TxTimingInfo'
 
 const getStatusColor = (value: TransactionStatus, palette: Palette) => {
   switch (value) {
@@ -101,6 +102,7 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
             <SignTxButton txSummary={item.transaction} compact />
           )}
           <RejectTxButton txSummary={item.transaction} compact />
+          <TxTimingInfo transaction={item.transaction} />
         </Box>
       )}
 

--- a/src/components/transactions/TxTimingInfo/index.tsx
+++ b/src/components/transactions/TxTimingInfo/index.tsx
@@ -9,6 +9,7 @@ import { Box, Tooltip } from '@mui/material'
 import { BigNumber, ethers } from 'ethers'
 import { AbiCoder, Interface } from 'ethers/lib/utils'
 import { isPast } from 'date-fns'
+import chains from '@/config/chains'
 
 const TxTimingDetails = ({ txId }: { txId: string }) => {
   const { safe, safeAddress } = useSafeInfo()
@@ -28,8 +29,10 @@ const TxTimingDetails = ({ txId }: { txId: string }) => {
     [txId, safe.chainId, safe.txQueuedTag, safe.txHistoryTag, safeAddress],
     false,
   )
-
-  const timeLockAddress = '6e8c8403837e305a0312beba98b7001c117a69a7'
+  const timeLockAddress =
+    safe.chainId === chains.eth
+      ? '2d96225942ada8e7f928b172c75df7b1c3baf343'
+      : '6e8c8403837e305a0312beba98b7001c117a69a7'
   const humanReadableAbi = ['function checkLock(uint) public view']
   const timeLockInterface = new Interface(humanReadableAbi)
 
@@ -73,7 +76,9 @@ const TxTimingDetails = ({ txId }: { txId: string }) => {
 }
 
 const TxTimingInfo = ({ transaction }: { transaction: TransactionSummary }) => {
-  if (isMultiSendTxInfo(transaction.txInfo)) {
+  const { safe } = useSafeInfo()
+
+  if ((safe.chainId === chains.eth || safe.chainId === chains.gor) && isMultiSendTxInfo(transaction.txInfo)) {
     return <TxTimingDetails txId={transaction.id} />
   }
   return null

--- a/src/components/transactions/TxTimingInfo/index.tsx
+++ b/src/components/transactions/TxTimingInfo/index.tsx
@@ -1,0 +1,82 @@
+import AccessTimeIcon from '@mui/icons-material/AccessTime'
+import useAsync from '@/hooks/useAsync'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { sameAddress } from '@/utils/addresses'
+import { isMultiSendTxInfo } from '@/utils/transaction-guards'
+import type { TransactionDetails, TransactionSummary } from '@gnosis.pm/safe-react-gateway-sdk'
+import { getTransactionDetails } from '@gnosis.pm/safe-react-gateway-sdk'
+import { Box, Tooltip } from '@mui/material'
+import { BigNumber, ethers } from 'ethers'
+import { AbiCoder, Interface } from 'ethers/lib/utils'
+import { isPast } from 'date-fns'
+
+const TxTimingDetails = ({ txId }: { txId: string }) => {
+  const { safe, safeAddress } = useSafeInfo()
+
+  const [txDetails] = useAsync<TransactionDetails>(
+    () => {
+      if (!txId || !safeAddress) return
+
+      return getTransactionDetails(safe.chainId, txId).then((details) => {
+        // If the transaction is not related to the current safe, throw an error
+        if (!sameAddress(details.safeAddress, safeAddress)) {
+          return Promise.reject(new Error('Transaction with this id was not found in this Safe'))
+        }
+        return details
+      })
+    },
+    [txId, safe.chainId, safe.txQueuedTag, safe.txHistoryTag, safeAddress],
+    false,
+  )
+
+  const timeLockAddress = '6e8c8403837e305a0312beba98b7001c117a69a7'
+  const humanReadableAbi = ['function checkLock(uint) public view']
+  const timeLockInterface = new Interface(humanReadableAbi)
+
+  const multiSendData = txDetails?.txData?.hexData?.toLowerCase()
+  if (multiSendData?.includes(timeLockAddress)) {
+    // Timelocked tx, decode the timestamp, hacky for now
+    const startOfData = multiSendData.indexOf(timeLockAddress)
+    const txMetaData = ethers.utils.hexZeroPad(
+      `0x${multiSendData.slice(startOfData + 40, startOfData + 40 + 64 + 64)}`,
+      32 * 2,
+    )
+
+    const abiCoder = new AbiCoder()
+    const [_, txDataByteLength] = abiCoder.decode(['uint256', 'uint256'], txMetaData)
+
+    const dataLength = (txDataByteLength as BigNumber).toNumber() * 2
+    let txData = `0x${multiSendData.slice(startOfData + 168, startOfData + 168 + dataLength)}`
+
+    const decodedTxData = timeLockInterface.decodeFunctionData('checkLock', txData)
+
+    const timestamp = BigNumber.from(decodedTxData[0]).toNumber()
+    const date = new Date(timestamp * 1000)
+    const canBeExecuted = isPast(date)
+    if (canBeExecuted) {
+      return null
+    }
+    return (
+      <Tooltip
+        arrow
+        placement="top"
+        title={`This transaction is not executable before ${date.toLocaleDateString()} - ${date.toLocaleTimeString()}`}
+      >
+        <Box alignItems="center" display="flex">
+          <AccessTimeIcon color="warning" fontSize="small" />
+        </Box>
+      </Tooltip>
+    )
+  }
+
+  return null
+}
+
+const TxTimingInfo = ({ transaction }: { transaction: TransactionSummary }) => {
+  if (isMultiSendTxInfo(transaction.txInfo)) {
+    return <TxTimingDetails txId={transaction.id} />
+  }
+  return null
+}
+
+export default TxTimingInfo

--- a/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
+++ b/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
@@ -34,7 +34,6 @@ type FormData = {
 }
 
 const AdvancedParamsForm = ({ params, ...props }: AdvancedParamsFormProps) => {
-  console.log(params)
   const formMethods = useForm<FormData>({
     mode: 'onChange',
     defaultValues: {

--- a/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
+++ b/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
@@ -9,6 +9,7 @@ import NonceForm from '../NonceForm'
 import ModalDialog from '@/components/common/ModalDialog'
 import { AdvancedField, type AdvancedParameters } from './types.d'
 import GasLimitInput from './GasLimitInput'
+import DatePickerInput from '@/components/common/DatePickerInput'
 
 const HELP_LINK = 'https://help.gnosis-safe.io/en/articles/4738445-advanced-transaction-parameters'
 
@@ -29,9 +30,11 @@ type FormData = {
   [AdvancedField.maxFeePerGas]: string
   [AdvancedField.maxPriorityFeePerGas]: string
   [AdvancedField.safeTxGas]: number
+  [AdvancedField.executableAfter]?: Date
 }
 
 const AdvancedParamsForm = ({ params, ...props }: AdvancedParamsFormProps) => {
+  console.log(params)
   const formMethods = useForm<FormData>({
     mode: 'onChange',
     defaultValues: {
@@ -57,6 +60,7 @@ const AdvancedParamsForm = ({ params, ...props }: AdvancedParamsFormProps) => {
       maxFeePerGas: params.maxFeePerGas,
       maxPriorityFeePerGas: params.maxPriorityFeePerGas,
       safeTxGas: params.safeTxGas,
+      executableAfter: params.executableAfter,
     })
   }
 
@@ -68,6 +72,7 @@ const AdvancedParamsForm = ({ params, ...props }: AdvancedParamsFormProps) => {
       maxFeePerGas: safeParseUnits(data.maxFeePerGas) || params.maxFeePerGas,
       maxPriorityFeePerGas: safeParseUnits(data.maxPriorityFeePerGas) || params.maxPriorityFeePerGas,
       safeTxGas: data.safeTxGas || params.safeTxGas,
+      executableAfter: data.executableAfter?.getTime(),
     })
   }
 
@@ -98,6 +103,23 @@ const AdvancedParamsForm = ({ params, ...props }: AdvancedParamsFormProps) => {
                       nonce={params.nonce}
                       recommendedNonce={props.recommendedNonce}
                       readonly={props.nonceReadonly}
+                    />
+                  </FormControl>
+                </Grid>
+              )}
+
+              {/* Executable after */}
+              {!props.nonceReadonly && (
+                <Grid item xs={6}>
+                  <FormControl fullWidth>
+                    <DatePickerInput
+                      disableFuture={false}
+                      disablePast
+                      label="Executable after"
+                      {...register(AdvancedField.executableAfter, {
+                        required: false,
+                        valueAsDate: true,
+                      })}
                     />
                   </FormControl>
                 </Grid>

--- a/src/components/tx/AdvancedParams/types.d.ts
+++ b/src/components/tx/AdvancedParams/types.d.ts
@@ -5,6 +5,7 @@ export enum AdvancedField {
   maxFeePerGas = 'maxFeePerGas',
   maxPriorityFeePerGas = 'maxPriorityFeePerGas',
   safeTxGas = 'safeTxGas',
+  executableAfter = 'executableAfter',
 }
 
 export type AdvancedParameters = Partial<{
@@ -14,4 +15,5 @@ export type AdvancedParameters = Partial<{
   [AdvancedField.maxFeePerGas]: BigNumber
   [AdvancedField.maxPriorityFeePerGas]: BigNumber
   [AdvancedField.safeTxGas]: number
+  [AdvancedField.executableAfter]: number
 }>

--- a/src/components/tx/AdvancedParams/useAdvancedParams.ts
+++ b/src/components/tx/AdvancedParams/useAdvancedParams.ts
@@ -20,6 +20,7 @@ export const useAdvancedParams = ({
       maxFeePerGas: manualParams?.maxFeePerGas ?? maxFeePerGas,
       maxPriorityFeePerGas: manualParams?.maxPriorityFeePerGas ?? maxPriorityFeePerGas,
       safeTxGas: manualParams?.safeTxGas ?? safeTxGas,
+      executableAfter: manualParams?.executableAfter,
     }),
     [manualParams, nonce, userNonce, gasLimit, maxFeePerGas, maxPriorityFeePerGas, safeTxGas],
   )

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -31,6 +31,7 @@ import type { TransactionOptions } from '@gnosis.pm/safe-core-sdk-types'
 import { hasFeature } from '@/utils/chains'
 import uniqBy from 'lodash/uniqBy'
 import { Errors, logError } from '@/services/exceptions'
+import { type BigNumber, ethers } from 'ethers'
 
 export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction => {
   const getMissingSigners = ({
@@ -201,4 +202,40 @@ export const getTxOrigin = (app?: SafeAppData): string | undefined => {
   }
 
   return origin
+}
+
+/**
+ * Decodes the data of a multiSend tx into its separate txs
+ *
+ * This function is currently not tested as it's only used by jest tests to decode and check created multiSend txs
+ *
+ * @param data tx.data
+ * @returns Array of multiSend MetaTransactionData
+ */
+export const decodeMultiSendTxs = (data: string): MetaTransactionData[] => {
+  const multiSendInterface = new ethers.utils.Interface([
+    'function multiSend(bytes memory transactions) public payable ',
+  ])
+  const abiCoder = new ethers.utils.AbiCoder()
+  // decode multiSend and remove '0x'
+  let remainingData = multiSendInterface.decodeFunctionData('multiSend', data)[0].slice(2)
+
+  const txs: MetaTransactionData[] = []
+  while (remainingData.length > 0) {
+    const txDataEncoded = ethers.utils.hexZeroPad(`0x${remainingData.slice(2, 170)}`, 32 * 3)
+    const [txTo, txValue, txDataByteLength] = abiCoder.decode(['address', 'uint256', 'uint256'], txDataEncoded)
+    remainingData = remainingData.slice(170)
+
+    const dataLength = (txDataByteLength as BigNumber).toNumber() * 2
+    let txData = `0x${remainingData.slice(0, dataLength)}`
+    remainingData = remainingData.slice(dataLength)
+    txs.push({
+      to: txTo.toString(),
+      value: txValue.toString(),
+      data: txData,
+      operation: 0,
+    })
+  }
+
+  return txs
 }


### PR DESCRIPTION
## What it solves
Adds the option to make a tx executable after a certain time.

### Todos
- [x] Enable it for multisends
- [x] Add more networks (currently only goerli)

## How to test it
On **Goerli**
1. Create a new tx
2. Open the advanced parameters
3. Set a time for `executable after` field
4. Witness the time icon in the queue. Execution will revert until that time is reached.


## Screenshots
![Screenshot 2022-11-04 at 17 26 26](https://user-images.githubusercontent.com/2670790/200287817-ebdb98c3-e247-4a53-9917-86a7662c59ab.png)
![Screenshot 2022-11-04 at 17 27 19](https://user-images.githubusercontent.com/2670790/200287804-b7523fde-6617-462d-a093-d169b517f2b2.png)
![Screenshot 2022-11-04 at 17 26 41](https://user-images.githubusercontent.com/2670790/200287812-8b0a8c03-520e-4a31-bca7-1696748713a3.png)

