### PR TITLE
Chore: enable sourcemaps on prod

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,7 @@ import withBundleAnalyzer from '@next/bundle-analyzer'
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
+  productionBrowserSourceMaps: true,
   eslint: {
     dirs: ['src'],
   },


### PR DESCRIPTION
## What it solves
Upload sourcemaps along with the code, so that we can see better traces on Sentry and in the console on prod.