### PR TITLE
fix: set `defaultValues` of `SendAssetsForm`

### DIFF
--- a/src/components/tx/modals/NewTxModal/index.tsx
+++ b/src/components/tx/modals/NewTxModal/index.tsx
@@ -34,7 +34,7 @@ const useTxBuilderApp = (): { app?: SafeAppData; link: UrlObject } => {
   }
 }
 
-const NewTxModal = ({ onClose, recipient = '' }: { onClose: () => void; recipient?: string }): ReactElement => {
+const NewTxModal = ({ onClose, recipient }: { onClose: () => void; recipient?: string }): ReactElement => {
   const [tokenModalOpen, setTokenModalOpen] = useState<boolean>(false)
   const [nftsModalOpen, setNftModalOpen] = useState<boolean>(false)
   const txBuilder = useTxBuilderApp()

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -69,7 +69,12 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
   const addressBook = useAddressBook()
 
   const formMethods = useForm<SendAssetsFormData>({
-    defaultValues: { ...formData, [SendAssetsField.type]: SendTxType.multiSig },
+    defaultValues: {
+      [SendAssetsField.recipient]: formData?.[SendAssetsField.recipient] || '',
+      [SendAssetsField.tokenAddress]: formData?.[SendAssetsField.tokenAddress] || '',
+      [SendAssetsField.amount]: formData?.[SendAssetsField.amount] || '',
+      [SendAssetsField.type]: formData?.[SendAssetsField.type] || SendTxType.multiSig,
+    },
     mode: 'onChange',
     delayError: 500,
   })


### PR DESCRIPTION
## What it solves

Resolves #1111

## How this PR fixes it

The `SendAssetsForm` now has `defaultValues`. Before, the `address` could've been `undefined` and was being passed down to `EthHashInfo`.

## How to test it

Open the send assets modal and observe no errors in the console. We should also see no further Sentry logs regarding this issue either.