### PR TITLE
feat: pass dark mode in the widgets url

### DIFF
--- a/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
+++ b/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
@@ -22,7 +22,7 @@ const GovernanceSection = () => {
   const fetchingSafeClaimingApp = !claimingApp && !errorFetchingClaimingSafeApp
 
   return (
-    <Accordion className={css.accordion} defaultExpanded={true}>
+    <Accordion className={css.accordion} defaultExpanded>
       <AccordionSummary expandIcon={<ExpandMoreIcon color="border" />}>
         <div>
           <Typography component="h2" variant="subtitle1" fontWeight={700}>

--- a/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
+++ b/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
@@ -11,11 +11,13 @@ import AppFrame from '@/components/safe-apps/AppFrame'
 import { useBrowserPermissions } from '@/hooks/safe-apps/permissions'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
 import { SafeAppsTag } from '@/config/constants'
+import { useDarkMode } from '@/hooks/useDarkMode'
 
 const CLAIMING_WIDGET_ID = '#claiming-widget'
 const SNAPSHOT_WIDGET_ID = '#snapshot-widget'
 
 const GovernanceSection = () => {
+  const isDarkMode = useDarkMode()
   const { getAllowedFeaturesList } = useBrowserPermissions()
   const [claimingSafeApp, errorFetchingClaimingSafeApp] = useRemoteSafeApps(SafeAppsTag.SAFE_CLAIMING_APP)
   const claimingApp = claimingSafeApp?.[0]
@@ -43,7 +45,7 @@ const GovernanceSection = () => {
                   {claimingApp ? (
                     <SafeAppsErrorBoundary render={() => <SafeAppsLoadError onBackToApps={() => {}} />}>
                       <AppFrame
-                        appUrl={`${claimingApp.url}${SNAPSHOT_WIDGET_ID}`}
+                        appUrl={`${claimingApp.url}${SNAPSHOT_WIDGET_ID}${isDarkMode ? '+dark' : ''}`}
                         allowedFeaturesList={getAllowedFeaturesList(claimingApp.url)}
                         isQueueBarDisabled
                       />
@@ -68,7 +70,7 @@ const GovernanceSection = () => {
                   {claimingApp ? (
                     <SafeAppsErrorBoundary render={() => <SafeAppsLoadError onBackToApps={() => {}} />}>
                       <AppFrame
-                        appUrl={`${claimingApp.url}${CLAIMING_WIDGET_ID}`}
+                        appUrl={`${claimingApp.url}${CLAIMING_WIDGET_ID}${isDarkMode ? '+dark' : ''}`}
                         allowedFeaturesList={getAllowedFeaturesList(claimingApp.url)}
                         isQueueBarDisabled
                       />

--- a/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
+++ b/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
@@ -18,6 +18,7 @@ const SNAPSHOT_WIDGET_ID = '#snapshot-widget'
 
 const GovernanceSection = () => {
   const isDarkMode = useDarkMode()
+  const theme = isDarkMode ? 'dark' : 'light'
   const { getAllowedFeaturesList } = useBrowserPermissions()
   const [claimingSafeApp, errorFetchingClaimingSafeApp] = useRemoteSafeApps(SafeAppsTag.SAFE_CLAIMING_APP)
   const claimingApp = claimingSafeApp?.[0]
@@ -45,7 +46,7 @@ const GovernanceSection = () => {
                   {claimingApp ? (
                     <SafeAppsErrorBoundary render={() => <SafeAppsLoadError onBackToApps={() => {}} />}>
                       <AppFrame
-                        appUrl={`${claimingApp.url}${SNAPSHOT_WIDGET_ID}${isDarkMode ? '+dark' : ''}`}
+                        appUrl={`${claimingApp.url}?theme=${theme}${SNAPSHOT_WIDGET_ID}`}
                         allowedFeaturesList={getAllowedFeaturesList(claimingApp.url)}
                         isQueueBarDisabled
                       />
@@ -70,7 +71,7 @@ const GovernanceSection = () => {
                   {claimingApp ? (
                     <SafeAppsErrorBoundary render={() => <SafeAppsLoadError onBackToApps={() => {}} />}>
                       <AppFrame
-                        appUrl={`${claimingApp.url}${CLAIMING_WIDGET_ID}${isDarkMode ? '+dark' : ''}`}
+                        appUrl={`${claimingApp.url}?theme=${theme}${CLAIMING_WIDGET_ID}`}
                         allowedFeaturesList={getAllowedFeaturesList(claimingApp.url)}
                         isQueueBarDisabled
                       />

--- a/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
+++ b/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
@@ -22,7 +22,7 @@ const GovernanceSection = () => {
   const fetchingSafeClaimingApp = !claimingApp && !errorFetchingClaimingSafeApp
 
   return (
-    <Accordion className={css.accordion} defaultExpanded>
+    <Accordion className={css.accordion} defaultExpanded={true}>
       <AccordionSummary expandIcon={<ExpandMoreIcon color="border" />}>
         <div>
           <Typography component="h2" variant="subtitle1" fontWeight={700}>


### PR DESCRIPTION
## What it solves
Part of https://github.com/safe-global/web-core/issues/1221
Allows passing a dark mode flag in the url to the governance widgets

## How this PR fixes it
Reads app dark setting and passes it in the `appUrl`

## How to test it
Needs https://github.com/safe-global/safe-react-apps/pull/580 to be merged or it will break parsing the widgets ID

## Analytics changes
N/A

## Screenshots
Nothing changes
