### PR TITLE
fix: update banner text + mobile layout

### DIFF
--- a/src/components/common/PsaBanner/index.module.css
+++ b/src/components/common/PsaBanner/index.module.css
@@ -36,13 +36,16 @@
   z-index: 2;
 }
 
-@media (max-width: 600px) {
-  .banner {
-    padding: var(--space-1) var(--space-3);
-  }
+@media (max-width: 900px) {
   .close {
     position: relative;
     right: unset;
     top: unset;
+  }
+}
+
+@media (max-width: 600px) {
+  .banner {
+    padding: var(--space-1) var(--space-3);
   }
 }

--- a/src/components/common/PsaBanner/index.module.css
+++ b/src/components/common/PsaBanner/index.module.css
@@ -6,7 +6,7 @@
   right: 0;
   background-color: var(--color-info-dark);
   color: var(--color-text-light);
-  padding: 0 20px;
+  padding: 0 var(--space-3);
   font-size: 16px;
 }
 
@@ -38,7 +38,7 @@
 
 @media (max-width: 600px) {
   .banner {
-    padding: 5px 20px;
+    padding: var(--space-1) var(--space-3);
   }
   .close {
     position: relative;

--- a/src/components/common/PsaBanner/index.module.css
+++ b/src/components/common/PsaBanner/index.module.css
@@ -22,7 +22,6 @@
   align-items: center;
   justify-content: center;
   min-height: var(--header-height);
-  flex-wrap: wrap;
 }
 
 .content {
@@ -38,13 +37,11 @@
 }
 
 @media (max-width: 600px) {
-  .content {
-    width: 100%;
+  .banner {
+    padding: 5px 20px;
   }
-
   .close {
-    flex: 1;
-    position: unset;
+    position: relative;
     right: unset;
     top: unset;
   }

--- a/src/components/common/PsaBanner/index.module.css
+++ b/src/components/common/PsaBanner/index.module.css
@@ -6,7 +6,7 @@
   right: 0;
   background-color: var(--color-info-dark);
   color: var(--color-text-light);
-  padding: 5px 20px;
+  padding: 0 20px;
   font-size: 16px;
 }
 
@@ -19,22 +19,33 @@
 .wrapper {
   position: relative;
   display: flex;
-  flex-direction: column;
-  alignitems: center;
-  height: 70px;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--header-height);
+  flex-wrap: wrap;
 }
 
 .content {
   max-width: 960px;
-  margin: 0 auto;
   text-align: center;
-  padding: 10px;
 }
 
 .close {
   position: absolute;
   right: 10px;
-  top: 10px;
-  cursor: pointer;
+  top: 6px;
   z-index: 2;
+}
+
+@media (max-width: 600px) {
+  .content {
+    width: 100%;
+  }
+
+  .close {
+    flex: 1;
+    position: unset;
+    right: unset;
+    top: unset;
+  }
 }

--- a/src/components/common/PsaBanner/index.tsx
+++ b/src/components/common/PsaBanner/index.tsx
@@ -13,12 +13,11 @@ import { useAppSelector } from '@/store'
 
 const WARNING_BANNER = 'WARNING_BANNER'
 const OLD_APP = 'https://gnosis-safe.io/app'
-const NO_REDIRECT = '?no-redirect=true'
 
 const ExportLink = ({ children }: { children: ReactNode }): ReactElement => {
   const router = useRouter()
   const safeAddress = router.query.safe as string
-  const url = safeAddress ? `${OLD_APP}/${safeAddress}/address-book${NO_REDIRECT}` : `${OLD_APP}${NO_REDIRECT}`
+  const url = safeAddress ? `${OLD_APP}/${safeAddress}/settings/details` : `${OLD_APP}/export`
 
   return (
     <a href={url} target="_blank" rel="noreferrer">
@@ -32,7 +31,7 @@ const BANNERS: Record<string, ReactElement | string> = {
     <>
       <b>app.safe.global</b> is Safe&apos;s new official URL.
       <br />
-      Import your address book via the CSV export from the <ExportLink>old app</ExportLink>.
+      Export your data from the old app <ExportLink>here</ExportLink>.
     </>
   ),
 }

--- a/src/components/common/PsaBanner/index.tsx
+++ b/src/components/common/PsaBanner/index.tsx
@@ -29,9 +29,8 @@ const ExportLink = ({ children }: { children: ReactNode }): ReactElement => {
 const BANNERS: Record<string, ReactElement | string> = {
   '*': (
     <>
-      <b>app.safe.global</b> is Safe&apos;s new official URL.
-      <br />
-      Export your data from the old app <ExportLink>here</ExportLink>.
+      <b>app.safe.global</b> is Safe&apos;s new official URL. Export your data from the old app{' '}
+      <ExportLink>here</ExportLink>.
     </>
   ),
 }


### PR DESCRIPTION
## What it solves

Resolves #1146

## How this PR fixes it

The banner text/link has been updated to:

"app.safe.global is Safe's new official URL. Export your data from the old app here"

"here" links to either the settings of the open Safe (`/app/{{safe}}/settings/details`) or `/export`.

## How to test it

Open the Safe and observe the banner, with link to relevant route. On smaller resolutions, the close button should move below the text.

## Screenshots

![banner](https://user-images.githubusercontent.com/20442784/201857700-08d3ef3e-cddf-4d4a-8b21-6932f979906e.gif)