### PR TITLE
fix: redirect to old deployment for legacy Safes

### DIFF
--- a/src/hooks/__tests__/useSafeNotifications.test.ts
+++ b/src/hooks/__tests__/useSafeNotifications.test.ts
@@ -2,10 +2,8 @@ import { act } from '@testing-library/react'
 import { renderHook } from '@/tests//test-utils'
 import useSafeNotifications from '../../hooks/useSafeNotifications'
 import useSafeInfo from '../../hooks/useSafeInfo'
-import * as useChainHook from '@/hooks/useChains'
 import { showNotification } from '@/store/notificationsSlice'
 import * as contracts from '@/services/contracts/safeContracts'
-import type { ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 
 // mock showNotification
 jest.mock('@/store/notificationsSlice', () => {
@@ -22,7 +20,7 @@ jest.mock('../../hooks/useSafeInfo')
 // mock router
 jest.mock('next/router', () => ({
   useRouter: jest.fn(() => ({
-    query: { safe: 'rin:0x123' },
+    query: { safe: 'eth:0x123' },
   })),
 }))
 
@@ -39,7 +37,6 @@ describe('useSafeNotifications', () => {
           implementation: { value: '0x123' },
           implementationVersionState: 'OUTDATED',
           version: '1.1.1',
-          chainId: '1',
         },
         safeAddress: '0x123',
       })
@@ -59,7 +56,7 @@ describe('useSafeNotifications', () => {
         link: {
           href: {
             pathname: '/settings/setup',
-            query: { safe: 'rin:0x123' },
+            query: { safe: 'eth:0x123' },
           },
           title: 'Update Safe',
         },
@@ -76,14 +73,6 @@ describe('useSafeNotifications', () => {
         },
         safeAddress: '0x123',
       })
-
-      // mock useCurrentChain to return the shortName
-      jest.spyOn(useChainHook, 'useCurrentChain').mockImplementation(
-        () =>
-          ({
-            shortName: 'eth',
-          } as ChainInfo),
-      )
 
       // render the hook
       const { result } = renderHook(() => useSafeNotifications())

--- a/src/hooks/__tests__/useSafeNotifications.test.ts
+++ b/src/hooks/__tests__/useSafeNotifications.test.ts
@@ -2,9 +2,10 @@ import { act } from '@testing-library/react'
 import { renderHook } from '@/tests//test-utils'
 import useSafeNotifications from '../../hooks/useSafeNotifications'
 import useSafeInfo from '../../hooks/useSafeInfo'
-import { useCurrentChain } from '../../hooks/useChains'
+import * as useChainHook from '@/hooks/useChains'
 import { showNotification } from '@/store/notificationsSlice'
 import * as contracts from '@/services/contracts/safeContracts'
+import type { ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 
 // mock showNotification
 jest.mock('@/store/notificationsSlice', () => {
@@ -38,6 +39,7 @@ describe('useSafeNotifications', () => {
           implementation: { value: '0x123' },
           implementationVersionState: 'OUTDATED',
           version: '1.1.1',
+          chainId: '1',
         },
         safeAddress: '0x123',
       })
@@ -76,9 +78,12 @@ describe('useSafeNotifications', () => {
       })
 
       // mock useCurrentChain to return the shortName
-      ;(useCurrentChain as jest.Mock).mockReturnValue({
-        shortName: 'eth',
-      })
+      jest.spyOn(useChainHook, 'useCurrentChain').mockImplementation(
+        () =>
+          ({
+            shortName: 'eth',
+          } as ChainInfo),
+      )
 
       // render the hook
       const { result } = renderHook(() => useSafeNotifications())
@@ -93,7 +98,7 @@ describe('useSafeNotifications', () => {
         message: `Safe version 1.0.0 is not supported by this web app anymore. You can update your Safe via the old web app here.`,
         groupKey: 'safe-outdated-version',
         link: {
-          href: 'https://gnosis-safe.io/app/eth:0x123/settings/details?redirect=false',
+          href: 'https://gnosis-safe.io/app/eth:0x123/settings/details?no-redirect=true',
           title: 'Update Safe',
         },
       })
@@ -125,6 +130,8 @@ describe('useSafeNotifications', () => {
       ;(useSafeInfo as jest.Mock).mockReturnValue({
         safe: {
           implementation: { value: '0x123' },
+          implementationVersionState: 'UP_TO_DATE',
+          version: '1.3.0',
         },
       })
       jest.spyOn(contracts, 'isValidMasterCopy').mockImplementation((...args: any[]) => Promise.resolve(false))
@@ -153,6 +160,8 @@ describe('useSafeNotifications', () => {
       ;(useSafeInfo as jest.Mock).mockReturnValue({
         safe: {
           implementation: { value: '0x456' },
+          implementationVersionState: 'UP_TO_DATE',
+          version: '1.3.0',
         },
       })
       jest.spyOn(contracts, 'isValidMasterCopy').mockImplementation((...args: any[]) => Promise.resolve(true))

--- a/src/hooks/useSafeNotifications.ts
+++ b/src/hooks/useSafeNotifications.ts
@@ -21,8 +21,8 @@ const CLI_LINK = {
 const useSafeNotifications = (): void => {
   const dispatch = useAppDispatch()
   const { query } = useRouter()
-  const { safe } = useSafeInfo()
-  const { chainId, version, implementationVersionState, address } = safe
+  const { safe, safeAddress } = useSafeInfo()
+  const { chainId, version, implementationVersionState } = safe
   const chain = useCurrentChain()
 
   /**
@@ -30,24 +30,24 @@ const useSafeNotifications = (): void => {
    */
 
   useEffect(() => {
-    const isValid = isValidSafeVersion(version)
-
-    if (implementationVersionState !== ImplementationVersionState.OUTDATED && isValid) {
+    if (implementationVersionState !== ImplementationVersionState.OUTDATED) {
       return
     }
+
+    const isOldSafe = !isValidSafeVersion(version)
 
     const id = dispatch(
       showNotification({
         variant: 'warning',
         groupKey: 'safe-outdated-version',
 
-        message: !isValid
+        message: isOldSafe
           ? `Safe version ${version} is not supported by this web app anymore. You can update your Safe via the old web app here.`
           : `Your Safe version ${version} is out of date. Please update it.`,
 
         link: {
-          href: !isValid
-            ? `https://gnosis-safe.io/app/${chain?.shortName}:${address.value}/settings/details?no-redirect=true`
+          href: isOldSafe
+            ? `https://gnosis-safe.io/app/${chain?.shortName}:${safeAddress}/settings/details?no-redirect=true`
             : {
                 pathname: AppRoutes.settings.setup,
                 query: { safe: query.safe },
@@ -60,7 +60,7 @@ const useSafeNotifications = (): void => {
     return () => {
       dispatch(closeNotification({ id }))
     }
-  }, [dispatch, implementationVersionState, version, query.safe, chain?.shortName, address.value])
+  }, [dispatch, implementationVersionState, version, query.safe, chain?.shortName, safeAddress])
 
   /**
    * Show a notification when the Safe master copy is not supported

--- a/src/hooks/useSafeNotifications.ts
+++ b/src/hooks/useSafeNotifications.ts
@@ -7,8 +7,9 @@ import { AppRoutes } from '@/config/routes'
 import useAsync from './useAsync'
 import { isValidMasterCopy } from '@/services/contracts/safeContracts'
 import { useRouter } from 'next/router'
-import { useCurrentChain } from './useChains'
 import { isValidSafeVersion } from './coreSDK/safeCoreSDK'
+
+const OLD_URL = 'https://gnosis-safe.io/app'
 
 const CLI_LINK = {
   href: 'https://github.com/5afe/safe-cli',
@@ -23,7 +24,6 @@ const useSafeNotifications = (): void => {
   const { query } = useRouter()
   const { safe, safeAddress } = useSafeInfo()
   const { chainId, version, implementationVersionState } = safe
-  const chain = useCurrentChain()
 
   /**
    * Show a notification when the Safe version is out of date
@@ -47,7 +47,7 @@ const useSafeNotifications = (): void => {
 
         link: {
           href: isOldSafe
-            ? `https://gnosis-safe.io/app/${chain?.shortName}:${safeAddress}/settings/details?no-redirect=true`
+            ? `${OLD_URL}/${query.safe}/settings/details?no-redirect=true`
             : {
                 pathname: AppRoutes.settings.setup,
                 query: { safe: query.safe },
@@ -60,7 +60,7 @@ const useSafeNotifications = (): void => {
     return () => {
       dispatch(closeNotification({ id }))
     }
-  }, [dispatch, implementationVersionState, version, query.safe, chain?.shortName, safeAddress])
+  }, [dispatch, implementationVersionState, version, query.safe, safeAddress])
 
   /**
    * Show a notification when the Safe master copy is not supported

--- a/src/hooks/useSafeNotifications.ts
+++ b/src/hooks/useSafeNotifications.ts
@@ -30,9 +30,9 @@ const useSafeNotifications = (): void => {
    */
 
   useEffect(() => {
-    const isUnsupportedSafe = !isValidSafeVersion(version)
+    const isValid = isValidSafeVersion(version)
 
-    if (implementationVersionState !== ImplementationVersionState.OUTDATED || isUnsupportedSafe) {
+    if (implementationVersionState !== ImplementationVersionState.OUTDATED && isValid) {
       return
     }
 
@@ -41,12 +41,12 @@ const useSafeNotifications = (): void => {
         variant: 'warning',
         groupKey: 'safe-outdated-version',
 
-        message: isUnsupportedSafe
+        message: !isValid
           ? `Safe version ${version} is not supported by this web app anymore. You can update your Safe via the old web app here.`
           : `Your Safe version ${version} is out of date. Please update it.`,
 
         link: {
-          href: isUnsupportedSafe
+          href: !isValid
             ? `https://gnosis-safe.io/app/${chain?.shortName}:${address.value}/settings/details?redirect=false`
             : {
                 pathname: AppRoutes.settings.setup,

--- a/src/hooks/useSafeNotifications.ts
+++ b/src/hooks/useSafeNotifications.ts
@@ -47,7 +47,7 @@ const useSafeNotifications = (): void => {
 
         link: {
           href: !isValid
-            ? `https://gnosis-safe.io/app/${chain?.shortName}:${address.value}/settings/details?redirect=false`
+            ? `https://gnosis-safe.io/app/${chain?.shortName}:${address.value}/settings/details?no-redirect=true`
             : {
                 pathname: AppRoutes.settings.setup,
                 query: { safe: query.safe },

--- a/src/hooks/useSafeNotifications.ts
+++ b/src/hooks/useSafeNotifications.ts
@@ -22,7 +22,7 @@ const CLI_LINK = {
 const useSafeNotifications = (): void => {
   const dispatch = useAppDispatch()
   const { query } = useRouter()
-  const { safe, safeAddress } = useSafeInfo()
+  const { safe } = useSafeInfo()
   const { chainId, version, implementationVersionState } = safe
 
   /**
@@ -60,7 +60,7 @@ const useSafeNotifications = (): void => {
     return () => {
       dispatch(closeNotification({ id }))
     }
-  }, [dispatch, implementationVersionState, version, query.safe, safeAddress])
+  }, [dispatch, implementationVersionState, version, query.safe])
 
   /**
    * Show a notification when the Safe master copy is not supported

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -54,7 +54,7 @@ export const getSpecificGnosisSafeContractInstance = (safe: SafeInfo) => {
   })
 }
 
-export const isOldestVersion = (safeVersion: string): boolean => {
+const isOldestVersion = (safeVersion: string): boolean => {
   return semverSatisfies(safeVersion, '<=1.0.0')
 }
 


### PR DESCRIPTION
## What it solves

Notification link for legacy Safes

## How this PR fixes it

Instead of linking to the CLI, we link to the upgrade page of the `safe-react` deployment for older Safes not supported by `web-core`.

## How to test it

Open a <1.1.1 Safe and observe the new link in the notification.

Note: redirection on `safe-react` will still happen until we merge [this](https://github.com/safe-global/safe-react/pull/4113).