### PR TITLE
fix: set default `recipient`

### DIFF
--- a/src/components/tx/modals/NewTxModal/index.tsx
+++ b/src/components/tx/modals/NewTxModal/index.tsx
@@ -34,7 +34,7 @@ const useTxBuilderApp = (): { app?: SafeAppData; link: UrlObject } => {
   }
 }
 
-const NewTxModal = ({ onClose, recipient }: { onClose: () => void; recipient?: string }): ReactElement => {
+const NewTxModal = ({ onClose, recipient = '' }: { onClose: () => void; recipient?: string }): ReactElement => {
   const [tokenModalOpen, setTokenModalOpen] = useState<boolean>(false)
   const [nftsModalOpen, setNftModalOpen] = useState<boolean>(false)
   const txBuilder = useTxBuilderApp()


### PR DESCRIPTION
## What it solves

Resolves #1069 

## How this PR fixes it

We [set the `initialData` of `TokenTransferModal` and `NftTransferModal`](https://github.com/safe-global/web-core/blob/dev/src/components/tx/modals/NewTxModal/index.tsx#L88-L91) when [sending to a contact from the address book](https://github.com/safe-global/web-core/blob/dev/src/components/address-book/AddressBookTable/index.tsx#L163). 

We weren't setting a default `recipient` value [for our `formData`](https://github.com/safe-global/web-core/blob/dev/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx#L72). An empty string is now used by default.

## How to test it

Unable to replicate.