### PR TITLE
fix: dark mode notification bell colour

### DIFF
--- a/src/components/notification-center/NotificationCenter/styles.module.css
+++ b/src/components/notification-center/NotificationCenter/styles.module.css
@@ -4,6 +4,10 @@
   height: 100%;
 }
 
+.bell svg path {
+  stroke: var(--color-text-primary);
+}
+
 .popoverContainer {
   width: 446px;
   border: 1px solid var(--color-border-light);


### PR DESCRIPTION
## What it solves

Resolves dark mode colour.

## How this PR fixes it

The `stroke` colour of the notification centre bell in dark mode is now set to that of `"text.primary"`. It has to be done via CSS as `stroke` does not seem to play well with `SvgIcon`.

## How to test it

Open the Safe and switch between light/dark mode. Observe the notification centre bell icon change accordingly.

## Screenshots

Before:

![image](https://user-images.githubusercontent.com/20442784/200301157-d91a7291-a887-4140-8697-967010099266.png)

After:

![image](https://user-images.githubusercontent.com/20442784/200301182-012c6d0c-cb8b-4b1f-b250-e3fb6d0d80a1.png)

![image](https://user-images.githubusercontent.com/20442784/200301224-2f3eaaa2-cf1d-40e6-8e49-2dcfe6153938.png)