### PR TITLE
fix: redirect to `/home` of Safe present in URL

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,18 +6,19 @@ import { AppRoutes } from '@/config/routes'
 
 const IndexPage: NextPage = () => {
   const router = useRouter()
-  const { chain } = router.query
+  const { safe, chain } = router.query
   const lastSafe = useLastSafe()
+  const safeAddress = safe || lastSafe
 
   useLayoutEffect(() => {
     router.replace(
-      lastSafe
-        ? `${AppRoutes.home}?safe=${lastSafe}`
+      safeAddress
+        ? `${AppRoutes.home}?safe=${safeAddress}`
         : chain
         ? `${AppRoutes.welcome}?chain=${chain}`
         : AppRoutes.welcome,
     )
-  }, [router, lastSafe, chain])
+  }, [router, safeAddress, chain])
 
   return <></>
 }


### PR DESCRIPTION
## What it solves

Resolves #1172

## How this PR fixes it

If an address is present in the URL, it will redirect to the `/home` of that Safe.

## How to test it

Open `/{{shortName}}:{{address}}` with no session cache (e.g. in Incognito) and observe that it directs to `/{{shortName}}:{{address}}/home`. When opening the Safe with a `lastSafe` cached, it should open to that one.

All Safe-specific routes should function as before, e.g. opening `/{{shortName}}:{{address}}/settings/setup` should not direct to `/{{shortName}}:{{address}}/home`.