### PR TITLE
fix: show warning based on `trusted` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@gnosis.pm/safe-deployments": "^1.15.0",
     "@gnosis.pm/safe-ethers-lib": "^1.6.1",
     "@gnosis.pm/safe-modules-deployments": "^1.0.0",
-    "@gnosis.pm/safe-react-gateway-sdk": "^3.4.5",
+    "@gnosis.pm/safe-react-gateway-sdk": "^3.4.6",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.9.3",
     "@mui/x-date-pickers": "^5.0.0-beta.6",

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -46,8 +46,9 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
   const awaitingExecution = isAwaitingExecution(txSummary.txStatus)
   const isUnsigned =
     isMultisigExecutionInfo(txSummary.executionInfo) && txSummary.executionInfo.confirmationsSubmitted === 0
-  const isTrusted =
-    isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo) && txDetails.detailedExecutionInfo.trusted
+  const isUntrusted =
+    isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo) &&
+    txDetails.detailedExecutionInfo.trusted === false
 
   return (
     <>
@@ -78,7 +79,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
         )}
 
         <div className={css.txSummary}>
-          {isTrusted === false && <UnsignedWarning />}
+          {isUntrusted && <UnsignedWarning />}
           {txDetails.txData?.operation === Operation.DELEGATE && (
             <div className={css.delegateCall}>
               <DelegateCallWarning showWarning={!txDetails.txData.trustedDelegateCallTarget} />

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -78,7 +78,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
         )}
 
         <div className={css.txSummary}>
-          {!isTrusted && <UntrustedWarning />}
+          {isTrusted === false && <UntrustedWarning />}
           {txDetails.txData?.operation === Operation.DELEGATE && (
             <div className={css.delegateCall}>
               <DelegateCallWarning showWarning={!txDetails.txData.trustedDelegateCallTarget} />

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -28,7 +28,7 @@ import SignTxButton from '@/components/transactions/SignTxButton'
 import RejectTxButton from '@/components/transactions/RejectTxButton'
 import useWallet from '@/hooks/wallets/useWallet'
 import useIsWrongChain from '@/hooks/useIsWrongChain'
-import { DelegateCallWarning, UntrustedWarning } from '@/components/transactions/Warning'
+import { DelegateCallWarning, UnsignedWarning } from '@/components/transactions/Warning'
 import Multisend from '@/components/transactions/TxDetails/TxData/DecodedData/Multisend'
 
 export const NOT_AVAILABLE = 'n/a'
@@ -78,7 +78,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
         )}
 
         <div className={css.txSummary}>
-          {isTrusted === false && <UntrustedWarning />}
+          {isTrusted === false && <UnsignedWarning />}
           {txDetails.txData?.operation === Operation.DELEGATE && (
             <div className={css.delegateCall}>
               <DelegateCallWarning showWarning={!txDetails.txData.trustedDelegateCallTarget} />

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -12,6 +12,7 @@ import {
   isAwaitingExecution,
   isModuleExecutionInfo,
   isMultiSendTxInfo,
+  isMultisigDetailedExecutionInfo,
   isMultisigExecutionInfo,
   isSupportedMultiSendAddress,
   isTxQueued,
@@ -27,7 +28,7 @@ import SignTxButton from '@/components/transactions/SignTxButton'
 import RejectTxButton from '@/components/transactions/RejectTxButton'
 import useWallet from '@/hooks/wallets/useWallet'
 import useIsWrongChain from '@/hooks/useIsWrongChain'
-import { DelegateCallWarning, UnsignedWarning } from '@/components/transactions/Warning'
+import { DelegateCallWarning, UntrustedWarning } from '@/components/transactions/Warning'
 import Multisend from '@/components/transactions/TxDetails/TxData/DecodedData/Multisend'
 
 export const NOT_AVAILABLE = 'n/a'
@@ -45,6 +46,8 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
   const awaitingExecution = isAwaitingExecution(txSummary.txStatus)
   const isUnsigned =
     isMultisigExecutionInfo(txSummary.executionInfo) && txSummary.executionInfo.confirmationsSubmitted === 0
+  const isTrusted =
+    isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo) && txDetails.detailedExecutionInfo.trusted
 
   return (
     <>
@@ -75,7 +78,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
         )}
 
         <div className={css.txSummary}>
-          {isUnsigned && <UnsignedWarning />}
+          {!isTrusted && <UntrustedWarning />}
           {txDetails.txData?.operation === Operation.DELEGATE && (
             <div className={css.delegateCall}>
               <DelegateCallWarning showWarning={!txDetails.txData.trustedDelegateCallTarget} />

--- a/src/components/transactions/Warning/index.tsx
+++ b/src/components/transactions/Warning/index.tsx
@@ -62,9 +62,9 @@ export const ThresholdWarning = (): ReactElement => (
   />
 )
 
-export const UntrustedWarning = (): ReactElement => (
+export const UnsignedWarning = (): ReactElement => (
   <Warning
-    title="This transaction is not trusted and could have been created by anyone. To avoid phishing, only sign it if you trust the source of the link."
+    title="This transaction is unsigned and could have been created by anyone. To avoid phishing, only sign it if you trust the source of the link."
     severity="error"
     text="Untrusted transaction"
   />

--- a/src/components/transactions/Warning/index.tsx
+++ b/src/components/transactions/Warning/index.tsx
@@ -62,9 +62,9 @@ export const ThresholdWarning = (): ReactElement => (
   />
 )
 
-export const UnsignedWarning = (): ReactElement => (
+export const UntrustedWarning = (): ReactElement => (
   <Warning
-    title="This transaction is unsigned and could have been created by anyone. To avoid phishing, only sign it if you trust the source of the link."
+    title="This transaction is not trusted and could have been created by anyone. To avoid phishing, only sign it if you trust the source of the link."
     severity="error"
     text="Untrusted transaction"
   />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2470,10 +2470,10 @@
   dependencies:
     cross-fetch "^3.1.5"
 
-"@gnosis.pm/safe-react-gateway-sdk@^3.4.5":
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-3.4.5.tgz#bd59ca973721991f54a2df6b05baeb884434208f"
-  integrity sha512-b8ZaYaQ1apS/4R9sEEUCtrg0AwTf8tfqS0Jp6JAopLxHdX0NItCvs5/Y1+rjDodv2l+I/Zf9vJJyUDC0XABfMA==
+"@gnosis.pm/safe-react-gateway-sdk@^3.4.6":
+  version "3.4.6"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-3.4.6.tgz#14ae3cd6557eb2a3d0f165228b95f16d24aebfa8"
+  integrity sha512-9JeALF5j4cGF8a9NBZTJP2owGruG7w3bw8O6xR8JY2ZyJw4l5f0MHbPU/7rGPHwN33Q9W5c5u1tkXHiHkjkReQ==
   dependencies:
     cross-fetch "^3.1.5"
 


### PR DESCRIPTION
## What it solves

Resolves default warning when no signatures exist.

## How this PR fixes it

A warning should no longer shown by default when no signatures are present, e.g. when queuing an approval of a nested Safe. Instead, they are shown when the `trusted` flag is `false`.

Note: no warning will be shown [until the flag is implemented](https://github.com/safe-global/safe-client-gateway/issues/1005).

## How to test it

Open an "untrusted" transaction and observe the warning