### PR TITLE
Refactor: extract sidebar drawer

### DIFF
--- a/src/components/common/PageLayout/SideDrawer.tsx
+++ b/src/components/common/PageLayout/SideDrawer.tsx
@@ -1,0 +1,61 @@
+import { useEffect, type ReactElement } from 'react'
+import { IconButton, Drawer, useMediaQuery } from '@mui/material'
+import DoubleArrowRightIcon from '@mui/icons-material/KeyboardDoubleArrowRightRounded'
+import DoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrowLeftRounded'
+import { useRouter } from 'next/router'
+import classnames from 'classnames'
+import { type ParsedUrlQuery } from 'querystring'
+
+import Sidebar from '@/components/sidebar/Sidebar'
+import css from './styles.module.css'
+import { AppRoutes } from '@/config/routes'
+
+type SideDrawerProps = {
+  isOpen: boolean
+  onToggle: (isOpen: boolean) => void
+}
+
+const isAppShareRoute = (pathname: string): boolean => {
+  return pathname === AppRoutes.share.safeApp
+}
+
+const isSafeAppRoute = (pathname: string, query: ParsedUrlQuery): boolean => {
+  return pathname === AppRoutes.apps && !!query.appUrl
+}
+
+const SideDrawer = ({ isOpen, onToggle }: SideDrawerProps): ReactElement => {
+  const { pathname, query } = useRouter()
+  const isSmallScreen = useMediaQuery('(max-width: 900px)')
+  const showSidebarToggle = isSafeAppRoute(pathname, query)
+
+  useEffect(() => {
+    onToggle(!isSmallScreen && !isAppShareRoute(pathname))
+  }, [isSmallScreen, pathname, onToggle])
+
+  return (
+    <>
+      <Drawer
+        variant={isSmallScreen ? 'temporary' : 'persistent'}
+        anchor="left"
+        open={isOpen}
+        onClose={() => onToggle(false)}
+      >
+        <Sidebar />
+      </Drawer>
+
+      {showSidebarToggle && (
+        <div
+          className={classnames(css.sidebarToggle, isOpen && css.sidebarOpen)}
+          role="button"
+          onClick={() => onToggle(!isOpen)}
+        >
+          <IconButton aria-label="collapse sidebar" size="small">
+            {isOpen ? <DoubleArrowLeftIcon fontSize="inherit" /> : <DoubleArrowRightIcon fontSize="inherit" />}
+          </IconButton>
+        </div>
+      )}
+    </>
+  )
+}
+
+export default SideDrawer

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -1,50 +1,28 @@
-import { useEffect, useState, type ReactElement } from 'react'
-import { useRouter } from 'next/router'
-import cn from 'classnames'
+import { useState, type ReactElement } from 'react'
+import classnames from 'classnames'
 
-import Sidebar from '@/components/sidebar/Sidebar'
 import Header from '@/components/common//Header'
 import css from './styles.module.css'
 import SafeLoadingError from '../SafeLoadingError'
 import Footer from '../Footer'
-import { AppRoutes } from '@/config/routes'
-import { useSafeAppUrl } from '@/hooks/safe-apps/useSafeAppUrl'
-import { useMediaQuery } from '@mui/material'
+import SideDrawer from './SideDrawer'
 
 const PageLayout = ({ children }: { children: ReactElement }): ReactElement => {
-  const router = useRouter()
-  const isMobile = useMediaQuery('(max-width: 900px)')
+  const [isSidebarOpen, setSidebarOpen] = useState<boolean>(true)
 
-  const [appUrl] = useSafeAppUrl()
-  const isSafeAppPage = !!appUrl && router.pathname === AppRoutes.apps
-  const isShareSafeAppPage = router.pathname === AppRoutes.share.safeApp
-
-  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState<boolean>(isMobile)
-
-  const collapseSidebar = () => setIsSidebarCollapsed((prev) => !prev)
-  const showCollapseSidebarButton = isSafeAppPage && !isMobile
-
-  const isSidebarHiddenDesktop = (isShareSafeAppPage || isSafeAppPage) && isSidebarCollapsed
-  const isSidebarHiddenMobile = isSidebarCollapsed
-  const isSidebarHidden = isMobile ? isSidebarHiddenMobile : isSidebarHiddenDesktop
-
-  useEffect(() => {
-    setIsSidebarCollapsed(true)
-  }, [router.pathname, router.query.safe, isMobile, isSafeAppPage])
+  const toggleSidebar = () => {
+    setSidebarOpen((prev) => !prev)
+  }
 
   return (
     <>
       <header className={css.header}>
-        <Header onMenuToggle={collapseSidebar} />
+        <Header onMenuToggle={toggleSidebar} />
       </header>
 
-      <Sidebar
-        isSidebarHidden={isSidebarHidden}
-        showCollapseSidebarButton={showCollapseSidebarButton}
-        collapseSidebar={collapseSidebar}
-      />
+      <SideDrawer isOpen={isSidebarOpen} onToggle={setSidebarOpen} />
 
-      <div className={cn(css.main, isSidebarHidden && css.mainNoSidebar)}>
+      <div className={classnames(css.main, !isSidebarOpen && css.mainNoSidebar)}>
         <div className={css.content}>
           <SafeLoadingError>{children}</SafeLoadingError>
         </div>

--- a/src/components/common/PageLayout/styles.module.css
+++ b/src/components/common/PageLayout/styles.module.css
@@ -32,6 +32,33 @@
   padding: var(--space-3);
 }
 
+.sidebarToggle {
+  position: fixed;
+  z-index: 2;
+  left: 0;
+  top: 0;
+  height: 100vh;
+  width: var(--space-1);
+  background-color: var(--color-border-light);
+  /* mimics MUI drawer animation */
+  transition: transform 225ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+}
+
+.sidebarToggle.sidebarOpen {
+  transform: translateX(230px);
+}
+
+.sidebarToggle button {
+  position: absolute;
+  z-index: 1;
+  top: 50%;
+  left: -3px;
+  transform: translateY(-50%);
+  background-color: var(--color-border-light);
+  clip-path: inset(0 -14px 0 0);
+  transition: background-color 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
 @media (max-width: 900px) {
   .main {
     padding-left: 0;

--- a/src/components/sidebar/Sidebar/index.tsx
+++ b/src/components/sidebar/Sidebar/index.tsx
@@ -1,12 +1,6 @@
 import { useState, type ReactElement } from 'react'
-import Divider from '@mui/material/Divider'
-import IconButton from '@mui/material/IconButton'
-import Drawer from '@mui/material/Drawer'
+import { Divider, Drawer, IconButton } from '@mui/material'
 import ChevronRight from '@mui/icons-material/ChevronRight'
-import useMediaQuery from '@mui/material/useMediaQuery'
-import Tooltip from '@mui/material/Tooltip'
-import DoubleArrowRightIcon from '@mui/icons-material/KeyboardDoubleArrowRightRounded'
-import DoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrowLeftRounded'
 import { useRouter } from 'next/router'
 
 import ChainIndicator from '@/components/common/ChainIndicator'
@@ -20,85 +14,54 @@ import { trackEvent, OVERVIEW_EVENTS } from '@/services/analytics'
 import KeyholeIcon from '@/components/common/icons/KeyholeIcon'
 import OwnedSafes from '../OwnedSafes'
 
-type SidebarProps = {
-  isSidebarHidden: boolean
-  showCollapseSidebarButton: boolean
-  collapseSidebar: () => void
-}
-
-const Sidebar = ({ isSidebarHidden, showCollapseSidebarButton, collapseSidebar }: SidebarProps): ReactElement => {
+const Sidebar = (): ReactElement => {
   const router = useRouter()
-  const isMobile = useMediaQuery('(max-width: 900px)')
-
-  const [isSafeListOpen, setIsSafeListOpen] = useState<boolean>(false)
-
+  const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(false)
   const isSafeRoute = !!router.query?.safe
 
-  const onToggleSafeList = () => {
-    trackEvent({ ...OVERVIEW_EVENTS.SIDEBAR, label: isSafeListOpen ? 'Close' : 'Open' })
-    setIsSafeListOpen((prev) => !prev)
+  const onDrawerToggle = () => {
+    trackEvent({ ...OVERVIEW_EVENTS.SIDEBAR, label: isDrawerOpen ? 'Close' : 'Open' })
+    setIsDrawerOpen((prev) => !prev)
   }
 
   return (
-    <Drawer
-      variant={isMobile ? 'temporary' : 'persistent'}
-      anchor="left"
-      open={!isSidebarHidden}
-      onClose={collapseSidebar}
-      PaperProps={{ style: { overflow: 'visible' } }}
-    >
-      <aside className={css.container}>
-        <div className={css.scroll}>
-          <ChainIndicator />
+    <div className={css.container}>
+      <div className={css.scroll}>
+        <ChainIndicator />
 
-          <IconButton className={css.drawerButton} onClick={onToggleSafeList}>
-            <ChevronRight />
-          </IconButton>
+        <IconButton className={css.drawerButton} onClick={onDrawerToggle}>
+          <ChevronRight />
+        </IconButton>
 
-          {isSafeRoute ? (
-            <>
-              <SidebarHeader />
-              <Divider />
-              <SidebarNavigation />
-            </>
-          ) : (
-            <>
-              <div className={css.noSafeHeader}>
-                <KeyholeIcon />
-              </div>
+        {isSafeRoute ? (
+          <>
+            <SidebarHeader />
+            <Divider />
+            <SidebarNavigation />
+          </>
+        ) : (
+          <>
+            <div className={css.noSafeHeader}>
+              <KeyholeIcon />
+            </div>
 
-              <OwnedSafes />
-            </>
-          )}
+            <OwnedSafes />
+          </>
+        )}
 
-          <div style={{ flexGrow: 1 }} />
+        <div style={{ flexGrow: 1 }} />
 
-          <Divider flexItem />
+        <Divider flexItem />
 
-          <SidebarFooter />
+        <SidebarFooter />
+      </div>
+
+      <Drawer variant="temporary" anchor="left" open={isDrawerOpen} onClose={onDrawerToggle}>
+        <div className={css.drawer}>
+          <SafeList closeDrawer={() => setIsDrawerOpen(false)} />
         </div>
-
-        <Drawer variant="temporary" anchor="left" open={isSafeListOpen} onClose={onToggleSafeList}>
-          <div className={css.drawer}>
-            <SafeList closeDrawer={() => setIsSafeListOpen(false)} />
-          </div>
-        </Drawer>
-      </aside>
-
-      {showCollapseSidebarButton && (
-        <Tooltip title={isSidebarHidden ? 'Open sidebar' : 'Close sidebar'} placement="right" followCursor={true}>
-          <div onClick={collapseSidebar} className={css.collapseSidebarBar} role="button">
-            <IconButton className={css.collapseSidebarBarButton} aria-label="collapse sidebar" size="small">
-              {isSidebarHidden ? (
-                <DoubleArrowRightIcon fontSize="inherit" />
-              ) : (
-                <DoubleArrowLeftIcon fontSize="inherit" />
-              )}
-            </IconButton>
-          </div>
-        </Tooltip>
-      )}
-    </Drawer>
+      </Drawer>
+    </div>
   )
 }
 

--- a/src/components/sidebar/Sidebar/styles.module.css
+++ b/src/components/sidebar/Sidebar/styles.module.css
@@ -1,6 +1,7 @@
 .container,
 .drawer {
-  height: 100%;
+  height: 100vh;
+  padding-top: var(--header-height);
   display: flex;
   overflow: hidden;
   flex-direction: column;
@@ -9,7 +10,6 @@
 
 .container {
   width: 230px;
-  padding-top: var(--header-height);
   border-right: 1px solid var(--color-border-light);
 }
 
@@ -20,7 +20,6 @@
   position: relative;
   overflow-y: auto;
   overflow-x: hidden;
-  max-height: calc(100vh - var(--header-height)); /* needed for scroll */
 }
 
 .drawer {
@@ -65,41 +64,11 @@
   transform: translateX(-25%);
 }
 
-.collapseSidebarBar {
-  position: absolute;
-  visibility: visible;
-  height: calc(100vh - var(--header-height));
-  width: var(--show-sidebar-bar-width);
-  top: var(--header-height);
-  right: calc(var(--show-sidebar-bar-width) * -1);
-  background-color: var(--color-border-light);
-  transition: background-color 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  cursor: pointer;
-  z-index: 1;
-  clip-path: inset(0 -14px 0 0);
-}
-
-.collapseSidebarBar:hover {
-  background-color: var(--color-text-disabled);
-}
-
-.collapseSidebarBarButton {
-  position: absolute;
-  top: 50%;
-  left: calc(var(--show-sidebar-bar-width) * -0.5);
-  background-color: var(--color-border-light);
-  transition: background-color 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-}
-
-.collapseSidebarBar:hover .collapseSidebarBarButton {
-  background-color: var(--color-text-disabled);
-}
-
-.collapseSidebarBarButton:hover {
-  background-color: var(--color-text-disabled);
-}
-
 @media (max-width: 900px) {
+  .container {
+    padding-top: var(--header-height);
+  }
+
   .drawer {
     max-width: 90vw;
   }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -42,7 +42,6 @@ button {
 
 :root {
   --header-height: 52px;
-  --show-sidebar-bar-width: 8px;
 }
 
 input::-webkit-outer-spin-button,


### PR DESCRIPTION
A small refactoring based on #1169.

Extracts the collapsible drawer logic into a SideDrawer component. PageLayout only lifts the state.
The Sidebar component is untouched, it's the same as on dev.