### PR TITLE
fix: improve reliability of E2E tests

### DIFF
--- a/cypress/e2e/safe-apps/apps_list.cy.js
+++ b/cypress/e2e/safe-apps/apps_list.cy.js
@@ -8,8 +8,11 @@ describe('The Safe Apps list', () => {
 
   describe('When searching apps', () => {
     it('should filter the list by app name', () => {
-      cy.findByRole('textbox').type('walletconnect')
-      cy.findAllByRole('link', { name: /logo/i }).should('have.length', 1)
+      // Wait for /safe-apps response
+      cy.intercept('GET', '/**/safe-apps').then(() => {
+        cy.findByRole('textbox').type('walletconnect')
+        cy.findAllByRole('link', { name: /logo/i }).should('have.length', 1)
+      })
     })
 
     it('should filter the list by app description', () => {

--- a/cypress/e2e/smoke/create_tx.cy.js
+++ b/cypress/e2e/smoke/create_tx.cy.js
@@ -16,7 +16,9 @@ describe('Queue a transaction on 1/N', () => {
 
   it('should create and queue a transaction', () => {
     // Assert that "New transaction" button is visible
-    cy.contains('New transaction').should('be.visible', { timeout: 30_000 })
+    cy.contains('New transaction', {
+      timeout: 60_000, // `lastWallet` takes a while initialize in CI
+    }).should('be.visible')
 
     // Open the new transaction modal
     cy.contains('New transaction').click()

--- a/cypress/e2e/smoke/create_tx.cy.js
+++ b/cypress/e2e/smoke/create_tx.cy.js
@@ -15,8 +15,11 @@ describe('Queue a transaction on 1/N', () => {
   })
 
   it('should create and queue a transaction', () => {
+    // Assert that "New transaction" button is visible
+    cy.contains('New transaction').should('be.visible', { timeout: 30_000 })
+
     // Open the new transaction modal
-    cy.contains('New transaction', { timeout: 30_000 }).click()
+    cy.contains('New transaction').click()
 
     // Modal is open
     cy.contains('h2', 'New transaction').should('be.visible')

--- a/cypress/e2e/smoke/create_tx.cy.js
+++ b/cypress/e2e/smoke/create_tx.cy.js
@@ -16,7 +16,7 @@ describe('Queue a transaction on 1/N', () => {
 
   it('should create and queue a transaction', () => {
     // Open the new transaction modal
-    cy.contains('New transaction', { timeout: 10000 }).click()
+    cy.contains('New transaction', { timeout: 30_000 }).click()
 
     // Modal is open
     cy.contains('h2', 'New transaction').should('be.visible')
@@ -35,89 +35,83 @@ describe('Queue a transaction on 1/N', () => {
   })
 
   it('should create a queued transaction', () => {
-    // Spy the /estimations request
-    cy.intercept('POST', '/**/multisig-transactions/estimations').as('estimations')
-
     // Alias for New transaction modal
     cy.contains('h2', 'Review transaction').parents('div').as('modal')
 
     // Wait for /estimations response
-    cy.wait('@estimations', { timeout: 30_000 })
+    cy.intercept('POST', '/**/multisig-transactions/estimations').then(() => {
+      // Estimation is loaded
+      cy.get('button[type="submit"]').should('not.be.disabled')
 
-    // Estimation is loaded
-    cy.get('button[type="submit"]').should('not.be.disabled')
+      // Gets the recommended nonce
+      cy.contains('Signing the transaction with nonce').should(($div) => {
+        // get the number in the string
+        recommendedNonce = $div.text().match(/\d+$/)[0]
+      })
 
-    // Gets the recommended nonce
-    cy.contains('Signing the transaction with nonce').should(($div) => {
-      // get the number in the string
-      recommendedNonce = $div.text().match(/\d+$/)[0]
+      // Changes nonce to next one
+      cy.contains('Signing the transaction with nonce').click()
+      cy.contains('button', 'Edit').click()
+      cy.get('label').contains('Safe transaction nonce').next().clear().type('3')
+      cy.contains('Confirm').click()
+
+      // Asserts the execute checkbox exists
+      cy.get('@modal').within(() => {
+        cy.get('input[type="checkbox"]')
+          .parent('span')
+          .should(($div) => {
+            // Turn the classList into a string
+            const classListString = Array.from($div[0].classList).join()
+            // Check if it contains the error class
+            expect(classListString).to.include('checked')
+          })
+      })
+      cy.contains('Estimated fee').should('exist')
+
+      // Asserts the execute checkbox is uncheckable
+      cy.contains('Execute transaction').click()
+      cy.get('@modal').within(() => {
+        cy.get('input[type="checkbox"]')
+          .parent('span')
+          .should(($div) => {
+            // Turn the classList into a string
+            const classListString = Array.from($div[0].classList).join()
+            // Check if it contains the error class
+            expect(classListString).not.to.include('checked')
+          })
+      })
+      cy.contains('Signing the transaction with nonce').should('exist')
+
+      // Changes back to recommended nonce
+      cy.contains('Signing the transaction with nonce').click()
+      cy.contains('Edit').click()
+      cy.get('button[aria-label="Reset to recommended nonce"]').click()
+
+      // Accepts the values
+      cy.contains('Confirm').click()
+
+      cy.get('@modal').within(() => {
+        cy.get('input[type="checkbox"]').should('not.exist')
+      })
+
+      cy.contains('Submit').click()
     })
-
-    // Changes nonce to next one
-    cy.contains('Signing the transaction with nonce').click()
-    cy.contains('button', 'Edit').click()
-    cy.get('label').contains('Safe transaction nonce').next().clear().type('3')
-    cy.contains('Confirm').click()
-
-    // Asserts the execute checkbox exists
-    cy.get('@modal').within(() => {
-      cy.get('input[type="checkbox"]')
-        .parent('span')
-        .should(($div) => {
-          // Turn the classList into a string
-          const classListString = Array.from($div[0].classList).join()
-          // Check if it contains the error class
-          expect(classListString).to.include('checked')
-        })
-    })
-    cy.contains('Estimated fee').should('exist')
-
-    // Asserts the execute checkbox is uncheckable
-    cy.contains('Execute transaction').click()
-    cy.get('@modal').within(() => {
-      cy.get('input[type="checkbox"]')
-        .parent('span')
-        .should(($div) => {
-          // Turn the classList into a string
-          const classListString = Array.from($div[0].classList).join()
-          // Check if it contains the error class
-          expect(classListString).not.to.include('checked')
-        })
-    })
-    cy.contains('Signing the transaction with nonce').should('exist')
-
-    // Changes back to recommended nonce
-    cy.contains('Signing the transaction with nonce').click()
-    cy.contains('Edit').click()
-    cy.get('button[aria-label="Reset to recommended nonce"]').click()
-
-    // Accepts the values
-    cy.contains('Confirm').click()
-
-    cy.get('@modal').within(() => {
-      cy.get('input[type="checkbox"]').should('not.exist')
-    })
-
-    cy.contains('Submit').click()
-
-    // Spy the /propose request and give it an alias
-    cy.intercept('POST', '/**/propose').as('propose')
-
-    // Wait for the /propose request
-    cy.wait('@propose', { timeout: 30_000 })
   })
 
   it('should click the notification and see the transaction queued', () => {
-    // Click on the notification
-    cy.contains('View transaction').click()
+    // Wait for the /propose request
+    cy.intercept('POST', '/**/propose').then(() => {
+      // Click on the notification
+      cy.contains('View transaction').click()
 
-    // Single Tx page
-    cy.contains('h3', 'Transaction details').should('be.visible')
+      // Single Tx page
+      cy.contains('h3', 'Transaction details').should('be.visible')
 
-    // Queue label
-    cy.contains('Queued - transaction with nonce 3 needs to be executed first').should('be.visible')
+      // Queue label
+      cy.contains('Queued - transaction with nonce 3 needs to be executed first').should('be.visible')
 
-    // Transaction summary
-    cy.contains(`${recommendedNonce}` + 'Send' + '-' + `${sendValue} GOR`).should('exist')
+      // Transaction summary
+      cy.contains(`${recommendedNonce}` + 'Send' + '-' + `${sendValue} GOR`).should('exist')
+    })
   })
 })


### PR DESCRIPTION
## What it solves

Unreliable transaction creation test.

## How this PR fixes it

- The timeout for E2E wallet connection has been increased
- Tests relevant to the estimation/proposal/safe-apps endpoint incerceptions have been moved inside [the `intercept` callback](https://docs.cypress.io/api/commands/intercept#Using-the-yielded-object)

## How to test it

Observe the test passes in the E2E job.