### PR TITLE
fix: QR reader crashes app

### DIFF
--- a/src/components/common/ScanQRModal/index.tsx
+++ b/src/components/common/ScanQRModal/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, createRef, useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { Box, Dialog, DialogTitle, IconButton, Button, Divider } from '@mui/material'
 import QrReader from 'react-qr-reader'
 import CloseIcon from '@mui/icons-material/Close'
@@ -15,19 +15,14 @@ const ScanQRModal = ({ isOpen, onClose, onScan }: Props): React.ReactElement => 
   const [fileUploadModalOpen, setFileUploadModalOpen] = useState<boolean>(false)
   const [error, setError] = useState<string>('')
   const [cameraBlocked, setCameraBlocked] = useState<boolean>(false)
-  const scannerRef = createRef<QrReader>()
-  const openImageDialog = useCallback(() => {
-    if (!scannerRef.current) return
-
-    scannerRef.current.openImageDialog()
-  }, [scannerRef])
+  const scannerRef = useRef<QrReader>(null)
 
   useEffect(() => {
     if (!fileUploadModalOpen && cameraBlocked && !error) {
       setFileUploadModalOpen(true)
-      openImageDialog()
+      scannerRef.current?.openImageDialog()
     }
-  }, [cameraBlocked, openImageDialog, fileUploadModalOpen, setFileUploadModalOpen, error])
+  }, [cameraBlocked, fileUploadModalOpen, error])
 
   const onFileScannedError = (error: Error) => {
     if (error.name === 'NotAllowedError' || error.name === 'PermissionDismissedError') {

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -57,7 +57,7 @@ const initTheme = (darkMode: boolean) => {
     },
     spacing: base,
     shape: {
-      borderRadius: '6px',
+      borderRadius: 6,
     },
     shadows: [
       'none',


### PR DESCRIPTION
## What it solves

Resolves #1171 
Resolves #1185 

## How this PR fixes it

- Uses `useRef` instead of `createRef` and fixes side effect dependencies to prevent rerenders

## How to test it

1. Open the Safe
2. Create a new safe
3. Navigate to the add owner screen
4. Press the QR Button with camera allowed
5. Press the Upload an Image button
6. Observe the app not crashing
