### PR TITLE
Fix: MUI Switch default color

### DIFF
--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -473,6 +473,9 @@ const initTheme = (darkMode: boolean) => {
         },
       },
       MuiSwitch: {
+        defaultProps: {
+          color: 'success',
+        },
         styleOverrides: {
           thumb: ({ theme }) => ({
             boxShadow:

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -474,7 +474,7 @@ const initTheme = (darkMode: boolean) => {
       },
       MuiSwitch: {
         defaultProps: {
-          color: 'success',
+          color: darkMode ? undefined : 'success',
         },
         styleOverrides: {
           thumb: ({ theme }) => ({


### PR DESCRIPTION
## What it solves

Based on user feedback, we're making the toggle color green when checked. Only affects the light mode.
Color approved by the designers.

## Screenshots
<img width="441" alt="Screenshot 2022-11-17 at 13 49 40" src="https://user-images.githubusercontent.com/381895/202450933-a81ea4e6-1098-4a99-a15c-f2fe7bf3d5b2.png">
