### PR TITLE
Fix: backdrop color

### DIFF
--- a/src/components/tx/modals/NewTxModal/index.tsx
+++ b/src/components/tx/modals/NewTxModal/index.tsx
@@ -57,7 +57,7 @@ const NewTxModal = ({ onClose, recipient }: { onClose: () => void; recipient?: s
 
   return (
     <>
-      <ModalDialog open dialogTitle="New transaction" onClose={onClose}>
+      <ModalDialog open={!tokenModalOpen && !nftsModalOpen} dialogTitle="New transaction" onClose={onClose}>
         <DialogContent>
           <Box display="flex" flexDirection="column" alignItems="center" gap={2} pt={7} pb={4} width={240} m="auto">
             <TxButton onClick={onTokenModalOpen} startIcon={<SvgIcon component={AssetsIcon} inheritViewBox />}>

--- a/src/styles/colors-dark.ts
+++ b/src/styles/colors-dark.ts
@@ -50,6 +50,9 @@ const darkPalette = {
     paper: '#1C1C1C',
     light: '#1B2A22',
   },
+  backdrop: {
+    main: '#636669',
+  },
   logo: {
     main: '#FFFFFF',
     background: '#303033',

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -50,6 +50,9 @@ const palette = {
     paper: '#FFFFFF',
     light: '#EFFFF4',
   },
+  backdrop: {
+    main: '#636669',
+  },
   logo: {
     main: '#121312',
     background: '#EEEFF0',

--- a/src/styles/onboard.css
+++ b/src/styles/onboard.css
@@ -32,6 +32,9 @@
   --onboard-warning-600: var(--color-error-main);
   --onboard-warning-700: var(--color-error-dark);
 
+  /* var(--color-backdrop-main) + opacity */
+  --onboard-modal-backdrop: rgba(99, 102, 105, 0.75);
+
   --account-select-modal-white: var(--color-background-paper);
   --account-select-modal-black: var(--color-primary-main);
   --account-select-modal-primary-100: var(--color-secondary-background);

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -11,11 +11,13 @@ declare module '@mui/material/styles' {
   interface Palette {
     border: Palette['primary']
     logo: Palette['primary']
+    backdrop: Palette['primary']
     static: Palette['primary']
   }
   interface PaletteOptions {
     border: PaletteOptions['primary']
     logo: PaletteOptions['primary']
+    backdrop: PaletteOptions['primary']
     static: PaletteOptions['primary']
   }
 
@@ -468,7 +470,7 @@ const initTheme = (darkMode: boolean) => {
       MuiBackdrop: {
         styleOverrides: {
           root: ({ theme }) => ({
-            backgroundColor: alpha(theme.palette.background.main, 0.75),
+            backgroundColor: alpha(theme.palette.backdrop.main, 0.75),
           }),
         },
       },

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -34,6 +34,7 @@
   --color-background-main: #f4f4f4;
   --color-background-paper: #ffffff;
   --color-background-light: #effff4;
+  --color-backdrop-main: #636669;
   --color-logo-main: #121312;
   --color-logo-background: #eeeff0;
   --color-static-main: #121312;
@@ -85,6 +86,7 @@
   --color-background-main: #121312;
   --color-background-paper: #1c1c1c;
   --color-background-light: #1b2a22;
+  --color-backdrop-main: #636669;
   --color-logo-main: #ffffff;
   --color-logo-background: #303033;
   --color-static-main: #121312;
@@ -126,6 +128,7 @@
     --color-background-main: #121312;
     --color-background-paper: #1c1c1c;
     --color-background-light: #1b2a22;
+    --color-backdrop-main: #636669;
     --color-logo-main: #ffffff;
     --color-logo-background: #303033;
     --color-static-main: #121312;


### PR DESCRIPTION
## What it solves
@liliiaorlenko provided a new, more contrastive, backdrop color. It's the same in both dark and light modes.

<img width="905" alt="Screenshot 2022-11-17 at 08 50 10" src="https://user-images.githubusercontent.com/381895/202388361-337b583f-b365-4104-ae96-4ff57da04168.png">
<img width="880" alt="Screenshot 2022-11-17 at 08 50 20" src="https://user-images.githubusercontent.com/381895/202388371-e23d1d71-ecfd-4d39-8ba8-559add6119da.png">
