### PR TITLE
fix: check for pending safe creation in first step

### DIFF
--- a/src/components/new-safe/steps/Step0/index.tsx
+++ b/src/components/new-safe/steps/Step0/index.tsx
@@ -10,18 +10,21 @@ import WalletDetails from '@/components/common/ConnectWallet/WalletDetails'
 import PairingDetails from '@/components/common/PairingDetails'
 import useSyncSafeCreationStep from '@/components/new-safe/CreateSafe/useSyncSafeCreationStep'
 import layoutCss from '@/components/new-safe/CreateSafe/styles.module.css'
+import useLocalStorage from '@/services/local-storage/useLocalStorage'
+import { type PendingSafeData, SAFE_PENDING_CREATION_STORAGE_KEY } from '@/components/new-safe/steps/Step4'
 
 const CreateSafeStep0 = ({ onSubmit, setStep }: StepRenderProps<NewSafeFormData>) => {
+  const [pendingSafe] = useLocalStorage<PendingSafeData | undefined>(SAFE_PENDING_CREATION_STORAGE_KEY)
   const wallet = useWallet()
   const chain = useCurrentChain()
   const isSupported = isPairingSupported(chain?.disabledWallets)
   useSyncSafeCreationStep(setStep)
 
   useEffect(() => {
-    if (!wallet) return
+    if (!wallet || pendingSafe) return
 
     onSubmit({ owners: [{ address: wallet.address, name: wallet.ens || '' }] })
-  }, [onSubmit, wallet])
+  }, [onSubmit, wallet, pendingSafe])
 
   return (
     <>


### PR DESCRIPTION
## What it solves

Resolves #1173 

## How this PR fixes it

- Disables auto navigation from Step 0 if there is a pending safe

## How to test it

1. Open the Safe
2. Create a new safe
3. Reject the transaction in your wallet
4. Click the Safe logo
5. Go to /welcome and click create new safe
6. Observe being navigated to the status screen
7. Observe the app not crashing
