### PR TITLE
Fix: added safes across chains

### DIFF
--- a/src/services/analytics/events/overview.ts
+++ b/src/services/analytics/events/overview.ts
@@ -31,9 +31,9 @@ export const OVERVIEW_EVENTS = {
     action: 'Sidebar',
     category: OVERVIEW_CATEGORY,
   },
-  ADDED_SAFES_ON_NETWORK: {
+  TOTAL_ADDED_SAFES: {
     event: EventType.META,
-    action: 'Added Safes on', // Safe name is appended trackEvent on SafeList
+    action: 'Total added Safes',
     category: OVERVIEW_CATEGORY,
   },
   WHATS_NEW: {

--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -25,7 +25,6 @@ type GTMEnvironment = 'LIVE' | 'LATEST' | 'DEVELOPMENT'
 type GTMEnvironmentArgs = Required<Pick<TagManagerArgs, 'auth' | 'preview'>>
 
 const GOOGLE_ANALYTICS_COOKIE_LIST = ['_ga', '_gat', '_gid']
-const EMPTY_SAFE_APP = 'unknown'
 
 const GTM_ENV_AUTH: Record<GTMEnvironment, GTMEnvironmentArgs> = {
   LIVE: {

--- a/src/services/analytics/useGtm.ts
+++ b/src/services/analytics/useGtm.ts
@@ -3,13 +3,45 @@
  * It won't initialize GTM if a consent wasn't given for analytics cookies.
  * The hook needs to be called when the app starts.
  */
-import { useEffect } from 'react'
-import { gtmClear, gtmInit, gtmTrackPageview, gtmSetChainId } from '@/services/analytics/gtm'
+import { useEffect, useMemo } from 'react'
+import { gtmClear, gtmInit, gtmTrackPageview, gtmSetChainId, gtmTrack } from '@/services/analytics/gtm'
 import { useAppSelector } from '@/store'
 import { CookieType, selectCookies } from '@/store/cookiesSlice'
 import useChainId from '@/hooks/useChainId'
 import { useRouter } from 'next/router'
 import { AppRoutes } from '@/config/routes'
+import { OVERVIEW_EVENTS, TX_LIST_EVENTS } from './events'
+import { selectTotalAdded } from '@/store/addedSafesSlice'
+import useSafeAddress from '@/hooks/useSafeAddress'
+import { selectQueuedTransactions } from '@/store/txQueueSlice'
+
+// Track meta events on app load
+const useMetaEvents = (isAnalyticsEnabled: boolean) => {
+  // Track total added safes
+  const totalAddedSafes = useAppSelector(selectTotalAdded)
+  useEffect(() => {
+    if (!isAnalyticsEnabled || totalAddedSafes === 0) return
+
+    gtmTrack({
+      ...OVERVIEW_EVENTS.TOTAL_ADDED_SAFES,
+      label: totalAddedSafes.toString(),
+    })
+  }, [isAnalyticsEnabled, totalAddedSafes])
+
+  // Track queue size
+  const safeAddress = useSafeAddress()
+  const queue = useAppSelector(selectQueuedTransactions)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const safeQueue = useMemo(() => queue, [safeAddress, queue !== undefined])
+  useEffect(() => {
+    if (!isAnalyticsEnabled || !safeQueue) return
+
+    gtmTrack({
+      ...TX_LIST_EVENTS.QUEUED_TXS,
+      label: safeQueue.length.toString(),
+    })
+  }, [isAnalyticsEnabled, safeQueue])
+}
 
 const useGtm = () => {
   const chainId = useChainId()
@@ -37,6 +69,9 @@ const useGtm = () => {
       gtmTrackPageview(router.pathname)
     }
   }, [isAnalyticsEnabled, router.pathname])
+
+  // Track meta events on app load
+  useMetaEvents(isAnalyticsEnabled)
 }
 
 export default useGtm


### PR DESCRIPTION
## What it solves

Resolves #1166

## How this PR fixes it
Added Safes across chains and queue size are now tracked in `useGtm`.

* Added Safe will be tracked on page load and whenever a Safe is added
* The queue size will be tracked when one opens a safe

## How to test it
Trigger those events and see that the correct value is sent.

## Analytics changes

I also removed the old per-chain Added Safes event, so it should not be tracked anymore.

## Screenshots
<img width="869" alt="Screenshot 2022-11-16 at 12 21 13" src="https://user-images.githubusercontent.com/381895/202167370-19557887-d000-4d2a-8124-507afdf2124a.png">
