### PR TITLE
fix: fallback to empty string when shortening address

### DIFF
--- a/src/utils/__tests__/formatters.test.ts
+++ b/src/utils/__tests__/formatters.test.ts
@@ -45,5 +45,15 @@ describe('formatters', () => {
     it('should shorten an address with custom length', () => {
       expect(formatters.shortenAddress('0x1234567890123456789012345678901234567890', 5)).toEqual('0x12345...67890')
     })
+
+    it('should return an empty string if passed a falsy value', () => {
+      expect(formatters.shortenAddress('', 5)).toEqual('')
+
+      // @ts-ignore - Invalid type
+      expect(formatters.shortenAddress(undefined, 5)).toEqual('')
+
+      // @ts-ignore - Invalid type
+      expect(formatters.shortenAddress(null, 5)).toEqual('')
+    })
   })
 })

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -52,6 +52,10 @@ export const safeParseUnits = (value: string, decimals: number | string = GWEI):
 }
 
 export const shortenAddress = (address: string, length = 4): string => {
+  if (!address) {
+    return ''
+  }
+
   return `${address.slice(0, length + 2)}...${address.slice(-length)}`
 }
 


### PR DESCRIPTION
## What it solves

Resolves [ongoing Sentry errors](https://sentry.io/organizations/gnosis/issues/3725083966/?project=6769196&query=is%3Aunresolved&referrer=issue-stream&sort=date&statsPeriod=14d)

## How this PR fixes it

An empty string fallback has been added to `shortenAddress` if passed a falsy value.

## How to test it

It is covered by tests.