### PR TITLE
fix: Watch safe creation tx even without a connected wallet

### DIFF
--- a/src/components/create-safe/status/__tests__/useSafeCreation.test.ts
+++ b/src/components/create-safe/status/__tests__/useSafeCreation.test.ts
@@ -149,6 +149,24 @@ describe('useSafeCreation', () => {
     })
   })
 
+  it('should watch a tx even if no wallet is connected', async () => {
+    jest.spyOn(wallet, 'default').mockReturnValue(null)
+    const watchSafeTxSpy = jest.spyOn(logic, 'checkSafeCreationTx')
+
+    renderHook(() =>
+      useSafeCreation(
+        { ...mockPendingSafe, txHash: '0x123', tx: mockSafeInfo },
+        mockSetPendingSafe,
+        mockStatus,
+        mockSetStatus,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(watchSafeTxSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it('should not watch a tx if there is no txHash', async () => {
     const watchSafeTxSpy = jest.spyOn(logic, 'checkSafeCreationTx')
 

--- a/src/components/create-safe/status/__tests__/useSafeCreation.test.ts
+++ b/src/components/create-safe/status/__tests__/useSafeCreation.test.ts
@@ -4,7 +4,7 @@ import * as web3 from '@/hooks/wallets/web3'
 import * as chain from '@/hooks/useChains'
 import * as wallet from '@/hooks/wallets/useWallet'
 import * as logic from '@/components/create-safe/logic'
-import { Web3Provider } from '@ethersproject/providers'
+import { JsonRpcProvider, Web3Provider } from '@ethersproject/providers'
 import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import type { ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { BigNumber } from '@ethersproject/bignumber'
@@ -32,16 +32,18 @@ describe('useSafeCreation', () => {
 
   const mockStatus = SafeCreationStatus.AWAITING
   const mockSetStatus = jest.fn()
+  const mockProvider: Web3Provider = new Web3Provider(jest.fn())
+  const mockReadOnlyProvider: JsonRpcProvider = new JsonRpcProvider()
 
   beforeEach(() => {
     jest.resetAllMocks()
 
-    const mockProvider: Web3Provider = new Web3Provider(jest.fn())
     const mockChain = {
       chainId: '4',
     } as unknown as ChainInfo
 
     jest.spyOn(web3, 'useWeb3').mockImplementation(() => mockProvider)
+    jest.spyOn(web3, 'useWeb3ReadOnly').mockImplementation(() => mockReadOnlyProvider)
     jest.spyOn(chain, 'useCurrentChain').mockImplementation(() => mockChain)
     jest.spyOn(wallet, 'default').mockReturnValue({} as ConnectedWallet)
     jest.spyOn(logic, 'getSafeCreationTxInfo').mockReturnValue(Promise.resolve(mockSafeInfo))

--- a/src/components/create-safe/status/useSafeCreation.ts
+++ b/src/components/create-safe/status/useSafeCreation.ts
@@ -7,7 +7,7 @@ import {
   checkSafeCreationTx,
   handleSafeCreationError,
 } from '@/components/create-safe/logic'
-import { useWeb3 } from '@/hooks/wallets/web3'
+import { useWeb3, useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { useCurrentChain } from '@/hooks/useChains'
 import useWallet from '@/hooks/wallets/useWallet'
 import type { PendingSafeData, PendingSafeTx } from '@/components/create-safe/types.d'
@@ -37,6 +37,7 @@ export const useSafeCreation = (
 
   const wallet = useWallet()
   const provider = useWeb3()
+  const web3ReadOnly = useWeb3ReadOnly()
   const chain = useCurrentChain()
 
   const createSafeCallback = useCallback(
@@ -74,15 +75,15 @@ export const useSafeCreation = (
   }, [chain, createSafeCallback, isCreating, pendingSafe, provider, setStatus, wallet])
 
   const watchSafeTx = useCallback(async () => {
-    if (!pendingSafe?.tx || !pendingSafe?.txHash || !provider || isWatching) return
+    if (!pendingSafe?.tx || !pendingSafe?.txHash || !web3ReadOnly || isWatching) return
 
     setStatus(SafeCreationStatus.PROCESSING)
     setIsWatching(true)
 
-    const txStatus = await checkSafeCreationTx(provider, pendingSafe.tx, pendingSafe.txHash)
+    const txStatus = await checkSafeCreationTx(web3ReadOnly, pendingSafe.tx, pendingSafe.txHash)
     setStatus(txStatus)
     setIsWatching(false)
-  }, [isWatching, pendingSafe, provider, setStatus])
+  }, [isWatching, pendingSafe, web3ReadOnly, setStatus])
 
   useEffect(() => {
     if (status !== SafeCreationStatus.AWAITING) return

--- a/src/components/new-safe/steps/Step4/useSafeCreation.ts
+++ b/src/components/new-safe/steps/Step4/useSafeCreation.ts
@@ -1,6 +1,6 @@
 import type { Dispatch, SetStateAction } from 'react'
 import { useCallback, useEffect, useState } from 'react'
-import { useWeb3 } from '@/hooks/wallets/web3'
+import { useWeb3, useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { useCurrentChain } from '@/hooks/useChains'
 import useWallet from '@/hooks/wallets/useWallet'
 import type { EthersError } from '@/utils/ethers-utils'
@@ -43,6 +43,7 @@ export const useSafeCreation = (
 
   const wallet = useWallet()
   const provider = useWeb3()
+  const web3ReadOnly = useWeb3ReadOnly()
   const chain = useCurrentChain()
 
   const createSafeCallback = useCallback(
@@ -88,15 +89,15 @@ export const useSafeCreation = (
   }, [chain, createSafeCallback, dispatch, isCreating, pendingSafe, provider, setStatus, wallet])
 
   const watchSafeTx = useCallback(async () => {
-    if (!pendingSafe?.tx || !pendingSafe?.txHash || !provider || isWatching) return
+    if (!pendingSafe?.tx || !pendingSafe?.txHash || !web3ReadOnly || isWatching) return
 
     setStatus(SafeCreationStatus.PROCESSING)
     setIsWatching(true)
 
-    const txStatus = await checkSafeCreationTx(provider, pendingSafe.tx, pendingSafe.txHash, dispatch)
+    const txStatus = await checkSafeCreationTx(web3ReadOnly, pendingSafe.tx, pendingSafe.txHash, dispatch)
     setStatus(txStatus)
     setIsWatching(false)
-  }, [isWatching, pendingSafe, provider, setStatus, dispatch])
+  }, [isWatching, pendingSafe, web3ReadOnly, setStatus, dispatch])
 
   useEffect(() => {
     if (status !== SafeCreationStatus.AWAITING) return


### PR DESCRIPTION
## What it solves

Resolves #1214 

## How this PR fixes it

- Uses the `web3ReadOnly` provider to watch an existing tx

## How to test it

1. Navigate to the new safe creation flow
2. Create a new safe and confirm the transaction
3. Disconnect your wallet
4. Reload the page
5. Observe the UI showing `Transaction is being executed.`
6. Observe the UI watching the tx and updating the status once the tx has been executed or canceled
