### PR TITLE
fix: Add overview widget to step 1 in safe creation

### DIFF
--- a/src/components/new-safe/CreateSafe/index.tsx
+++ b/src/components/new-safe/CreateSafe/index.tsx
@@ -203,7 +203,7 @@ const CreateSafe = () => {
 
         <Grid item xs={12} md={4} mb={[3, null, 0]} order={[0, null, 1]}>
           <Grid container spacing={3}>
-            {wallet?.address && activeStep < 3 && <OverviewWidget safeName={safeName} />}
+            {activeStep < 3 && <OverviewWidget safeName={safeName} />}
             {wallet?.address && <CreateSafeInfos staticHint={staticHint} dynamicHint={dynamicHint} />}
           </Grid>
         </Grid>

--- a/src/components/new-safe/OverviewWidget/index.tsx
+++ b/src/components/new-safe/OverviewWidget/index.tsx
@@ -26,12 +26,20 @@ const OverviewWidget = ({ safeName }: { safeName: string }): ReactElement | null
           <SafeLogo alt="Safe logo" width={LOGO_DIMENSIONS} height={LOGO_DIMENSIONS} />
           <Typography variant="h4">Your Safe preview</Typography>
         </div>
-        {rows?.map((row) => (
-          <div key={row.title} className={css.row}>
-            <Typography variant="body2">{row.title}</Typography>
-            {row.component}
+        {wallet ? (
+          rows.map((row) => (
+            <div key={row.title} className={css.row}>
+              <Typography variant="body2">{row.title}</Typography>
+              {row.component}
+            </div>
+          ))
+        ) : (
+          <div className={css.row}>
+            <Typography variant="body2" color="border.main" textAlign="center" width={1}>
+              Connect your wallet to continue
+            </Typography>
           </div>
-        ))}
+        )}
       </Card>
     </Grid>
   )


### PR DESCRIPTION
## What it solves

Resolves #1209 

## How this PR fixes it

- Displays the overview widget in step 1 with a message 

## How to test it

1. Open the new safe creation flow
2. Disconnect wallet
3. The overview widget is visible

## Screenshots

<img width="1209" alt="Screenshot 2022-11-21 at 15 06 17" src="https://user-images.githubusercontent.com/5880855/203074965-6f1dc577-9c48-4299-9d26-87cee9ff677b.png">
