### PR TITLE
[Governance Visibility] Dashboard section

### DIFF
--- a/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
+++ b/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
@@ -1,37 +1,66 @@
-import { Typography, Grid, Card, Box } from '@mui/material'
+import { Typography, Grid, Card, Box, IconButton } from '@mui/material'
 import { WidgetBody, WidgetContainer } from '@/components/dashboard/styled'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import { useState } from 'react'
 
-const GovernanceSection = () => (
-  <Grid item xs={12} md>
-    <WidgetContainer>
-      <Typography component="h2" variant="subtitle1" fontWeight={700} mb={2}>
-        Governance
-      </Typography>
+const GovernanceSection = () => {
+  const [isExpanded, setIsExpanded] = useState(true)
 
-      <WidgetBody>
-        <Grid gap="24px" container>
-          <Grid minWidth="200px" item xs md>
-            <Card>
-              <Box m={2} sx={{ minHeight: '200px' }}>
-                <Typography variant="h3">
-                  <strong>Claiming app</strong>
-                </Typography>
-              </Box>
-            </Card>
-          </Grid>
-          <Grid minWidth="200px" item xs md>
-            <Card>
-              <Box m={2} sx={{ minHeight: '200px' }}>
-                <Typography variant="h3">
-                  <strong>Snapshot</strong>
-                </Typography>
-              </Box>
-            </Card>
-          </Grid>
-        </Grid>
-      </WidgetBody>
-    </WidgetContainer>
-  </Grid>
-)
+  const handleExpandClick = () => {
+    setIsExpanded((val) => !val)
+  }
+
+  return (
+    <Grid item xs={12} md>
+      <WidgetContainer>
+        <Box display="flex" justifyContent="space-between" position="relative">
+          <Typography component="h2" variant="subtitle1" fontWeight={700}>
+            Governance
+          </Typography>
+
+          <IconButton
+            sx={{
+              position: 'absolute',
+              right: 8,
+              top: 8,
+            }}
+            onClick={handleExpandClick}
+          >
+            {isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+          </IconButton>
+        </Box>
+        <Typography variant="body2" mb={2} color="text.secondary">
+          Use your SAFE tokens to vote on important proposals or participate in forum discussions.
+        </Typography>
+
+        {isExpanded && (
+          <WidgetBody>
+            <Grid spacing={3} container>
+              <Grid item xs={8}>
+                <Card>
+                  <Box m={2} sx={{ minHeight: '200px' }}>
+                    <Typography variant="h3">
+                      <strong>Snapshot</strong>
+                    </Typography>
+                  </Box>
+                </Card>
+              </Grid>
+              <Grid item xs={4}>
+                <Card>
+                  <Box m={2} sx={{ minHeight: '200px' }}>
+                    <Typography variant="h3">
+                      <strong>Claiming app</strong>
+                    </Typography>
+                  </Box>
+                </Card>
+              </Grid>
+            </Grid>
+          </WidgetBody>
+        )}
+      </WidgetContainer>
+    </Grid>
+  )
+}
 
 export default GovernanceSection

--- a/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
+++ b/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
@@ -9,7 +9,7 @@ import css from './styles.module.css'
 const GovernanceSection = () => (
   <Grid item xs={12} md>
     <Accordion className={css.accordion}>
-      <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: ({ palette }) => palette.primary.light }} />}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon color="border" />}>
         <div>
           <Typography component="h2" variant="subtitle1" fontWeight={700}>
             Governance

--- a/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
+++ b/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
@@ -1,66 +1,51 @@
-import { Typography, Grid, Card, Box, IconButton } from '@mui/material'
-import { WidgetBody, WidgetContainer } from '@/components/dashboard/styled'
+import { Typography, Grid, Card, Box } from '@mui/material'
+import { WidgetBody } from '@/components/dashboard/styled'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
-import ExpandLessIcon from '@mui/icons-material/ExpandLess'
-import { useState } from 'react'
+import Accordion from '@mui/material/Accordion'
+import AccordionSummary from '@mui/material/AccordionSummary'
+import AccordionDetails from '@mui/material/AccordionDetails'
+import css from './styles.module.css'
 
-const GovernanceSection = () => {
-  const [isExpanded, setIsExpanded] = useState(true)
-
-  const handleExpandClick = () => {
-    setIsExpanded((val) => !val)
-  }
-
-  return (
-    <Grid item xs={12} md>
-      <WidgetContainer>
-        <Box display="flex" justifyContent="space-between" position="relative">
+const GovernanceSection = () => (
+  <Grid item xs={12} md>
+    <Accordion className={css.accordion}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: ({ palette }) => palette.primary.light }} />}>
+        <div>
           <Typography component="h2" variant="subtitle1" fontWeight={700}>
             Governance
           </Typography>
+          <Typography variant="body2" mb={2} color="text.secondary">
+            Use your SAFE tokens to vote on important proposals or participate in forum discussions.
+          </Typography>
+        </div>
+      </AccordionSummary>
 
-          <IconButton
-            sx={{
-              position: 'absolute',
-              right: 8,
-              top: 8,
-            }}
-            onClick={handleExpandClick}
-          >
-            {isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-          </IconButton>
-        </Box>
-        <Typography variant="body2" mb={2} color="text.secondary">
-          Use your SAFE tokens to vote on important proposals or participate in forum discussions.
-        </Typography>
-
-        {isExpanded && (
-          <WidgetBody>
-            <Grid spacing={3} container>
-              <Grid item xs={8}>
-                <Card>
-                  <Box m={2} sx={{ minHeight: '200px' }}>
-                    <Typography variant="h3">
-                      <strong>Snapshot</strong>
-                    </Typography>
-                  </Box>
-                </Card>
-              </Grid>
-              <Grid item xs={4}>
-                <Card>
-                  <Box m={2} sx={{ minHeight: '200px' }}>
-                    <Typography variant="h3">
-                      <strong>Claiming app</strong>
-                    </Typography>
-                  </Box>
-                </Card>
-              </Grid>
+      <AccordionDetails sx={({ spacing }) => ({ padding: `0 ${spacing(3)}` })}>
+        <WidgetBody>
+          <Grid spacing={3} container>
+            <Grid item xs={8}>
+              <Card>
+                <Box m={2} sx={{ minHeight: '200px' }}>
+                  <Typography variant="h3">
+                    <strong>Snapshot</strong>
+                  </Typography>
+                </Box>
+              </Card>
             </Grid>
-          </WidgetBody>
-        )}
-      </WidgetContainer>
-    </Grid>
-  )
-}
+            <Grid item xs={4}>
+              <Card>
+                <Box m={2} sx={{ minHeight: '200px' }}>
+                  <Typography variant="h3">
+                    <strong>Claiming app</strong>
+                  </Typography>
+                </Box>
+              </Card>
+            </Grid>
+          </Grid>
+        </WidgetBody>
+      </AccordionDetails>
+    </Accordion>
+  </Grid>
+)
 
 export default GovernanceSection

--- a/src/components/dashboard/GovernanceSection/styles.module.css
+++ b/src/components/dashboard/GovernanceSection/styles.module.css
@@ -1,0 +1,18 @@
+.accordion {
+  box-shadow: none;
+  border: none;
+  background: transparent;
+}
+
+.accordion :global .MuiAccordionSummary-root,
+.accordion :global .MuiAccordionDetails-root {
+  padding: 0;
+}
+
+.accordion :global .MuiAccordionSummary-root:hover {
+  background: inherit;
+}
+
+.accordion :global .Mui-expanded.MuiAccordionSummary-root {
+  background: inherit;
+}


### PR DESCRIPTION
## What it solves
Gives a frame to display the Governance components inside a collapsible section

Part of #974 

## How to test it
1. Go to dashboard and observe the new section

## Screenshots
<img width="805" alt="Screenshot 2022-11-10 at 11 03 32" src="https://user-images.githubusercontent.com/32431609/201061320-9ea9970c-9e38-4165-a40d-fa488f10ecb1.png">
