### PR TITLE
fix: Only watch safe creation tx once

### DIFF
--- a/src/components/new-safe/steps/Step4/useSafeCreation.ts
+++ b/src/components/new-safe/steps/Step4/useSafeCreation.ts
@@ -48,10 +48,11 @@ export const useSafeCreation = (
 
   const createSafeCallback = useCallback(
     async (txHash: string, tx: PendingSafeTx) => {
+      setStatus(SafeCreationStatus.PROCESSING)
       trackEvent(CREATE_SAFE_EVENTS.SUBMIT_CREATE_SAFE)
       setPendingSafe((prev) => (prev ? { ...prev, txHash, tx } : undefined))
     },
-    [setPendingSafe],
+    [setStatus, setPendingSafe],
   )
 
   const createSafe = useCallback(async () => {
@@ -74,6 +75,7 @@ export const useSafeCreation = (
       )
 
       await createNewSafe(provider, safeParams)
+      setStatus(SafeCreationStatus.SUCCESS)
     } catch (err) {
       const _err = err as EthersError
       const status = handleSafeCreationError(_err)
@@ -102,13 +104,13 @@ export const useSafeCreation = (
   useEffect(() => {
     if (status !== SafeCreationStatus.AWAITING) return
 
-    if (pendingSafe?.txHash) {
+    if (pendingSafe?.txHash && !isCreating) {
       void watchSafeTx()
       return
     }
 
     void createSafe()
-  }, [createSafe, watchSafeTx, pendingSafe?.txHash, status])
+  }, [createSafe, watchSafeTx, isCreating, pendingSafe?.txHash, status])
 
   return {
     createSafe,


### PR DESCRIPTION
## What it solves

Part of #864 

## How this PR fixes it

- It doesn't run the watcher if there is already a pending creation

## How to test it

1. Open the new safe creation
2. Create a safe and execute in wallet
3. Cancel the tx from the wallet
4. Wait until the cancellation is processed
5. Observe that there is only one error in the console
6. Create a safe and execute in wallet
7. Cancel the tx from the wallet
8. Reload the page
9. Wait until the cancellation is processed
5. Observe that there is only one error in the console
