### PR TITLE
fix: Check that isUnlocked exists before calling

### DIFF
--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -29,7 +29,7 @@ export const isWalletUnlocked = async (walletName: string): Promise<boolean> => 
 
   // Only MetaMask exposes a method to check if the wallet is unlocked
   if (walletName === WalletNames.METAMASK) {
-    return window.ethereum?._metamask?.isUnlocked() || false
+    return window.ethereum?._metamask?.isUnlocked?.() || false
   }
 
   // Wallet connect creates a localStorage entry when connected and removes it when disconnected


### PR DESCRIPTION
## What it solves

Resolves #1134 

## How this PR fixes it

- Checks that the method exists before calling it

## How to test

This error most likely happens with older versions of the metamask extension. It was implemented [in 2018](https://github.com/MetaMask/metamask-extension/commit/84874a639d217da36926869fa3cb235c05725cf5)

- Connect to the safe via MM
- Lock the Account from MM
- Observe the wallet disconnecting in the safe