### PR TITLE
fix: sanitize migrated address books

### DIFF
--- a/src/services/ls-migration/addressBook.ts
+++ b/src/services/ls-migration/addressBook.ts
@@ -30,24 +30,20 @@ export const migrateAddressBook = (lsData: LOCAL_STORAGE_DATA): AddressBookState
 
 // Temporary post-migration fix for malformed data
 export const sanitizeMigratedAddressBook = (state: AddressBookState): AddressBookState => {
-  const hasValidAb = Object.values(state).every((ab) => {
-    return Object.keys(ab).every(utils.isAddress)
-  })
-
-  if (hasValidAb) {
-    return state
-  }
+  console.log('Sanitizing address book')
 
   const sanitizedAb = Object.keys(state).reduce<AddressBookState>((sanitizedAb, chainId) => {
     const chainAb = state[chainId]
 
     const sanitizedChainAb = Object.keys(chainAb).reduce<AddressBook>((sanitizedChainAb, address) => {
       if (!address || !utils.isAddress(address)) {
+        console.log(`Removing malformed address book entry (invalid address): ${address}`)
         return sanitizedChainAb
       }
 
-      const name = chainAb[address]
+      const name = chainAb[address]?.trim()
       if (!name) {
+        console.log(`Removing malformed address book entry (invalid name): ${address}`)
         return sanitizedChainAb
       }
 

--- a/src/services/ls-migration/addressBook.ts
+++ b/src/services/ls-migration/addressBook.ts
@@ -30,6 +30,14 @@ export const migrateAddressBook = (lsData: LOCAL_STORAGE_DATA): AddressBookState
 
 // Temporary post-migration fix for malformed data
 export const sanitizeMigratedAddressBook = (state: AddressBookState): AddressBookState => {
+  const hasValidAb = Object.values(state).every((ab) => {
+    return Object.keys(ab).every(utils.isAddress)
+  })
+
+  if (hasValidAb) {
+    return state
+  }
+
   const sanitizedAb = Object.keys(state).reduce<AddressBookState>((sanitizedAb, chainId) => {
     const chainAb = state[chainId]
 

--- a/src/services/ls-migration/config.ts
+++ b/src/services/ls-migration/config.ts
@@ -1,3 +1,4 @@
 export const IFRAME_HOST = 'https://gnosis-safe.io'
 export const IFRAME_PATH = '/app/migrate.html'
 export const MIGRATION_KEY = 'migrationFinished'
+export const SANITIZE_KEY = 'sanitizeFinished'

--- a/src/services/ls-migration/index.ts
+++ b/src/services/ls-migration/index.ts
@@ -13,6 +13,7 @@ import { MIGRATION_KEY } from './config'
 const useStorageMigration = (): void => {
   const dispatch = useAppDispatch()
   const [isMigrationFinished = false, setIsMigrationFinished] = useLocalStorage<boolean>(MIGRATION_KEY)
+  const [isSanitized = false, setIsSanitized] = useLocalStorage<boolean>(MIGRATION_KEY)
 
   useEffect(() => {
     if (isMigrationFinished) return
@@ -34,6 +35,17 @@ const useStorageMigration = (): void => {
 
     return unmount
   }, [isMigrationFinished, setIsMigrationFinished, dispatch])
+
+  // Temporary post-migration fix for malformed data
+  useEffect(() => {
+    if (!isMigrationFinished || isSanitized) {
+      return
+    }
+
+    dispatch(addressBookSlice.actions.sanitize)
+
+    setIsSanitized(true)
+  }, [dispatch, isMigrationFinished, isSanitized, setIsSanitized])
 }
 
 export default IS_PRODUCTION ? useStorageMigration : () => void null

--- a/src/services/ls-migration/index.ts
+++ b/src/services/ls-migration/index.ts
@@ -8,12 +8,12 @@ import { migrateAddressBook } from './addressBook'
 import { migrateAddedSafes } from './addedSafes'
 import type { LOCAL_STORAGE_DATA } from './common'
 import createMigrationBus from './migrationBus'
-import { MIGRATION_KEY } from './config'
+import { MIGRATION_KEY, SANITIZE_KEY } from './config'
 
 const useStorageMigration = (): void => {
   const dispatch = useAppDispatch()
   const [isMigrationFinished = false, setIsMigrationFinished] = useLocalStorage<boolean>(MIGRATION_KEY)
-  const [isSanitized = false, setIsSanitized] = useLocalStorage<boolean>(MIGRATION_KEY)
+  const [isSanitized = false, setIsSanitized] = useLocalStorage<boolean>(SANITIZE_KEY)
 
   useEffect(() => {
     if (isMigrationFinished) return

--- a/src/services/ls-migration/tests.test.ts
+++ b/src/services/ls-migration/tests.test.ts
@@ -221,6 +221,21 @@ describe('sanitizeMigratedAddressBook', () => {
     expect(sanitizeMigratedAddressBook(addressBook)).toEqual(addressBook)
   })
 
+  it('should return early if all addresses are valid', () => {
+    const addressBook = {
+      '1': {
+        '0x1F2504De05f5167650bE5B28c472601Be434b60A': 'Alice',
+      },
+      '5': {
+        '0x9913B9180C20C6b0F21B6480c84422F6ebc4B808': 'Charlie',
+      },
+    }
+
+    const sanitizedAb = sanitizeMigratedAddressBook(addressBook)
+
+    expect(addressBook === sanitizedAb).toEqual(true)
+  })
+
   it('should remove entries with empty/invalid addresses', () => {
     const invalidAddressBook = {
       '1': {

--- a/src/services/ls-migration/tests.test.ts
+++ b/src/services/ls-migration/tests.test.ts
@@ -221,21 +221,6 @@ describe('sanitizeMigratedAddressBook', () => {
     expect(sanitizeMigratedAddressBook(addressBook)).toEqual(addressBook)
   })
 
-  it('should return early if all addresses are valid', () => {
-    const addressBook = {
-      '1': {
-        '0x1F2504De05f5167650bE5B28c472601Be434b60A': 'Alice',
-      },
-      '5': {
-        '0x9913B9180C20C6b0F21B6480c84422F6ebc4B808': 'Charlie',
-      },
-    }
-
-    const sanitizedAb = sanitizeMigratedAddressBook(addressBook)
-
-    expect(addressBook === sanitizedAb).toEqual(true)
-  })
-
   it('should remove entries with empty/invalid addresses', () => {
     const invalidAddressBook = {
       '1': {
@@ -267,6 +252,7 @@ describe('sanitizeMigratedAddressBook', () => {
       '5': {
         '0x9913B9180C20C6b0F21B6480c84422F6ebc4B808': 'Charlie',
         '0x979774d85274A5F63C85786aC4Fa54B9A4f391c2': undefined,
+        '0xF3E977e7Eea1A91ce5B2d5077e5A7195Ae18b722': ' ',
       },
     }
 

--- a/src/store/addressBookSlice.ts
+++ b/src/store/addressBookSlice.ts
@@ -1,3 +1,4 @@
+import { sanitizeMigratedAddressBook } from '@/services/ls-migration/addressBook'
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import type { RootState } from '.'
 
@@ -5,7 +6,7 @@ export type AddressBook = { [address: string]: string }
 
 export type AddressBookState = { [chainId: string]: AddressBook }
 
-const initialState: AddressBookState = {}
+export const initialState: AddressBookState = {}
 
 export const addressBookSlice = createSlice({
   name: 'addressBook',
@@ -17,6 +18,9 @@ export const addressBookSlice = createSlice({
       // Otherwise, migrate
       return action.payload
     },
+
+    // Temporary post-migration fix for malformed data
+    sanitize: (state): AddressBookState => sanitizeMigratedAddressBook(state),
 
     setAddressBook: (_, action: PayloadAction<AddressBookState>): AddressBookState => {
       return action.payload


### PR DESCRIPTION
## What it solves

Resolves malformed address books

## How this PR fixes it

Initial address book migration [did not include validation](https://github.com/safe-global/web-core/pull/1081). As we have since seen reports of errors being thrown, this not sanitises address books post-migration.

## How to test it

Add invalid address book entries in the localStorage, i.e. empty names or invalid addresses and delete the `SAFE_v2__sanitizeFinished` key. Refresh the page and observe the invalid entries removed from the `localStorage`.

Note: empty chain-specific address books (post-sanitization) should not be present (the `chainId` should not exist in the address book object) and entirely invalid address books should be an empty object.