### PR TITLE
fix: handle invalid shortname in url

### DIFF
--- a/src/hooks/__tests__/useChainId.test.ts
+++ b/src/hooks/__tests__/useChainId.test.ts
@@ -105,19 +105,6 @@ describe('useChainId hook', () => {
     expect(result.current).toBe('137')
   })
 
-  it('should navigate to the welcome page when the chain query is invalid', () => {
-    const mockFn = jest.fn()
-    ;(useRouter as any).mockImplementation(() => ({
-      query: {
-        chain: 'invalid',
-      },
-      push: mockFn,
-    }))
-
-    renderHook(() => useChainId())
-    expect(mockFn).toHaveBeenCalledWith('/welcome')
-  })
-
   it('should return the last used chain id if no chain in the URL', () => {
     ;(useRouter as any).mockImplementation(() => ({
       query: {},

--- a/src/hooks/__tests__/useChainId.test.ts
+++ b/src/hooks/__tests__/useChainId.test.ts
@@ -105,21 +105,17 @@ describe('useChainId hook', () => {
     expect(result.current).toBe('137')
   })
 
-  it('should throw when the chain query is invalid', () => {
+  it('should navigate to the welcome page when the chain query is invalid', () => {
+    const mockFn = jest.fn()
     ;(useRouter as any).mockImplementation(() => ({
       query: {
         chain: 'invalid',
       },
+      push: mockFn,
     }))
 
-    // Mock console error because the hook will throw and show a huge error message in test output
-    const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation()
-    try {
-      renderHook(() => useChainId())
-    } catch (error) {
-      expect((error as Error).message).toBe('Invalid chain short name in the URL')
-    }
-    consoleErrorMock.mockRestore()
+    renderHook(() => useChainId())
+    expect(mockFn).toHaveBeenCalledWith('/welcome')
   })
 
   it('should return the last used chain id if no chain in the URL', () => {

--- a/src/hooks/__tests__/usePathRewrite.test.ts
+++ b/src/hooks/__tests__/usePathRewrite.test.ts
@@ -102,4 +102,18 @@ describe('usePathRewrite', () => {
       '/rin:0x0000000000000000000000000000000000000000/hello?hi=hello&count=1',
     )
   })
+
+  it('should navigate to the welcome page when the chain query is invalid', () => {
+    const mockFn = jest.fn()
+
+    renderHook(() => usePathRewrite(), {
+      routerProps: {
+        query: {
+          safe: 'undefined:0x0000000000000000000000000000000000000000',
+        },
+        push: mockFn,
+      },
+    })
+    expect(mockFn).toHaveBeenCalledWith('/welcome')
+  })
 })

--- a/src/hooks/useChainId.ts
+++ b/src/hooks/useChainId.ts
@@ -6,6 +6,7 @@ import { useAppSelector } from '@/store'
 import { selectSession } from '@/store/sessionSlice'
 import { parsePrefixedAddress } from '@/utils/addresses'
 import { prefixedAddressRe } from '@/utils/url'
+import { AppRoutes } from '@/config/routes'
 
 const defaultChainId = IS_PRODUCTION ? chains.eth : chains.gor
 
@@ -41,7 +42,7 @@ export const useUrlChainId = (): string | undefined => {
   if (shortName) {
     const chainId = Object.entries(chains).find(([key]) => key === shortName)?.[1]
     if (chainId == null) {
-      throw Error('Invalid chain short name in the URL')
+      router.push(AppRoutes.welcome)
     }
     return chainId
   }

--- a/src/hooks/useChainId.ts
+++ b/src/hooks/useChainId.ts
@@ -6,7 +6,6 @@ import { useAppSelector } from '@/store'
 import { selectSession } from '@/store/sessionSlice'
 import { parsePrefixedAddress } from '@/utils/addresses'
 import { prefixedAddressRe } from '@/utils/url'
-import { AppRoutes } from '@/config/routes'
 
 const defaultChainId = IS_PRODUCTION ? chains.eth : chains.gor
 
@@ -39,13 +38,7 @@ export const useUrlChainId = (): string | undefined => {
   const { prefix } = parsePrefixedAddress(safe)
   const shortName = prefix || chain
 
-  if (shortName) {
-    const chainId = Object.entries(chains).find(([key]) => key === shortName)?.[1]
-    if (chainId == null) {
-      router.push(AppRoutes.welcome)
-    }
-    return chainId
-  }
+  return Object.entries(chains).find(([key]) => key === shortName)?.[1]
 }
 
 export const useChainId = (): string => {

--- a/src/hooks/usePathRewrite.ts
+++ b/src/hooks/usePathRewrite.ts
@@ -26,7 +26,7 @@ const usePathRewrite = () => {
 
     const chainId = Object.entries(chains).find(([key]) => key === prefix)?.[1]
     if (!chainId) {
-      logError(ErrorCodes._621, prefix)
+      logError(ErrorCodes._104, prefix)
       router.push(AppRoutes.welcome)
       return
     }

--- a/src/hooks/usePathRewrite.ts
+++ b/src/hooks/usePathRewrite.ts
@@ -1,10 +1,9 @@
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
-import { parsePrefixedAddress } from '@/utils/addresses'
-import chains from '@/config/chains'
 import { AppRoutes } from '@/config/routes'
 import { logError } from '@/services/exceptions'
 import ErrorCodes from '@/services/exceptions/ErrorCodes'
+import { useUrlChainId } from '@/hooks/useChainId'
 
 // Next.js needs to know all the static paths in advance when doing SSG (static site generation)
 // @see https://nextjs.org/docs/api-reference/next.config.js/runtime-config-static-paths
@@ -16,17 +15,15 @@ import ErrorCodes from '@/services/exceptions/ErrorCodes'
 // Next.js doesn't care because dynamic path params are internally represented as query params anyway.
 const usePathRewrite = () => {
   const router = useRouter()
+  const chainId = useUrlChainId()
 
   useEffect(() => {
     let { safe = '', ...restQuery } = router.query
     if (Array.isArray(safe)) safe = safe[0]
     if (!safe) return
 
-    const { prefix } = parsePrefixedAddress(safe)
-
-    const chainId = Object.entries(chains).find(([key]) => key === prefix)?.[1]
     if (!chainId) {
-      logError(ErrorCodes._104, prefix)
+      logError(ErrorCodes._104)
       router.push(AppRoutes.welcome)
       return
     }
@@ -50,7 +47,7 @@ const usePathRewrite = () => {
       // This just changes what you see in the URL bar w/o triggering any rendering or route change
       history.replaceState(history.state, '', newPath)
     }
-  }, [router])
+  }, [chainId, router])
 }
 
 export default usePathRewrite

--- a/src/hooks/usePathRewrite.ts
+++ b/src/hooks/usePathRewrite.ts
@@ -1,5 +1,10 @@
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
+import { parsePrefixedAddress } from '@/utils/addresses'
+import chains from '@/config/chains'
+import { AppRoutes } from '@/config/routes'
+import { logError } from '@/services/exceptions'
+import ErrorCodes from '@/services/exceptions/ErrorCodes'
 
 // Next.js needs to know all the static paths in advance when doing SSG (static site generation)
 // @see https://nextjs.org/docs/api-reference/next.config.js/runtime-config-static-paths
@@ -16,6 +21,15 @@ const usePathRewrite = () => {
     let { safe = '', ...restQuery } = router.query
     if (Array.isArray(safe)) safe = safe[0]
     if (!safe) return
+
+    const { prefix } = parsePrefixedAddress(safe)
+
+    const chainId = Object.entries(chains).find(([key]) => key === prefix)?.[1]
+    if (!chainId) {
+      logError(ErrorCodes._621, prefix)
+      router.push(AppRoutes.welcome)
+      return
+    }
 
     // Move the Safe address to the path
     let newPath = router.pathname.replace(/^\//, `/${safe}/`)

--- a/src/hooks/usePathRewrite.ts
+++ b/src/hooks/usePathRewrite.ts
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import { AppRoutes } from '@/config/routes'
-import { logError } from '@/services/exceptions'
+import { trackError } from '@/services/exceptions'
 import ErrorCodes from '@/services/exceptions/ErrorCodes'
 import { useUrlChainId } from '@/hooks/useChainId'
 
@@ -23,7 +23,7 @@ const usePathRewrite = () => {
     if (!safe) return
 
     if (!chainId) {
-      logError(ErrorCodes._104)
+      trackError(ErrorCodes._104)
       router.push(AppRoutes.welcome)
       return
     }

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -10,6 +10,7 @@ enum ErrorCodes {
   _100 = '100: Invalid input in the address field',
   _101 = '101: Failed to resolve the address',
   _103 = '103: Error creating a SafeTransaction',
+  _104 = '104: Invalid chain short name in the URL',
 
   _302 = '302: Error connecting to the wallet',
   _303 = '303: Error creating pairing session',
@@ -27,7 +28,6 @@ enum ErrorCodes {
   _616 = '616: Failed to retrieve recommended nonce',
   _619 = '619: Error fetching data from master-copies',
   _620 = '620: Error loading chains',
-  _621 = '621: Invalid chain short name in the URL',
 
   _700 = '700: Failed to read from local/session storage',
   _701 = '701: Failed to write to local/session storage',

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -27,6 +27,7 @@ enum ErrorCodes {
   _616 = '616: Failed to retrieve recommended nonce',
   _619 = '619: Error fetching data from master-copies',
   _620 = '620: Error loading chains',
+  _621 = '621: Invalid chain short name in the URL',
 
   _700 = '700: Failed to read from local/session storage',
   _701 = '701: Failed to write to local/session storage',


### PR DESCRIPTION
## What it solves

Resolves #1154 

## How this PR fixes it

- Instead of throwing an error, we navigate the user to the `/welcome` page if there is an invalid shortname in the URL. This is the same behaviour as in safe-react.
- Error is being logged to the console and sentry instead

## How to test it

1. Open a safe
2. Change the URL shortname to an invalid shortname e.g. "test" or "undefined"
3. Observe being navigated to the welcome page
4. Change the URL shortname to a valid shortname for which the safe doesn't exist
5. Observe a Safe couldn't be loaded error
