### PR TITLE
fix: Store newly created safe

### DIFF
--- a/src/components/create-safe/status/useSafeCreationEffects.ts
+++ b/src/components/create-safe/status/useSafeCreationEffects.ts
@@ -71,9 +71,15 @@ const useSafeCreationEffects = ({
       trackEvent(CREATE_SAFE_EVENTS.CREATED_SAFE)
 
       // Add the Safe and add names to the address book
-      if (pendingSafe) {
+      if (pendingSafe && pendingSafe.safeAddress) {
         dispatch(
-          updateAddressBook(chainId, pendingSafe.address, pendingSafe.name, pendingSafe.owners, pendingSafe.threshold),
+          updateAddressBook(
+            chainId,
+            pendingSafe.safeAddress,
+            pendingSafe.name,
+            pendingSafe.owners,
+            pendingSafe.threshold,
+          ),
         )
       }
 

--- a/src/components/create-safe/types.d.ts
+++ b/src/components/create-safe/types.d.ts
@@ -6,6 +6,7 @@ export type NamedAddress = {
   ens?: string
 }
 
+// TODO: Split this type up for create and add safe since NamedAddress only makes sense when adding a safe
 export type SafeFormData = NamedAddress & {
   threshold: number
   owners: NamedAddress[]


### PR DESCRIPTION
## What it solves

Resolves #1121 

## How this PR fixes it

We were using `pendingSafe.address` instead of `pendingSafe.safeAddress`. I opted against refactoring the types to keep this PR small but added a TODO.

## How to test it

1. Create a new safe
2. Observe that it is being added to the added safes list
