### PR TITLE
fix: adjust modals to hug long addresses

### DIFF
--- a/src/components/common/EthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/index.tsx
@@ -70,10 +70,12 @@ const EthHashInfo = ({
         )}
 
         <Box className={css.addressRow}>
-          <Typography variant="body2" fontWeight="inherit" component="div" className={css.address}>
+          <Typography variant="body2">
             {showPrefix && shouldPrefix && prefix && <b>{prefix}:</b>}
-            <span className={css.mobileAddress}>{shortenAddress(address)}</span>
-            <span className={css.desktopAddress}>{shortAddress ? shortenAddress(address) : address}</span>
+            <Box className={css.address} component="span">
+              <span className={css.mobileAddress}>{shortenAddress(address)}</span>
+              <span className={css.desktopAddress}>{shortAddress ? shortenAddress(address) : address}</span>
+            </Box>
           </Typography>
 
           {showCopyButton && (

--- a/src/components/common/EthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/index.tsx
@@ -70,12 +70,10 @@ const EthHashInfo = ({
         )}
 
         <Box className={css.addressRow}>
-          <Typography variant="body2">
+          <Typography variant="body2" fontWeight="inherit">
             {showPrefix && shouldPrefix && prefix && <b>{prefix}:</b>}
-            <Box component="span">
-              <span className={css.mobileAddress}>{shortenAddress(address)}</span>
-              <span className={css.desktopAddress}>{shortAddress ? shortenAddress(address) : address}</span>
-            </Box>
+            <span className={css.mobileAddress}>{shortenAddress(address)}</span>
+            <span className={css.desktopAddress}>{shortAddress ? shortenAddress(address) : address}</span>
           </Typography>
 
           {showCopyButton && (

--- a/src/components/common/EthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/index.tsx
@@ -72,7 +72,7 @@ const EthHashInfo = ({
         <Box className={css.addressRow}>
           <Typography variant="body2">
             {showPrefix && shouldPrefix && prefix && <b>{prefix}:</b>}
-            <Box className={css.address} component="span">
+            <Box component="span">
               <span className={css.mobileAddress}>{shortenAddress(address)}</span>
               <span className={css.desktopAddress}>{shortAddress ? shortenAddress(address) : address}</span>
             </Box>

--- a/src/components/common/EthHashInfo/styles.module.css
+++ b/src/components/common/EthHashInfo/styles.module.css
@@ -2,12 +2,12 @@
   display: flex;
   align-items: center;
   gap: 0.5em;
+  line-height: 1.4;
 }
 
-.container,
 .address {
-  font-size: inherit;
-  line-height: 1.4;
+  font-family: monospace;
+  font-size: 13px;
 }
 
 .avatar {
@@ -35,7 +35,7 @@
   display: none;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 599px) {
   .mobileAddress {
     display: inline-block;
   }

--- a/src/components/common/EthHashInfo/styles.module.css
+++ b/src/components/common/EthHashInfo/styles.module.css
@@ -30,7 +30,7 @@
   display: none;
 }
 
-@media (max-width: 599px) {
+@media (max-width: 600px) {
   .mobileAddress {
     display: inline-block;
   }

--- a/src/components/common/EthHashInfo/styles.module.css
+++ b/src/components/common/EthHashInfo/styles.module.css
@@ -5,11 +5,6 @@
   line-height: 1.4;
 }
 
-.address {
-  font-family: monospace;
-  font-size: 13px;
-}
-
 .avatar {
   flex-shrink: 0;
 }

--- a/src/components/common/ModalDialog/index.tsx
+++ b/src/components/common/ModalDialog/index.tsx
@@ -5,16 +5,14 @@ import CloseIcon from '@mui/icons-material/Close'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import * as React from 'react'
 
+import css from './styles.module.css'
+
 interface ModalDialogProps extends DialogProps {
   dialogTitle?: React.ReactNode
   hideChainIndicator?: boolean
 }
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
-  '& .MuiDialog-paper': {
-    minWidth: '600px',
-    margin: '0px',
-  },
   '& .MuiDialogActions-root': {
     borderTop: `2px solid ${theme.palette.divider}`,
     padding: theme.spacing(3),
@@ -78,12 +76,7 @@ const ModalDialog = ({
       {...restProps}
       fullScreen={fullScreen}
       scroll="body"
-      PaperProps={{
-        sx: {
-          minWidth: [null, null, 600],
-          margin: '0px',
-        },
-      }}
+      className={css.paper}
       onClick={(e) => e.stopPropagation()}
     >
       {dialogTitle && (

--- a/src/components/common/ModalDialog/index.tsx
+++ b/src/components/common/ModalDialog/index.tsx
@@ -74,7 +74,18 @@ const ModalDialog = ({
   const fullScreen = useMediaQuery(theme.breakpoints.down('sm'))
 
   return (
-    <StyledDialog {...restProps} fullScreen={fullScreen} scroll="body" onClick={(e) => e.stopPropagation()}>
+    <StyledDialog
+      {...restProps}
+      fullScreen={fullScreen}
+      scroll="body"
+      PaperProps={{
+        sx: {
+          minWidth: [null, null, 600],
+          margin: '0px',
+        },
+      }}
+      onClick={(e) => e.stopPropagation()}
+    >
       {dialogTitle && (
         <ModalDialogTitle onClose={restProps.onClose} hideChainIndicator={hideChainIndicator}>
           {dialogTitle}

--- a/src/components/common/ModalDialog/index.tsx
+++ b/src/components/common/ModalDialog/index.tsx
@@ -1,6 +1,6 @@
 import type { ModalProps } from '@mui/material'
 import { Dialog, DialogTitle, type DialogProps, IconButton, useMediaQuery } from '@mui/material'
-import { styled, useTheme } from '@mui/material/styles'
+import { useTheme } from '@mui/material/styles'
 import CloseIcon from '@mui/icons-material/Close'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import * as React from 'react'
@@ -11,25 +11,6 @@ interface ModalDialogProps extends DialogProps {
   dialogTitle?: React.ReactNode
   hideChainIndicator?: boolean
 }
-
-const StyledDialog = styled(Dialog)(({ theme }) => ({
-  '& .MuiDialogActions-root': {
-    borderTop: `2px solid ${theme.palette.divider}`,
-    padding: theme.spacing(3),
-
-    '& > :last-of-type:not(:first-of-type)': {
-      order: 2,
-    },
-    '&:after': {
-      content: '""',
-      order: 1,
-      flex: 1,
-    },
-  },
-  '& .MuiDialogTitle-root': {
-    borderBottom: `2px solid ${theme.palette.divider}`,
-  },
-}))
 
 interface DialogTitleProps {
   children: React.ReactNode
@@ -72,11 +53,11 @@ const ModalDialog = ({
   const fullScreen = useMediaQuery(theme.breakpoints.down('sm'))
 
   return (
-    <StyledDialog
+    <Dialog
       {...restProps}
       fullScreen={fullScreen}
       scroll="body"
-      className={css.paper}
+      className={css.dialog}
       onClick={(e) => e.stopPropagation()}
     >
       {dialogTitle && (
@@ -86,7 +67,7 @@ const ModalDialog = ({
       )}
 
       {children}
-    </StyledDialog>
+    </Dialog>
   )
 }
 

--- a/src/components/common/ModalDialog/index.tsx
+++ b/src/components/common/ModalDialog/index.tsx
@@ -56,7 +56,7 @@ const ModalDialog = ({
     <Dialog
       {...restProps}
       fullScreen={fullScreen}
-      scroll="body"
+      scroll={fullScreen ? 'paper' : 'body'}
       className={css.dialog}
       onClick={(e) => e.stopPropagation()}
     >

--- a/src/components/common/ModalDialog/index.tsx
+++ b/src/components/common/ModalDialog/index.tsx
@@ -11,6 +11,10 @@ interface ModalDialogProps extends DialogProps {
 }
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
+  '& .MuiDialog-paper': {
+    minWidth: '600px',
+    margin: '0px',
+  },
   '& .MuiDialogActions-root': {
     borderTop: `2px solid ${theme.palette.divider}`,
     padding: theme.spacing(3),

--- a/src/components/common/ModalDialog/styles.module.css
+++ b/src/components/common/ModalDialog/styles.module.css
@@ -1,6 +1,25 @@
+.dialog :global .MuiDialogActions-root {
+  border-top: 2px solid var(--color-border-light);
+  padding: var(--space-3);
+}
+
+.dialog :global .MuiDialogActions-root > :last-of-type:not(:first-of-type) {
+  order: 2;
+}
+
+.dialog :global .MuiDialogActions-root:after {
+  content: '';
+  order: 1;
+  flex: 1;
+}
+
+.dialog :global .MuiDialogTitle-root {
+  border-bottom: 2px solid var(--color-border-light);
+}
+
 @media (min-width: 600px) {
-  .paper :global .MuiPaper-root {
-    min-width: 600px;
+  .dialog :global .MuiDialog-paper {
+    min-width: 600px !important;
     margin: 0;
   }
 }

--- a/src/components/common/ModalDialog/styles.module.css
+++ b/src/components/common/ModalDialog/styles.module.css
@@ -19,7 +19,7 @@
 
 @media (min-width: 600px) {
   .dialog :global .MuiDialog-paper {
-    min-width: 600px !important;
+    min-width: 600px;
     margin: 0;
   }
 }

--- a/src/components/common/ModalDialog/styles.module.css
+++ b/src/components/common/ModalDialog/styles.module.css
@@ -1,0 +1,6 @@
+@media (min-width: 600px) {
+  .paper :global .MuiPaper-root {
+    min-width: 600px;
+    margin: 0;
+  }
+}


### PR DESCRIPTION
## What it solves

Resolves #1046

## How this PR fixes it
Sets min-width in the `TxModal` and reduces the addresses font-size to always have addresses and buttons visible inside the Modal.

## How to test it
2. Open create a new transaction modal.
3. All legit addresses (40 chars) represented in the modal shall not push the buttons out of visible area.

## Analytics changes
N/A

## Screenshots
![Screenshot 2022-11-09 at 18 21 12](https://user-images.githubusercontent.com/32431609/200898639-4968197f-2551-48af-82ed-2cf32cfbdea3.png)

