### PR TITLE
test: spy and wait for slow network requests

### DIFF
--- a/cypress/e2e/smoke/balances.cy.js
+++ b/cypress/e2e/smoke/balances.cy.js
@@ -156,7 +156,7 @@ describe('Assets > Coins', () => {
       cy.get('[id="currency"]').click()
 
       // Select EUR
-      cy.get('ul[role="listbox"]').findByText('EUR').click()
+      cy.get('ul[role="listbox"]').findByText('EUR').click({ force: true })
 
       // First row Fiat balance should not contain USD
       cy.get(balanceSingleRow).first().find('td').eq(FIAT_AMOUNT_COLUMN).should('not.contain', 'USD')

--- a/cypress/e2e/smoke/create_tx.cy.js
+++ b/cypress/e2e/smoke/create_tx.cy.js
@@ -59,7 +59,7 @@ describe('Queue a transaction on 1/N', () => {
     cy.get('label').contains('Safe transaction nonce').next().clear().type('3')
     cy.contains('Confirm').click()
 
-    // Asserts the execute checkbox exists and is checkable
+    // Asserts the execute checkbox exists
     cy.get('@modal').within(() => {
       cy.get('input[type="checkbox"]')
         .parent('span')
@@ -72,6 +72,7 @@ describe('Queue a transaction on 1/N', () => {
     })
     cy.contains('Estimated fee').should('exist')
 
+    // Asserts the execute checkbox is uncheckable
     cy.contains('Execute transaction').click()
     cy.get('@modal').within(() => {
       cy.get('input[type="checkbox"]')
@@ -95,12 +96,6 @@ describe('Queue a transaction on 1/N', () => {
 
     cy.get('@modal').within(() => {
       cy.get('input[type="checkbox"]').should('not.exist')
-    })
-
-    // Stub the second /estimations request
-    cy.intercept('POST', '/**/multisig-transactions/estimations', {
-      statusCode: 200,
-      body: { currentNonce: 3, recommendedNonce: recommendedNonce, safeTxGas: '45006' },
     })
 
     cy.contains('Submit').click()


### PR DESCRIPTION
## What it solves
Broken `create_tx` E2E test in the CI

## How this PR fixes it
Spy and wait for the `/estimations` network request
Stub the second `/estimations` request
Spy and wait for the `/propose` network request