### PR TITLE
fix: Show error notifications in safe creation

### DIFF
--- a/src/components/new-safe/steps/Step3/index.tsx
+++ b/src/components/new-safe/steps/Step3/index.tsx
@@ -135,8 +135,8 @@ const CreateSafeStep3 = ({ data, onSubmit, onBack, setStep }: StepRenderProps<Ne
                 </Box>
               }
             />
-            <Grid xs={3} />
-            <Grid xs={9} pt={1} pl={3}>
+            <Grid item xs={3} />
+            <Grid item xs={9} pt={1} pl={3}>
               <Typography variant="body2" color="text.secondary">
                 You will have to confirm a transaction with your currently connected wallet.
               </Typography>

--- a/src/components/new-safe/steps/Step4/logic/index.ts
+++ b/src/components/new-safe/steps/Step4/logic/index.ts
@@ -183,13 +183,14 @@ export const handleSafeCreationError = (error: EthersError) => {
   return SafeCreationStatus.TIMEOUT
 }
 
+export const SAFE_CREATION_ERROR_KEY = 'create-safe-error'
 export const showSafeCreationError = (error: EthersError): AppThunk => {
   return (dispatch) => {
     dispatch(
       showNotification({
         message: `Your transaction was unsuccessful. Reason: ${formatError(error)}`,
         detailedMessage: error.message,
-        groupKey: 'create-safe-error',
+        groupKey: SAFE_CREATION_ERROR_KEY,
         variant: 'error',
       }),
     )

--- a/src/components/new-safe/steps/Step4/useSafeCreation.ts
+++ b/src/components/new-safe/steps/Step4/useSafeCreation.ts
@@ -12,10 +12,11 @@ import {
   getSafeCreationTxInfo,
   getSafeDeployProps,
   handleSafeCreationError,
+  SAFE_CREATION_ERROR_KEY,
   showSafeCreationError,
 } from '@/components/new-safe/steps/Step4/logic'
 import { useAppDispatch } from '@/store'
-import { closeAllNotifications } from '@/store/notificationsSlice'
+import { closeByGroupKey } from '@/store/notificationsSlice'
 
 export enum SafeCreationStatus {
   AWAITING,
@@ -54,7 +55,7 @@ export const useSafeCreation = (
     if (!pendingSafe || !provider || !chain || !wallet || isCreating) return
 
     setIsCreating(true)
-    dispatch(closeAllNotifications())
+    dispatch(closeByGroupKey({ groupKey: SAFE_CREATION_ERROR_KEY }))
 
     try {
       const tx = await getSafeCreationTxInfo(provider, pendingSafe, chain, pendingSafe.saltNonce, wallet)

--- a/src/components/welcome/index.tsx
+++ b/src/components/welcome/index.tsx
@@ -28,7 +28,8 @@ const NewSafe = () => {
               for creating your new Safe.
             </Typography>
             <Track {...CREATE_SAFE_EVENTS.CREATE_BUTTON}>
-              <Button variant="contained" onClick={() => router.push('/open')}>
+              {/* TODO: Revert this to /open before merging into dev */}
+              <Button variant="contained" onClick={() => router.push('/new-safe/create')}>
                 + Create new Safe
               </Button>
             </Track>

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -37,7 +37,7 @@ enum Variant {
 }
 
 // Format the error message
-const formatError = (error: Error & { reason?: string }): string => {
+export const formatError = (error: Error & { reason?: string }): string => {
   let { reason } = error
   if (!reason) return ''
   if (!reason.endsWith('.')) reason += '.'

--- a/src/store/notificationsSlice.ts
+++ b/src/store/notificationsSlice.ts
@@ -31,6 +31,11 @@ export const notificationsSlice = createSlice({
         return notification.id === payload.id ? { ...notification, isDismissed: true } : notification
       })
     },
+    closeAllNotifications: (state): NotificationState => {
+      return state.map((notification) => {
+        return { ...notification, isDismissed: true }
+      })
+    },
     deleteNotification: (state, { payload }: PayloadAction<Notification>) => {
       return state.filter((notification) => notification.id !== payload.id)
     },
@@ -45,8 +50,13 @@ export const notificationsSlice = createSlice({
   },
 })
 
-export const { closeNotification, deleteNotification, deleteAllNotifications, readNotification } =
-  notificationsSlice.actions
+export const {
+  closeNotification,
+  closeAllNotifications,
+  deleteNotification,
+  deleteAllNotifications,
+  readNotification,
+} = notificationsSlice.actions
 
 export const showNotification = (payload: Omit<Notification, 'id' | 'timestamp'>): AppThunk<string> => {
   return (dispatch) => {

--- a/src/store/notificationsSlice.ts
+++ b/src/store/notificationsSlice.ts
@@ -31,9 +31,9 @@ export const notificationsSlice = createSlice({
         return notification.id === payload.id ? { ...notification, isDismissed: true } : notification
       })
     },
-    closeAllNotifications: (state): NotificationState => {
+    closeByGroupKey: (state, { payload }: PayloadAction<{ groupKey: string }>): NotificationState => {
       return state.map((notification) => {
-        return { ...notification, isDismissed: true }
+        return notification.groupKey === payload.groupKey ? { ...notification, isDismissed: true } : notification
       })
     },
     deleteNotification: (state, { payload }: PayloadAction<Notification>) => {
@@ -50,13 +50,8 @@ export const notificationsSlice = createSlice({
   },
 })
 
-export const {
-  closeNotification,
-  closeAllNotifications,
-  deleteNotification,
-  deleteAllNotifications,
-  readNotification,
-} = notificationsSlice.actions
+export const { closeNotification, closeByGroupKey, deleteNotification, deleteAllNotifications, readNotification } =
+  notificationsSlice.actions
 
 export const showNotification = (payload: Omit<Notification, 'id' | 'timestamp'>): AppThunk<string> => {
   return (dispatch) => {


### PR DESCRIPTION
## What it solves

Part of #864 

## How this PR fixes it

- Shows a notification with more detailed errors
- Closes the notification when the user presses Retry

## Other changes

- Extends the notification slice to support closing all notifications
- Temporarily links to new safe creation on welcome page to make testing easier

## How to test it

1. Open the Safe
2. Create a new safe
3. Reject the tx
4. Observe a notification being shown
5. Cancel a tx
6. Observe a notification being shown
7. Press Retry
8. Observe the notification disappearing

## Screenshots

<img width="1358" alt="Screenshot 2022-11-14 at 11 04 21" src="https://user-images.githubusercontent.com/5880855/201632271-3da1a4e7-158e-4e5a-9db2-252254b438a5.png">
