### PR TITLE
feat: export/import 2.0 versioned data

### DIFF
--- a/src/components/settings/DataManagement/index.tsx
+++ b/src/components/settings/DataManagement/index.tsx
@@ -5,43 +5,81 @@ import { SETTINGS_EVENTS } from '@/services/analytics'
 import { Paper, Grid, Typography, Tooltip, SvgIcon, Button } from '@mui/material'
 import { useState } from 'react'
 import ImportAllDialog from '../ImportAllDialog'
+import { getPersistedState } from '@/store'
+import { SAFE_EXPORT_VERSION } from '../ImportAllDialog/useGlobalImportFileParser'
+import { pendingTxsSlice } from '@/store/pendingTxsSlice'
+import { cookiesSlice } from '@/store/cookiesSlice'
+
+const handleExport = () => {
+  const filename = `safe-data-${new Date().toISOString().slice(0, 10)}.json`
+
+  // Exclude pending transactions and cookie consent from export
+  const { [pendingTxsSlice.name]: _p, [cookiesSlice.name]: _c, ...exportData } = getPersistedState()
+
+  const data = JSON.stringify({ version: SAFE_EXPORT_VERSION.V2, data: exportData })
+
+  const blob = new Blob([data], { type: 'text/json' })
+  const link = document.createElement('a')
+
+  link.download = filename
+  link.href = window.URL.createObjectURL(blob)
+  link.dataset.downloadurl = ['text/json', link.download, link.href].join(':')
+  link.dispatchEvent(new MouseEvent('click'))
+}
+
+const InfoTooltip = ({ title }: { title: string }) => {
+  return (
+    <Tooltip placement="top" title={title}>
+      <span>
+        <SvgIcon
+          component={InfoIcon}
+          inheritViewBox
+          fontSize="small"
+          color="border"
+          sx={{ verticalAlign: 'middle', ml: 0.5 }}
+        />
+      </span>
+    </Tooltip>
+  )
+}
 
 const DataManagement = () => {
   const [modalOpen, setModalOpen] = useState(false)
 
   return (
-    <Paper sx={{ p: 4, mb: 2 }}>
-      <Grid container spacing={3}>
-        <Grid item sm={4} xs={12}>
-          <Typography variant="h4" fontWeight={700}>
-            Data import
-            <Tooltip
-              placement="top"
-              title="The imported data will overwrite all added Safes and all address book entries"
-            >
-              <span>
-                <SvgIcon
-                  component={InfoIcon}
-                  inheritViewBox
-                  fontSize="small"
-                  color="border"
-                  sx={{ verticalAlign: 'middle', ml: 0.5 }}
-                />
-              </span>
-            </Tooltip>
-          </Typography>
+    <>
+      <Paper sx={{ p: 4 }}>
+        <Grid container spacing={3}>
+          <Grid item lg={4} xs={12}>
+            <Typography variant="h4" fontWeight="bold" mb={1}>
+              Export all data{' '}
+              <InfoTooltip title="The export includes all added/defaults Safes, address book entries and settings" />
+            </Typography>
+          </Grid>
+          <Grid item lg={8}>
+            <Track {...SETTINGS_EVENTS.DATA.EXPORT_ALL_BUTTON}>
+              <Button size="small" variant="contained" onClick={handleExport}>
+                Export
+              </Button>
+            </Track>
+          </Grid>
+          <Grid item lg={4} xs={12}>
+            <Typography variant="h4" fontWeight="bold" mb={1}>
+              Import all data{' '}
+              <InfoTooltip title="The imported data will overwrite all added Safes and all address book entries" />
+            </Typography>
+          </Grid>
+          <Grid item lg={8}>
+            <Track {...SETTINGS_EVENTS.DATA.IMPORT_ALL_BUTTON}>
+              <Button size="small" variant="contained" onClick={() => setModalOpen(true)}>
+                Import
+              </Button>
+            </Track>
+          </Grid>
         </Grid>
-        <Grid item xs justifyContent="flex-end" display="flex">
-          <Track {...SETTINGS_EVENTS.DATA.IMPORT_ALL_BUTTON}>
-            <Button size="small" variant="contained" onClick={() => setModalOpen(true)}>
-              Import all data
-            </Button>
-          </Track>
-
-          {modalOpen && <ImportAllDialog handleClose={() => setModalOpen(false)} />}
-        </Grid>
-      </Grid>
-    </Paper>
+      </Paper>
+      {modalOpen && <ImportAllDialog handleClose={() => setModalOpen(false)} />}
+    </>
   )
 }
 

--- a/src/components/settings/ImportAllDialog/__tests__/useGlobalImportFileParser.test.ts
+++ b/src/components/settings/ImportAllDialog/__tests__/useGlobalImportFileParser.test.ts
@@ -1,5 +1,52 @@
 import { renderHook } from '@/tests/test-utils'
-import { ImportErrors, useGlobalImportJsonParser } from '../useGlobalImportFileParser'
+import { ImportErrors, useGlobalImportJsonParser, _filterValidAbEntries } from '../useGlobalImportFileParser'
+
+describe('filterValidAbEntries', () => {
+  it('it should return undefined if no address book is provided', () => {
+    const ab = _filterValidAbEntries()
+
+    expect(ab).toBeUndefined()
+  })
+
+  it('it should return valid address books as is', () => {
+    const ab = _filterValidAbEntries({ 1: { '0xAecDFD3A19f777F0c03e6bf99AAfB59937d6467b': 'name' } })
+
+    expect(ab).toStrictEqual({ 1: { '0xAecDFD3A19f777F0c03e6bf99AAfB59937d6467b': 'name' } })
+  })
+
+  it('it should filter entries with invalid addresses', () => {
+    const ab = _filterValidAbEntries({
+      1: { '0xAecDFD3A19f777F0c03e6bf99AAfB59937d6467b': 'name', invalidAddress: 'name2' },
+      2: { '0XAECDFD3A19F777F0C03E6BF99AAFB59937D6467B': 'name3' },
+    })
+
+    expect(ab).toStrictEqual({ 1: { '0xAecDFD3A19f777F0c03e6bf99AAfB59937d6467b': 'name' } })
+  })
+
+  it('it should filter entries with invalid names', () => {
+    const ab = _filterValidAbEntries({
+      1: {
+        '0xAecDFD3A19f777F0c03e6bf99AAfB59937d6467b': '',
+        '0x3819b800c67Be64029C1393c8b2e0d0d627dADE2': ' ',
+        '0x7cB6E6Cbc845e79d9CA05F6577141DA36ad398f5': 'name',
+      },
+    })
+
+    expect(ab).toStrictEqual({ 1: { '0x7cB6E6Cbc845e79d9CA05F6577141DA36ad398f5': 'name' } })
+  })
+
+  it('it should remove empty chain address books pre-/post-validation', () => {
+    // Pre-validation
+    const ab1 = _filterValidAbEntries({ 1: { '0xAecDFD3A19f777F0c03e6bf99AAfB59937d6467b': 'name' }, 2: {} })
+
+    expect(ab1).toStrictEqual({ 1: { '0xAecDFD3A19f777F0c03e6bf99AAfB59937d6467b': 'name' } })
+
+    // Post-validation
+    const ab2 = _filterValidAbEntries({ 1: { invalidAddress: 'name' }, 2: {} })
+
+    expect(ab2).toStrictEqual({})
+  })
+})
 
 describe('useGlobalImportFileParser', () => {
   it('should return undefined values for undefined json', () => {
@@ -9,28 +56,38 @@ describe('useGlobalImportFileParser', () => {
       addressBook: undefined,
       addressBookEntriesCount: 0,
       addedSafesCount: 0,
+      settings: undefined,
+      safeApps: undefined,
+      session: undefined,
+      error: undefined,
     })
   })
 
   it('should return undefined values and error for empty json', () => {
-    const { result } = renderHook(() => useGlobalImportJsonParser('{ "version": "1.0", "data": "{}" }'))
+    const { result } = renderHook(() => useGlobalImportJsonParser(JSON.stringify({ version: '1.0', data: {} })))
     expect(result.current).toEqual({
       addedSafes: undefined,
       addressBook: undefined,
       addressBookEntriesCount: 0,
       addedSafesCount: 0,
       error: ImportErrors.NO_IMPORT_DATA_FOUND,
+      settings: undefined,
+      safeApps: undefined,
+      session: undefined,
     })
   })
 
   it('should return empty objects for invalid json', () => {
-    const { result } = renderHook(() => useGlobalImportJsonParser('{ invalid: json, '))
+    const { result } = renderHook(() => useGlobalImportJsonParser('{ invalid: json'))
     expect(result.current).toEqual({
       addedSafes: undefined,
       addressBook: undefined,
       addressBookEntriesCount: 0,
       addedSafesCount: 0,
       error: ImportErrors.INVALID_JSON_FORMAT,
+      settings: undefined,
+      safeApps: undefined,
+      session: undefined,
     })
   })
 
@@ -42,7 +99,7 @@ describe('useGlobalImportFileParser', () => {
     const owner2 = '0x954cD69f0E902439f99156e3eeDA080752c08401'
 
     const jsonData = JSON.stringify({
-      version: '2.0',
+      version: '17.0',
       data: {
         '_immortal|v2_5__SAFES': `{"${goerliSafeAddress}":{"address":"${goerliSafeAddress}","chainId":"5","threshold":2,"ethBalance":"0.3","totalFiatBalance":"435.08","owners":["${owner1}","${owner2}"],"modules":[],"spendingLimits":[],"balances":[{"tokenAddress":"0x0000000000000000000000000000000000000000","fiatBalance":"435.08100","tokenBalance":"0.3"},{"tokenAddress":"0x61fD3b6d656F39395e32f46E2050953376c3f5Ff","fiatBalance":"0.00000","tokenBalance":"22405.086233211233211233"}],"implementation":{"value":"0x3E5c63644E683549055b9Be8653de26E0B4CD36E"},"loaded":true,"nonce":1,"currentVersion":"1.3.0+L2","needsUpdate":false,"featuresEnabled":["CONTRACT_INTERACTION","DOMAIN_LOOKUP","EIP1559","ERC721","SAFE_APPS","SAFE_TX_GAS_OPTIONAL","SPENDING_LIMIT","TX_SIMULATION","WARNING_BANNER"],"loadedViaUrl":false,"guard":"","collectiblesTag":"1667921524","txQueuedTag":"1667921524","txHistoryTag":"1667400927"}}`,
         '_immortal|v2_MAINNET__SAFES': `{"${mainnetSafeAddress}":{"address":"${mainnetSafeAddress}","chainId":"1","threshold":1,"ethBalance":"0","totalFiatBalance":"0.00","owners":["${owner1}","${owner2}"],"modules":[],"spendingLimits":[],"balances":[{"tokenAddress":"0x0000000000000000000000000000000000000000","fiatBalance":"0.00000","tokenBalance":"0"}],"implementation":{"value":"0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552","name":"Gnosis Safe: Singleton 1.3.0","logoUri":"https://safe-transaction-assets.safe.global/contracts/logos/0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552.png"},"loaded":true,"nonce":2,"currentVersion":"1.3.0","needsUpdate":false,"featuresEnabled":["CONTRACT_INTERACTION","DOMAIN_LOOKUP","EIP1559","ERC721","SAFE_APPS","SAFE_TX_GAS_OPTIONAL","SPENDING_LIMIT","TX_SIMULATION"],"loadedViaUrl":false,"guard":"","collectiblesTag":"1667397095","txQueuedTag":"1667397095","txHistoryTag":"1664287235"}}`,
@@ -57,10 +114,15 @@ describe('useGlobalImportFileParser', () => {
       addressBookEntriesCount: 0,
       addedSafesCount: 0,
       error: ImportErrors.INVALID_VERSION,
+      settings: undefined,
+      safeApps: undefined,
+      session: undefined,
     })
   })
 
-  it('should parse added safes correctly', () => {
+  // 1.0
+
+  it('should parse v1 added safes correctly', () => {
     const goerliSafeAddress = '0xAecDFD3A19f777F0c03e6bf99AAfB59937d6467b'
     const mainnetSafeAddress = '0x7cB6E6Cbc845e79d9CA05F6577141DA36ad398f5'
 
@@ -76,7 +138,8 @@ describe('useGlobalImportFileParser', () => {
     })
     const { result } = renderHook(() => useGlobalImportJsonParser(jsonData))
 
-    const { addedSafes, addedSafesCount, addressBook, addressBookEntriesCount } = result.current
+    const { addedSafes, addedSafesCount, addressBook, addressBookEntriesCount, safeApps, session, settings } =
+      result.current
 
     // No addressbook data
     expect(addressBookEntriesCount).toEqual(0)
@@ -94,9 +157,14 @@ describe('useGlobalImportFileParser', () => {
     expect(addedSafes['1'][mainnetSafeAddress]).toBeDefined()
     const mainnetAddedSafe = addedSafes['1'][mainnetSafeAddress]
     expect(mainnetAddedSafe.threshold).toEqual(1)
+
+    // Only v2
+    expect(safeApps).toEqual(undefined)
+    expect(session).toEqual(undefined)
+    expect(settings).toEqual(undefined)
   })
 
-  it('should parse address book entries correctly', () => {
+  it('should parse v1 address book entries correctly', () => {
     const goerliAddress1 = '0xAecDFD3A19f777F0c03e6bf99AAfB59937d6467b'
     const goerliName1 = 'test.eth'
     const goerliAddress2 = '0x3819b800c67Be64029C1393c8b2e0d0d627dADE2'
@@ -118,7 +186,8 @@ describe('useGlobalImportFileParser', () => {
 
     const { result } = renderHook(() => useGlobalImportJsonParser(jsonData))
 
-    const { addedSafes, addedSafesCount, addressBook, addressBookEntriesCount } = result.current
+    const { addedSafes, addedSafesCount, addressBook, addressBookEntriesCount, safeApps, session, settings } =
+      result.current
 
     // no added safes
     // No addressbook data
@@ -134,5 +203,192 @@ describe('useGlobalImportFileParser', () => {
 
     expect(addressBook['1'][mainnetAddress1]).toEqual(mainnetName1)
     expect(addressBook['1'][mainnetAddress2]).toEqual(mainnetName2)
+
+    // Only v2
+    expect(safeApps).toEqual(undefined)
+    expect(session).toEqual(undefined)
+    expect(settings).toEqual(undefined)
+  })
+
+  // 2.0
+
+  it('should parse v2 added Safes correctly', () => {
+    const goerliSafeAddress = '0xAecDFD3A19f777F0c03e6bf99AAfB59937d6467b'
+    const mainnetSafeAddress = '0x7cB6E6Cbc845e79d9CA05F6577141DA36ad398f5'
+
+    const owner1 = '0x3819b800c67Be64029C1393c8b2e0d0d627dADE2'
+    const owner2 = '0x954cD69f0E902439f99156e3eeDA080752c08401'
+
+    const jsonData = JSON.stringify({
+      version: '2.0',
+      data: {
+        addedSafes: {
+          '5': {
+            [goerliSafeAddress]: {
+              owners: [{ value: owner1 }, { value: owner2 }],
+              threshold: 2,
+              ethBalance: '0',
+            },
+          },
+          '1': {
+            [mainnetSafeAddress]: {
+              owners: [{ value: owner1 }, { value: owner2 }],
+              threshold: 1,
+              ethBalance: '0',
+            },
+          },
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useGlobalImportJsonParser(jsonData))
+
+    const { addedSafes, addedSafesCount } = result.current
+
+    expect(addedSafesCount).toEqual(2)
+
+    expect(addedSafes).toBeDefined()
+    if (!addedSafes) {
+      fail('No added Safes found')
+    }
+
+    expect(addedSafes['5'][goerliSafeAddress]).toBeDefined()
+
+    const goerliAddedSafe = addedSafes['5'][goerliSafeAddress]
+    expect(goerliAddedSafe.threshold).toEqual(2)
+
+    expect(addedSafes['1'][mainnetSafeAddress]).toBeDefined()
+    const mainnetAddedSafe = addedSafes['1'][mainnetSafeAddress]
+    expect(mainnetAddedSafe.threshold).toEqual(1)
+  })
+
+  it('should parse v2 address book entries correctly', () => {
+    const goerliAddress1 = '0xAecDFD3A19f777F0c03e6bf99AAfB59937d6467b'
+    const goerliName1 = 'test.eth'
+    const goerliAddress2 = '0x3819b800c67Be64029C1393c8b2e0d0d627dADE2'
+    const goerliName2 = 'some.eth'
+    const mainnetAddress1 = '0x954cD69f0E902439f99156e3eeDA080752c08401'
+    const mainnetName1 = 'mobile owner'
+    const mainnetAddress2 = '0x7cB6E6Cbc845e79d9CA05F6577141DA36ad398f5'
+    const mainnetName2 = 'S0mE&W3!rd#N4m€'
+
+    const jsonData = JSON.stringify({
+      version: '2.0',
+      data: {
+        addressBook: {
+          '5': {
+            [goerliAddress1]: goerliName1,
+            [goerliAddress2]: goerliName2,
+          },
+          '1': {
+            [mainnetAddress1]: mainnetName1,
+            [mainnetAddress2]: mainnetName2,
+          },
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useGlobalImportJsonParser(jsonData))
+
+    const { addressBook, addressBookEntriesCount } = result.current
+
+    expect(addressBookEntriesCount).toEqual(4)
+
+    if (!addressBook) {
+      fail('No address book found')
+    }
+
+    expect(addressBook['5'][goerliAddress1]).toEqual(goerliName1)
+    expect(addressBook['5'][goerliAddress2]).toEqual(goerliName2)
+
+    expect(addressBook['1'][mainnetAddress1]).toEqual(mainnetName1)
+    expect(addressBook['1'][mainnetAddress2]).toEqual(mainnetName2)
+  })
+
+  it('should parse v2 settings correctly', () => {
+    const jsonData = JSON.stringify({
+      version: '2.0',
+      data: {
+        settings: {
+          currency: 'usd',
+          shortName: { show: true, copy: true, qr: true },
+          theme: { darkMode: false },
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useGlobalImportJsonParser(jsonData))
+
+    const { settings } = result.current
+
+    if (!settings) {
+      fail('No settings found')
+    }
+
+    expect(settings.currency).toEqual('usd')
+
+    expect(settings.shortName.show).toEqual(true)
+    expect(settings.shortName.copy).toEqual(true)
+    expect(settings.shortName.qr).toEqual(true)
+
+    expect(settings.theme.darkMode).toEqual(false)
+  })
+
+  it('should parse v2 Safe app settings correctly', () => {
+    const jsonData = JSON.stringify({
+      version: '2.0',
+      data: {
+        safeApps: {
+          '5': {
+            pinned: [1, 2, 3],
+          },
+          '1': {
+            pinned: [4, 5, 6],
+          },
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useGlobalImportJsonParser(jsonData))
+
+    const { safeApps } = result.current
+
+    if (!safeApps) {
+      fail('No Safe app settings found')
+    }
+
+    expect(safeApps['5'].pinned).toEqual([1, 2, 3])
+    expect(safeApps['1'].pinned).toEqual([4, 5, 6])
+  })
+
+  it('should parse v2 session correctly', () => {
+    const goerliSafeAddress = '0xAecDFD3A19f777F0c03e6bf99AAfB59937d6467b'
+    const mainnetSafeAddress = '0x7cB6E6Cbc845e79d9CA05F6577141DA36ad398f5'
+
+    const jsonData = JSON.stringify({
+      version: '2.0',
+      data: {
+        session: {
+          lastChainId: '1',
+          lastSafeAddress: {
+            '5': goerliSafeAddress,
+            '1': mainnetSafeAddress,
+          },
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useGlobalImportJsonParser(jsonData))
+
+    const { session } = result.current
+
+    if (!session) {
+      fail('No session found')
+    }
+
+    expect(session.lastChainId).toEqual('1')
+
+    expect(session.lastSafeAddress['5']).toEqual(goerliSafeAddress)
+    expect(session.lastSafeAddress['1']).toEqual(mainnetSafeAddress)
   })
 })

--- a/src/components/settings/ImportAllDialog/index.tsx
+++ b/src/components/settings/ImportAllDialog/index.tsx
@@ -22,6 +22,9 @@ import { showNotification } from '@/store/notificationsSlice'
 import { Alert, AlertTitle, Link, SvgIcon, type SvgIconTypeMap } from '@mui/material'
 import FileIcon from '@/public/images/settings/data/file.svg'
 import { SETTINGS_EVENTS, trackEvent } from '@/services/analytics'
+import { settingsSlice } from '@/store/settingsSlice'
+import { safeAppsSlice } from '@/store/safeAppsSlice'
+import { sessionSlice } from '@/store/sessionSlice'
 
 const AcceptedMimeTypes = {
   'application/json': ['.json'],
@@ -36,7 +39,7 @@ const ImportAllDialog = ({ handleClose }: { handleClose: () => void }): ReactEle
   const [fileName, setFileName] = useState<string>()
 
   // Parse the jsonData whenever it changes
-  const { addedSafes, addedSafesCount, addressBook, addressBookEntriesCount, error } =
+  const { addedSafes, addedSafesCount, addressBook, addressBookEntriesCount, settings, safeApps, session, error } =
     useGlobalImportJsonParser(jsonData)
 
   const dispatch = useAppDispatch()
@@ -74,7 +77,7 @@ const ImportAllDialog = ({ handleClose }: { handleClose: () => void }): ReactEle
   })
 
   const handleImport = () => {
-    if (!addressBook && !addedSafes) {
+    if (!addressBook && !addedSafes && !settings && !safeApps && !session) {
       return
     }
 
@@ -94,6 +97,24 @@ const ImportAllDialog = ({ handleClose }: { handleClose: () => void }): ReactEle
         ...SETTINGS_EVENTS.DATA.IMPORT_ADDED_SAFES,
         label: addedSafesCount,
       })
+    }
+
+    if (settings) {
+      dispatch(settingsSlice.actions.setSettings(settings))
+
+      trackEvent(SETTINGS_EVENTS.DATA.IMPORT_SETTINGS)
+    }
+
+    if (safeApps) {
+      dispatch(safeAppsSlice.actions.setSafeApps(safeApps))
+
+      trackEvent(SETTINGS_EVENTS.DATA.IMPORT_SAFE_APPS)
+    }
+
+    if (session) {
+      dispatch(sessionSlice.actions.setSession(session))
+
+      trackEvent(SETTINGS_EVENTS.DATA.IMPORT_SESSION)
     }
 
     dispatch(

--- a/src/components/settings/ImportAllDialog/useGlobalImportFileParser.ts
+++ b/src/components/settings/ImportAllDialog/useGlobalImportFileParser.ts
@@ -2,9 +2,19 @@ import { logError } from '@/services/exceptions'
 import ErrorCodes from '@/services/exceptions/ErrorCodes'
 import { migrateAddedSafes } from '@/services/ls-migration/addedSafes'
 import { migrateAddressBook } from '@/services/ls-migration/addressBook'
+import { isChecksummedAddress } from '@/utils/addresses'
+import type { AddressBook, AddressBookState } from '@/store/addressBookSlice'
+import type { AddedSafesState } from '@/store/addedSafesSlice'
+import type { SafeAppsState } from '@/store/safeAppsSlice'
+import type { SettingsState } from '@/store/settingsSlice'
+import type { SessionState } from '@/store/sessionSlice'
+
 import { useMemo } from 'react'
 
-const V1 = '1.0'
+export enum SAFE_EXPORT_VERSION {
+  V1 = '1.0',
+  V2 = '2.0',
+}
 
 export enum ImportErrors {
   INVALID_VERSION = 'The file is not a Safe export.',
@@ -15,51 +25,113 @@ export enum ImportErrors {
 const countEntries = (data: { [chainId: string]: { [address: string]: unknown } }) =>
   Object.values(data).reduce<number>((count, entry) => count + Object.keys(entry).length, 0)
 
+export const _filterValidAbEntries = (ab?: AddressBookState): AddressBookState | undefined => {
+  if (!ab) {
+    return undefined
+  }
+
+  return Object.entries(ab).reduce<AddressBookState>((acc, [chainId, chainAb]) => {
+    const sanitizedChainAb = Object.entries(chainAb).reduce<AddressBook>((acc, [address, name]) => {
+      if (name?.trim() && address && isChecksummedAddress(address)) {
+        acc[address] = name
+      }
+      return acc
+    }, {})
+
+    if (Object.keys(sanitizedChainAb).length > 0) {
+      acc[chainId] = sanitizedChainAb
+    }
+
+    return acc
+  }, {})
+}
+
 /**
  * The global import currently imports:
- *  - all addressbook entries
- *  - all addedSafes
+ * 1.0:
+ *  - address book
+ *  - added Safes
+ *
+ * 2.0:
+ *  - address book
+ *  - added Safes
+ *  - safeApps
+ *  - settings
+ *  - session
  *
  * @param jsonData
  * @returns data to import and some insights about it
  */
-export const useGlobalImportJsonParser = (jsonData: string | undefined) => {
-  const [migrationAddedSafes, migrationAddressbook, addressBookEntriesCount, addedSafesCount, error] = useMemo(() => {
-    if (!jsonData) {
-      return [undefined, undefined, 0, 0, undefined]
+
+type Data = {
+  addedSafes?: AddedSafesState
+  addressBook?: AddressBookState
+  settings?: SettingsState
+  safeApps?: SafeAppsState
+  session?: SessionState
+  error?: ImportErrors
+  addressBookEntriesCount: number
+  addedSafesCount: number
+}
+
+export const useGlobalImportJsonParser = (jsonData: string | undefined): Data => {
+  return useMemo(() => {
+    const data: Data = {
+      addressBookEntriesCount: 0,
+      addedSafesCount: 0,
+      addressBook: undefined,
+      addedSafes: undefined,
+      settings: undefined,
+      safeApps: undefined,
+      session: undefined,
     }
+
+    if (!jsonData) {
+      return data
+    }
+
+    let parsedFile
+
     try {
-      const parsedFile = JSON.parse(jsonData)
-
-      // We only understand v1 data so far
-      if (!parsedFile.data || parsedFile.version !== V1) {
-        return [undefined, undefined, 0, 0, ImportErrors.INVALID_VERSION]
-      }
-
-      const abData = migrateAddressBook(parsedFile.data)
-      const addedSafesData = migrateAddedSafes(parsedFile.data)
-
-      const abCount = abData ? countEntries(abData) : 0
-      const addedSafesCount = addedSafesData ? countEntries(addedSafesData) : 0
-
-      return [
-        addedSafesData,
-        abData,
-        abCount,
-        addedSafesCount,
-        !abData && !addedSafesData ? ImportErrors.NO_IMPORT_DATA_FOUND : undefined,
-      ]
+      parsedFile = JSON.parse(jsonData)
     } catch (err) {
       logError(ErrorCodes._704, (err as Error).message)
-      return [undefined, undefined, 0, 0, ImportErrors.INVALID_JSON_FORMAT]
-    }
-  }, [jsonData])
 
-  return {
-    addedSafes: migrationAddedSafes,
-    addressBook: migrationAddressbook,
-    addressBookEntriesCount,
-    addedSafesCount,
-    error,
-  }
+      data.error = ImportErrors.INVALID_JSON_FORMAT
+      return data
+    }
+
+    if (!parsedFile.data || Object.keys(parsedFile.data).length === 0) {
+      data.error = ImportErrors.NO_IMPORT_DATA_FOUND
+      return data
+    }
+
+    switch (parsedFile.version) {
+      case SAFE_EXPORT_VERSION.V1: {
+        data.addressBook = migrateAddressBook(parsedFile.data) ?? undefined
+        data.addedSafes = migrateAddedSafes(parsedFile.data) ?? undefined
+
+        break
+      }
+
+      case SAFE_EXPORT_VERSION.V2: {
+        data.addressBook = _filterValidAbEntries(parsedFile.data.addressBook)
+        data.addedSafes = parsedFile.data.addedSafes
+        data.settings = parsedFile.data.settings
+        data.safeApps = parsedFile.data.safeApps
+        data.session = parsedFile.data.session
+
+        break
+      }
+
+      default: {
+        data.error = ImportErrors.INVALID_VERSION
+      }
+    }
+
+    data.addressBookEntriesCount = data.addressBook ? countEntries(data.addressBook) : 0
+    data.addedSafesCount = data.addedSafes ? countEntries(data.addedSafes) : 0
+
+    return data
+  }, [jsonData])
 }

--- a/src/services/analytics/events/settings.ts
+++ b/src/services/analytics/events/settings.ts
@@ -79,6 +79,10 @@ export const SETTINGS_EVENTS = {
     },
   },
   DATA: {
+    EXPORT_ALL_BUTTON: {
+      action: 'Export all data button clicked',
+      category: SETTINGS_CATEGORY,
+    },
     IMPORT_ALL_BUTTON: {
       action: 'Import all data button clicked',
       category: SETTINGS_CATEGORY,
@@ -89,6 +93,18 @@ export const SETTINGS_EVENTS = {
     },
     IMPORT_ADDRESS_BOOK: {
       action: 'Imported address book via Import all',
+      category: SETTINGS_CATEGORY,
+    },
+    IMPORT_SETTINGS: {
+      action: 'Imported settings via Import all',
+      category: SETTINGS_CATEGORY,
+    },
+    IMPORT_SAFE_APPS: {
+      action: 'Imported Safe apps via Import all',
+      category: SETTINGS_CATEGORY,
+    },
+    IMPORT_SESSION: {
+      action: 'Imported session via Import all',
       category: SETTINGS_CATEGORY,
     },
   },

--- a/src/store/safeAppsSlice.ts
+++ b/src/store/safeAppsSlice.ts
@@ -22,6 +22,9 @@ export const safeAppsSlice = createSlice({
       state[chainId] ??= { pinned: [] }
       state[chainId].pinned = pinned
     },
+    setSafeApps: (state, { payload }: PayloadAction<SafeAppsState>) => {
+      state = payload
+    },
   },
 })
 

--- a/src/store/sessionSlice.ts
+++ b/src/store/sessionSlice.ts
@@ -1,7 +1,8 @@
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import { merge } from 'lodash'
 import type { RootState } from '.'
 
-type SessionState = {
+export type SessionState = {
   lastChainId: string
   lastSafeAddress: { [chainId: string]: string }
 }
@@ -27,6 +28,10 @@ export const sessionSlice = createSlice({
     ) => {
       const { chainId, safeAddress } = action.payload
       state.lastSafeAddress[chainId] = safeAddress
+    },
+    setSession: (state, { payload }: PayloadAction<SessionState>) => {
+      // Preserve default `lastSafeAddress` if importing without
+      state = merge({}, initialState, payload)
     },
   },
 })

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -1,5 +1,6 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
+import { merge } from 'lodash'
 
 import type { RootState } from '@/store'
 
@@ -45,6 +46,10 @@ export const settingsSlice = createSlice({
     },
     setDarkMode: (state, { payload }: PayloadAction<SettingsState['theme']['darkMode']>) => {
       state.theme.darkMode = payload
+    },
+    setSettings: (state, { payload }: PayloadAction<SettingsState>) => {
+      // Preserve default nested settings if importing without
+      state = merge({}, initialState, payload)
     },
   },
 })


### PR DESCRIPTION
## What it solves

Resolves #1147

## How this PR fixes it

Safe apps, settings and session data has been added to the export data, as well as import for them. The imported address book is filtered in the same manner that `version: 1.0` is/was.

Tests have been added for `version 2.0`, covering the address book, added Safes, Safe apps, settings and sessions.

Note: the cookies, pending transactions or local flags are not included in the export/import.

## How to test it

Export all data from the Safe and observe the version is set to `2.0` and that there are keys for the address book, added Safes, Safe apps, settings and sessions. Importing the "backup" should set all of these as they were. No sanitisation is done, only the prevention of adding invalid address book entries (empty names, or empty/non-checksummed addresses).

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/201855426-dff4388a-a168-47df-8d45-7762aa6dba0c.png)

![image](https://user-images.githubusercontent.com/20442784/201855520-cea9a83e-2ccd-439a-8711-b7c729eb47f8.png)