### PR TITLE
fix: "Aborting fetching component for router"

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useLayoutEffect } from 'react'
 import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import useLastSafe from '@/hooks/useLastSafe'
@@ -9,7 +9,7 @@ const IndexPage: NextPage = () => {
   const { chain } = router.query
   const lastSafe = useLastSafe()
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     router.replace(
       lastSafe
         ? `${AppRoutes.home}?safe=${lastSafe}`


### PR DESCRIPTION
## What it solves

Resolves #1112

## How this PR fixes it

As we don't want to interact with the DOM, `useLayoutEffect` removed the error (which was caused by calling `router.replace` too many times).

## How to test it

Open `/` and observe no error in the console. Navigating to the following should work as before:

- Previously used Safe: `?safe=xyz:0x123`
- Currently selected network: `?chain=xyz` (no added Safe)
- Otherwise: `/welcome`