### PR TITLE
feat: replacement modal

### DIFF
--- a/src/components/tx/ExecuteCheckbox/index.tsx
+++ b/src/components/tx/ExecuteCheckbox/index.tsx
@@ -1,6 +1,6 @@
 import type { ChangeEvent, ReactElement } from 'react'
-import { Checkbox, FormControlLabel, Tooltip } from '@mui/material'
-import InfoIcon from '@mui/icons-material/Info'
+import { Checkbox, FormControlLabel, SvgIcon, Tooltip } from '@mui/material'
+import InfoIcon from '@/public/images/notifications/info.svg'
 import { trackEvent, MODALS_EVENTS } from '@/services/analytics'
 
 const ExecuteCheckbox = ({
@@ -25,7 +25,15 @@ const ExecuteCheckbox = ({
           : 'If you want to sign the transaction now but manually execute it later, uncheck this box.'
       }
     >
-      <InfoIcon fontSize="small" sx={{ verticalAlign: 'middle', marginLeft: 0.5 }} />
+      <span>
+        <SvgIcon
+          component={InfoIcon}
+          inheritViewBox
+          fontSize="small"
+          color="border"
+          sx={{ verticalAlign: 'middle', marginLeft: 0.5 }}
+        />
+      </span>
     </Tooltip>
   )
 

--- a/src/components/tx/modals/NewTxModal/CreationModal.tsx
+++ b/src/components/tx/modals/NewTxModal/CreationModal.tsx
@@ -1,0 +1,66 @@
+import { Box, DialogContent } from '@mui/material'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import type { UrlObject } from 'url'
+import type { SafeAppData } from '@gnosis.pm/safe-react-gateway-sdk'
+
+import ModalDialog from '@/components/common/ModalDialog'
+import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
+import { AppRoutes } from '@/config/routes'
+import { SafeAppsTag } from '@/config/constants'
+import TxButton, { SendNFTsButton, SendTokensButton } from './TxButton'
+
+const useTxBuilderApp = (): { app?: SafeAppData; link: UrlObject } => {
+  const [matchingApps] = useRemoteSafeApps(SafeAppsTag.TX_BUILDER)
+  const router = useRouter()
+  const app = matchingApps?.[0]
+
+  return {
+    app,
+    link: {
+      pathname: AppRoutes.apps,
+      query: { safe: router.query.safe, appUrl: app?.url },
+    },
+  }
+}
+
+const CreationModal = ({
+  onClose,
+  onTokenModalOpen,
+  onNFTModalOpen,
+  onContractInteraction,
+  shouldShowTxBuilder,
+}: {
+  onClose: () => void
+  onTokenModalOpen: () => void
+  onNFTModalOpen: () => void
+  onContractInteraction: () => void
+  shouldShowTxBuilder: boolean
+}) => {
+  const txBuilder = useTxBuilderApp()
+
+  return (
+    <ModalDialog open dialogTitle="New transaction" onClose={onClose}>
+      <DialogContent>
+        <Box display="flex" flexDirection="column" alignItems="center" gap={2} pt={7} pb={4} width={240} m="auto">
+          <SendTokensButton onClick={onTokenModalOpen} />
+          <SendNFTsButton onClick={onNFTModalOpen} />
+
+          {txBuilder.app && shouldShowTxBuilder && (
+            <Link href={txBuilder.link} passHref>
+              <TxButton
+                startIcon={<img src={txBuilder.app.iconUrl} height={20} width="auto" alt={txBuilder.app.name} />}
+                variant="outlined"
+                onClick={onContractInteraction}
+              >
+                Contract interaction
+              </TxButton>
+            </Link>
+          )}
+        </Box>
+      </DialogContent>
+    </ModalDialog>
+  )
+}
+
+export default CreationModal

--- a/src/components/tx/modals/NewTxModal/ReplacementModal.tsx
+++ b/src/components/tx/modals/NewTxModal/ReplacementModal.tsx
@@ -1,0 +1,124 @@
+import {
+  Box,
+  Button,
+  DialogContent,
+  SvgIcon,
+  Tooltip,
+  Typography,
+  Stepper,
+  Step,
+  StepLabel,
+  DialogActions,
+  Grid,
+} from '@mui/material'
+
+import ModalDialog from '@/components/common/ModalDialog'
+import InfoIcon from '@/public/images/notifications/info.svg'
+import RocketIcon from '@/public/images/transactions/rocket.svg'
+import CheckIcon from '@mui/icons-material/Check'
+import DeleteIcon from '@/public/images/common/delete.svg'
+import { SendTokensButton, SendNFTsButton } from './TxButton'
+
+import css from './styles.module.css'
+
+const wrapIcon = (icon: React.ReactNode) => <div className={css.circle}>{icon}</div>
+
+const steps = [
+  {
+    label: 'Create new transaction with same nonce',
+    icon: <div className={css.redCircle} />,
+  },
+  {
+    label: 'Collect confirmations from owners',
+    icon: wrapIcon(<CheckIcon fontSize="small" color="border" />),
+  },
+  {
+    label: 'Execute replacement transaction',
+    icon: wrapIcon(<SvgIcon component={RocketIcon} inheritViewBox fontSize="small" color="border" />),
+  },
+  {
+    label: 'The initial transaction is replaced',
+    icon: wrapIcon(<SvgIcon component={DeleteIcon} inheritViewBox fontSize="small" color="border" />),
+  },
+]
+
+const ReplacementModal = ({
+  txNonce,
+  onClose,
+  onTokenModalOpen,
+  onNFTModalOpen,
+  onRejectModalOpen,
+}: {
+  txNonce: number
+  onClose: () => void
+  onTokenModalOpen: () => void
+  onNFTModalOpen: () => void
+  onRejectModalOpen: () => void
+}) => {
+  return (
+    <ModalDialog open dialogTitle={`Replace transaction with nonce ${txNonce}`} onClose={onClose}>
+      <DialogContent>
+        <Box className={css.container}>
+          <Typography variant="h5" gutterBottom>
+            How to replace/change a transaction?
+          </Typography>
+          <Typography variant="body1" textAlign="center">
+            A signed transaction cannot be removed but it can be replaced with a new transaction with the same nonce.
+          </Typography>
+          <Stepper alternativeLabel className={css.stepper}>
+            {steps.map(({ label }) => (
+              <Step key={label}>
+                <StepLabel StepIconComponent={({ icon }) => steps[Number(icon) - 1].icon}>
+                  <Typography variant="body1" fontWeight={700}>
+                    {label}
+                  </Typography>
+                </StepLabel>
+              </Step>
+            ))}
+          </Stepper>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Grid container alignItems="center" justifyContent="center" spacing={2}>
+          <Grid item xs={12}>
+            <Typography variant="body2" textAlign="center" fontWeight={700}>
+              Select the type of replacement transaction
+            </Typography>
+          </Grid>
+          <Grid item xs>
+            <SendTokensButton onClick={onTokenModalOpen} sx={{ mb: 1 }} />
+            <SendNFTsButton onClick={onNFTModalOpen} />
+          </Grid>
+          <Grid xs={1}>
+            <Typography variant="body2" textAlign="center" fontWeight={700}>
+              or
+            </Typography>
+          </Grid>
+          <Grid xs>
+            <Button onClick={onRejectModalOpen} variant="outlined" fullWidth sx={{ mt: 2 }}>
+              Replace transaction
+            </Button>
+
+            <Typography variant="caption">How does it work?</Typography>
+            <Tooltip
+              title={`An on-chain rejection doesn't send any funds. Executing an on-chain rejection will replace all currently awaiting transactions with nonce ${txNonce}.`}
+              arrow
+            >
+              <span>
+                <SvgIcon
+                  component={InfoIcon}
+                  inheritViewBox
+                  fontSize="small"
+                  color="border"
+                  sx={{ verticalAlign: 'middle', ml: 0.5 }}
+                />
+              </span>
+            </Tooltip>
+          </Grid>
+        </Grid>
+      </DialogActions>
+    </ModalDialog>
+  )
+}
+
+export default ReplacementModal

--- a/src/components/tx/modals/NewTxModal/ReplacementModal.tsx
+++ b/src/components/tx/modals/NewTxModal/ReplacementModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   Button,
   DialogContent,
   SvgIcon,
@@ -37,7 +36,7 @@ const steps = [
     icon: wrapIcon(<SvgIcon component={RocketIcon} inheritViewBox fontSize="small" color="border" />),
   },
   {
-    label: 'The initial transaction is replaced',
+    label: 'Initial transaction is replaced',
     icon: wrapIcon(<SvgIcon component={DeleteIcon} inheritViewBox fontSize="small" color="border" />),
   },
 ]
@@ -57,46 +56,44 @@ const ReplacementModal = ({
 }) => {
   return (
     <ModalDialog open dialogTitle={`Replace transaction with nonce ${txNonce}`} onClose={onClose}>
-      <DialogContent>
-        <Box className={css.container}>
-          <Typography variant="h5" gutterBottom>
-            How to replace/change a transaction?
-          </Typography>
-          <Typography variant="body1" textAlign="center">
-            A signed transaction cannot be removed but it can be replaced with a new transaction with the same nonce.
-          </Typography>
-          <Stepper alternativeLabel className={css.stepper}>
-            {steps.map(({ label }) => (
-              <Step key={label}>
-                <StepLabel StepIconComponent={({ icon }) => steps[Number(icon) - 1].icon}>
-                  <Typography variant="body1" fontWeight={700}>
-                    {label}
-                  </Typography>
-                </StepLabel>
-              </Step>
-            ))}
-          </Stepper>
-        </Box>
+      <DialogContent className={css.container}>
+        <Typography variant="h5" mb={1}>
+          Need to replace or discard this transaction?
+        </Typography>
+        <Typography variant="body1" textAlign="center">
+          A signed transaction cannot be removed but it can be replaced with a new transaction with the same nonce.
+        </Typography>
+        <Stepper alternativeLabel className={css.stepper}>
+          {steps.map(({ label }) => (
+            <Step key={label}>
+              <StepLabel StepIconComponent={({ icon }) => steps[Number(icon) - 1].icon}>
+                <Typography variant="body1" fontWeight={700}>
+                  {label}
+                </Typography>
+              </StepLabel>
+            </Step>
+          ))}
+        </Stepper>
       </DialogContent>
-      <DialogActions>
-        <Grid container alignItems="center" justifyContent="center" spacing={2}>
+      <DialogActions className={css.container}>
+        <Grid container alignItems="center" justifyContent="center" spacing={3}>
           <Grid item xs={12}>
             <Typography variant="body2" textAlign="center" fontWeight={700}>
               Select the type of replacement transaction
             </Typography>
           </Grid>
           <Grid item xs>
-            <SendTokensButton onClick={onTokenModalOpen} sx={{ mb: 1 }} />
+            <SendTokensButton onClick={onTokenModalOpen} sx={{ mb: 1, maxWidth: '320px !important' }} />
             <SendNFTsButton onClick={onNFTModalOpen} />
           </Grid>
-          <Grid xs={1}>
-            <Typography variant="body2" textAlign="center" fontWeight={700}>
+          <Grid>
+            <Typography variant="body2" textAlign="center" fontWeight={700} p={3}>
               or
             </Typography>
           </Grid>
           <Grid xs>
-            <Button onClick={onRejectModalOpen} variant="outlined" fullWidth sx={{ mt: 2 }}>
-              Replace transaction
+            <Button onClick={onRejectModalOpen} variant="outlined" fullWidth sx={{ mt: 3 }}>
+              Rejection transaction
             </Button>
 
             <Typography variant="caption">How does it work?</Typography>

--- a/src/components/tx/modals/NewTxModal/ReplacementModal.tsx
+++ b/src/components/tx/modals/NewTxModal/ReplacementModal.tsx
@@ -41,6 +41,13 @@ const steps = [
   },
 ]
 
+const btnWidth = {
+  width: {
+    xs: 240,
+    sm: '100%',
+  },
+}
+
 const ReplacementModal = ({
   txNonce,
   onClose,
@@ -57,7 +64,7 @@ const ReplacementModal = ({
   return (
     <ModalDialog open dialogTitle={`Replace transaction with nonce ${txNonce}`} onClose={onClose}>
       <DialogContent className={css.container}>
-        <Typography variant="h5" mb={1}>
+        <Typography variant="h5" mb={1} textAlign="center">
           Need to replace or discard this transaction?
         </Typography>
         <Typography variant="body1" textAlign="center">
@@ -76,41 +83,53 @@ const ReplacementModal = ({
         </Stepper>
       </DialogContent>
       <DialogActions className={css.container}>
-        <Grid container alignItems="center" justifyContent="center" spacing={3}>
+        <Grid
+          container
+          alignItems="center"
+          justifyContent="center"
+          flexDirection={{
+            xs: 'column',
+            sm: 'row',
+          }}
+        >
           <Grid item xs={12}>
-            <Typography variant="body2" textAlign="center" fontWeight={700}>
+            <Typography variant="body2" textAlign="center" fontWeight={700} mb={3}>
               Select the type of replacement transaction
             </Typography>
           </Grid>
-          <Grid item xs>
-            <SendTokensButton onClick={onTokenModalOpen} sx={{ mb: 1, maxWidth: '320px !important' }} />
-            <SendNFTsButton onClick={onNFTModalOpen} />
+          <Grid item container justifyContent="center" gap={1} xs={12} sm>
+            <SendTokensButton onClick={onTokenModalOpen} sx={btnWidth} />
+            <SendNFTsButton onClick={onNFTModalOpen} sx={btnWidth} />
           </Grid>
-          <Grid>
-            <Typography variant="body2" textAlign="center" fontWeight={700} p={3}>
+          <Grid item>
+            <Typography variant="body2" className={css.or}>
               or
             </Typography>
           </Grid>
-          <Grid xs>
-            <Button onClick={onRejectModalOpen} variant="outlined" fullWidth sx={{ mt: 3 }}>
+          <Grid item container xs={12} sm sx={{ justifyContent: { xs: 'center', sm: 'flex-start' } }}>
+            <Button onClick={onRejectModalOpen} variant="outlined" fullWidth sx={{ mb: 1, ...btnWidth }}>
               Rejection transaction
             </Button>
 
-            <Typography variant="caption">How does it work?</Typography>
-            <Tooltip
-              title={`An on-chain rejection doesn't send any funds. Executing an on-chain rejection will replace all currently awaiting transactions with nonce ${txNonce}.`}
-              arrow
-            >
-              <span>
-                <SvgIcon
-                  component={InfoIcon}
-                  inheritViewBox
-                  fontSize="small"
-                  color="border"
-                  sx={{ verticalAlign: 'middle', ml: 0.5 }}
-                />
-              </span>
-            </Tooltip>
+            <div>
+              <Typography variant="caption" display="flex" alignItems="center">
+                How does it work?{' '}
+                <Tooltip
+                  title={`An on-chain rejection doesn't send any funds. Executing an on-chain rejection will replace all currently awaiting transactions with nonce ${txNonce}.`}
+                  arrow
+                >
+                  <span>
+                    <SvgIcon
+                      component={InfoIcon}
+                      inheritViewBox
+                      fontSize="small"
+                      color="border"
+                      sx={{ verticalAlign: 'middle', ml: 0.5 }}
+                    />
+                  </span>
+                </Tooltip>
+              </Typography>
+            </div>
           </Grid>
         </Grid>
       </DialogActions>

--- a/src/components/tx/modals/NewTxModal/ReplacementModal.tsx
+++ b/src/components/tx/modals/NewTxModal/ReplacementModal.tsx
@@ -10,6 +10,7 @@ import {
   DialogActions,
   Grid,
 } from '@mui/material'
+import type { SystemProps } from '@mui/system/Box'
 
 import ModalDialog from '@/components/common/ModalDialog'
 import InfoIcon from '@/public/images/notifications/info.svg'
@@ -48,6 +49,11 @@ const btnWidth = {
   },
 }
 
+const flexDirection: SystemProps['flexDirection'] = {
+  xs: 'column',
+  sm: 'row',
+}
+
 const ReplacementModal = ({
   txNonce,
   onClose,
@@ -83,21 +89,22 @@ const ReplacementModal = ({
         </Stepper>
       </DialogContent>
       <DialogActions className={css.container}>
-        <Grid
-          container
-          alignItems="center"
-          justifyContent="center"
-          flexDirection={{
-            xs: 'column',
-            sm: 'row',
-          }}
-        >
+        <Grid container alignItems="center" justifyContent="center" flexDirection={flexDirection}>
           <Grid item xs={12}>
             <Typography variant="body2" textAlign="center" fontWeight={700} mb={3}>
               Select the type of replacement transaction
             </Typography>
           </Grid>
-          <Grid item container justifyContent="center" gap={1} xs={12} sm>
+          <Grid
+            item
+            container
+            justifyContent="center"
+            alignItems="center"
+            gap={1}
+            xs={12}
+            sm
+            flexDirection={flexDirection}
+          >
             <SendTokensButton onClick={onTokenModalOpen} sx={btnWidth} />
             <SendNFTsButton onClick={onNFTModalOpen} sx={btnWidth} />
           </Grid>
@@ -106,7 +113,18 @@ const ReplacementModal = ({
               or
             </Typography>
           </Grid>
-          <Grid item container xs={12} sm sx={{ justifyContent: { xs: 'center', sm: 'flex-start' } }}>
+          <Grid
+            item
+            container
+            xs={12}
+            sm
+            justifyContent={{
+              xs: 'center',
+              sm: 'flex-start',
+            }}
+            alignItems="center"
+            flexDirection={flexDirection}
+          >
             <Button onClick={onRejectModalOpen} variant="outlined" fullWidth sx={{ mb: 1, ...btnWidth }}>
               Rejection transaction
             </Button>

--- a/src/components/tx/modals/NewTxModal/TxButton.tsx
+++ b/src/components/tx/modals/NewTxModal/TxButton.tsx
@@ -1,0 +1,23 @@
+import { Button, SvgIcon } from '@mui/material'
+import type { ButtonProps } from '@mui/material'
+
+import AssetsIcon from '@/public/images/sidebar/assets.svg'
+import NftIcon from '@/public/images/common/nft.svg'
+
+const TxButton = ({ sx, ...props }: ButtonProps) => (
+  <Button variant="contained" sx={{ '& svg path': { fill: 'currentColor' }, ...sx }} fullWidth {...props} />
+)
+
+export const SendTokensButton = ({ onClick, ...props }: ButtonProps) => (
+  <TxButton onClick={onClick} startIcon={<SvgIcon component={AssetsIcon} inheritViewBox />} {...props}>
+    Send tokens
+  </TxButton>
+)
+
+export const SendNFTsButton = ({ onClick, ...props }: ButtonProps) => (
+  <TxButton onClick={onClick} startIcon={<SvgIcon component={NftIcon} inheritViewBox />} {...props}>
+    Send NFTs
+  </TxButton>
+)
+
+export default TxButton

--- a/src/components/tx/modals/NewTxModal/index.tsx
+++ b/src/components/tx/modals/NewTxModal/index.tsx
@@ -1,39 +1,13 @@
-import { useState, type ReactElement } from 'react'
-import { Box, Button, type ButtonProps, DialogContent, SvgIcon, Tooltip } from '@mui/material'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
-import type { UrlObject } from 'url'
-import type { SafeAppData } from '@gnosis.pm/safe-react-gateway-sdk'
-import ModalDialog from '@/components/common/ModalDialog'
+import { useState } from 'react'
+import type { ReactElement } from 'react'
+
 import TokenTransferModal from '../TokenTransferModal'
-import AssetsIcon from '@/public/images/sidebar/assets.svg'
-import NftIcon from '@/public/images/common/nft.svg'
 import RejectTxModal from '../RejectTxModal'
 import NftTransferModal from '../NftTransferModal'
 import { trackEvent, MODALS_EVENTS } from '@/services/analytics'
 import { SendAssetsField } from '../TokenTransferModal/SendAssetsForm'
-import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
-import { AppRoutes } from '@/config/routes'
-import { SafeAppsTag } from '@/config/constants'
-import InfoIcon from '@/public/images/notifications/info.svg'
-
-const TxButton = (props: ButtonProps) => (
-  <Button variant="contained" sx={{ '& svg path': { fill: 'currentColor' } }} fullWidth {...props} />
-)
-
-const useTxBuilderApp = (): { app?: SafeAppData; link: UrlObject } => {
-  const [matchingApps] = useRemoteSafeApps(SafeAppsTag.TX_BUILDER)
-  const router = useRouter()
-  const app = matchingApps?.[0]
-
-  return {
-    app,
-    link: {
-      pathname: AppRoutes.apps,
-      query: { safe: router.query.safe, appUrl: app?.url },
-    },
-  }
-}
+import CreationModal from './CreationModal'
+import ReplacementModal from './ReplacementModal'
 
 const NewTxModal = ({
   onClose,
@@ -47,7 +21,6 @@ const NewTxModal = ({
   const [tokenModalOpen, setTokenModalOpen] = useState<boolean>(false)
   const [nftsModalOpen, setNftModalOpen] = useState<boolean>(false)
   const [rejectModalOpen, setRejectModalOpen] = useState<boolean>(false)
-  const txBuilder = useTxBuilderApp()
   const isReplacement = txNonce !== undefined
 
   // These cannot be Track components as they intefere with styling
@@ -71,64 +44,23 @@ const NewTxModal = ({
     onClose()
   }
 
-  const dialogTitle = isReplacement ? (
-    <>
-      Replace transaction with nonce {txNonce}
-      <Tooltip
-        title="Replacing a transaction will create a new one with the same nonce. Execution of this will replace the
-                previous one."
-        placement="top"
-        arrow
-      >
-        <span>
-          <SvgIcon
-            component={InfoIcon}
-            inheritViewBox
-            color="border"
-            fontSize="small"
-            sx={{ verticalAlign: 'middle', marginLeft: 0.5 }}
-          />
-        </span>
-      </Tooltip>
-    </>
-  ) : (
-    'New transaction'
-  )
+  const sharedProps = {
+    onClose,
+    onTokenModalOpen,
+    onNFTModalOpen,
+  }
 
   return (
     <>
-      <ModalDialog open dialogTitle={dialogTitle} onClose={onClose}>
-        <DialogContent>
-          <Box display="flex" flexDirection="column" alignItems="center" gap={2} pt={7} pb={4} width={240} m="auto">
-            <TxButton onClick={onTokenModalOpen} startIcon={<SvgIcon component={AssetsIcon} inheritViewBox />}>
-              Send tokens
-            </TxButton>
-
-            <TxButton onClick={onNFTModalOpen} startIcon={<SvgIcon component={NftIcon} inheritViewBox />}>
-              Send NFTs
-            </TxButton>
-
-            {isReplacement && (
-              <TxButton onClick={onRejectModalOpen} variant="outlined">
-                Empty transaction
-              </TxButton>
-            )}
-
-            {/* Contract interaction via Transaction Builder */}
-            {txBuilder.app && !recipient && !isReplacement && (
-              <Link href={txBuilder.link} passHref>
-                <TxButton
-                  startIcon={<img src={txBuilder.app.iconUrl} height={20} width="auto" alt={txBuilder.app.name} />}
-                  variant="outlined"
-                  onClick={onContractInteraction}
-                >
-                  Contract interaction
-                </TxButton>
-              </Link>
-            )}
-          </Box>
-        </DialogContent>
-      </ModalDialog>
+      {isReplacement ? (
+        <ReplacementModal txNonce={txNonce} onRejectModalOpen={onRejectModalOpen} {...sharedProps} />
+      ) : (
+        <CreationModal
+          shouldShowTxBuilder={!recipient}
+          onContractInteraction={onContractInteraction}
+          {...sharedProps}
+        />
+      )}
 
       {tokenModalOpen && (
         <TokenTransferModal onClose={onClose} initialData={[{ [SendAssetsField.recipient]: recipient }, { txNonce }]} />

--- a/src/components/tx/modals/NewTxModal/styles.module.css
+++ b/src/components/tx/modals/NewTxModal/styles.module.css
@@ -29,8 +29,9 @@
 }
 
 .stepper :global .MuiStepConnector-root {
-  left: calc(-50% + 14px);
-  right: calc(50% + 28px);
+  left: -8px;
+  transform: translateX(-50%);
+  width: calc(100% - 40px);
 }
 
 .stepper :global .MuiStepConnector-line {
@@ -39,4 +40,39 @@
 
 .stepper :global .MuiStep-root:not(:nth-of-type(2)) .MuiStepConnector-line {
   border-color: var(--color-border-light);
+}
+
+.or {
+  text-align: center;
+  font-weight: 700;
+  padding: var(--space-2) var(--space-3);
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: var(--space-3) !important;
+  }
+
+  .stepper {
+    gap: 0;
+  }
+
+  .stepper :global .MuiStep-root {
+    padding: 0 !important;
+    flex-shrink: 0;
+    flex-grow: 0;
+    flex-basis: 25%;
+    width: 25%;
+  }
+
+  .stepper :global .MuiTypography-root {
+    font-size: 11px;
+    line-height: 16px;
+    letter-spacing: 0.4px;
+  }
+
+  .stepper :global .MuiStepConnector-root {
+    left: 0;
+    width: calc(100% - 50px);
+  }
 }

--- a/src/components/tx/modals/NewTxModal/styles.module.css
+++ b/src/components/tx/modals/NewTxModal/styles.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: var(--space-3);
+  padding: var(--space-4) !important;
 }
 
 .redCircle {
@@ -24,11 +24,12 @@
 }
 
 .stepper {
-  padding: var(--space-3) 0;
+  padding-top: var(--space-3);
+  gap: var(--space-2);
 }
 
 .stepper :global .MuiStepConnector-root {
-  left: calc(-50% + 28px);
+  left: calc(-50% + 14px);
   right: calc(50% + 28px);
 }
 

--- a/src/components/tx/modals/NewTxModal/styles.module.css
+++ b/src/components/tx/modals/NewTxModal/styles.module.css
@@ -1,0 +1,41 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: var(--space-3);
+}
+
+.redCircle {
+  border: 3px solid var(--color-error-main);
+}
+
+.circle {
+  border: 2px solid var(--color-border-light);
+}
+
+.circle,
+.redCircle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+}
+
+.stepper {
+  padding: var(--space-3) 0;
+}
+
+.stepper :global .MuiStepConnector-root {
+  left: calc(-50% + 28px);
+  right: calc(50% + 28px);
+}
+
+.stepper :global .MuiStepConnector-line {
+  border: 1px solid var(--color-border-main);
+}
+
+.stepper :global .MuiStep-root:not(:nth-of-type(2)) .MuiStepConnector-line {
+  border-color: var(--color-border-light);
+}


### PR DESCRIPTION
## What it solves

Resolves #718 

## How this PR fixes it

The new create/replace transaction modals have been separated, with the latter including a stepper according to [this design](https://www.figma.com/file/ptTs6lDBeUuLNySroJ5PiF/Web-Master-File?node-id=2104%3A59002).

## How to test it

- Queue a transaction, then click replace. Observe the new modal, with the buttons working as intended.
- The create modal should function as before, displaying the Transaction Builder.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/201341389-1fa16d2e-e783-4b72-a798-30f940b46fee.png)

![image](https://user-images.githubusercontent.com/20442784/201341412-59876d8e-fa58-49a0-9328-94cd4172f43e.png)

![image](https://user-images.githubusercontent.com/20442784/201341425-84139bbc-d79c-47c8-8966-93d823af8b74.png)

![replacement stepper](https://user-images.githubusercontent.com/20442784/201341550-9b29531c-e8ac-49e7-8d64-12965b74c15e.gif)