### PR TITLE
fix: shorten `meta` description

### DIFF
--- a/src/components/common/MetaTags/index.tsx
+++ b/src/components/common/MetaTags/index.tsx
@@ -4,7 +4,7 @@ import palette from '@/styles/colors'
 import darkPalette from '@/styles/colors-dark'
 
 const descriptionText =
-  'Safe (prev. Gnosis Safe) is the most trusted platform to manage digital assets on Ethereum and multiple EVMs. Over $40B secured. Unlock Ownership.'
+  'Safe (prev. Gnosis Safe) is the most trusted platform to manage digital assets on Ethereum and multiple EVMs. Over $40B secured.'
 const titleText = 'Safe'
 
 const MetaTags = ({ prefetchUrl }: { prefetchUrl: string }) => (


### PR DESCRIPTION
## What it solves

Resolves truncated `meta` description on Twitter.

## How this PR fixes it

The description has been shortened [as per agreed](https://5afe.slack.com/archives/C03FNGQ1LTU/p1667921041810869?thread_ts=1667840653.495219&cid=C03FNGQ1LTU):

```
Safe (prev. Gnosis Safe) is the most trusted platform to manage digital assets on Ethereum and multiple EVMs. Over $40B secured.
```

## How to test it

Draft a Tweet with the PR link and observe the above description.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/200609790-4ae1beb8-a813-4db3-9c93-c87be1d1d1a9.png)