### PR TITLE
Chore: updated sidebar to be opened by default

### DIFF
--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -8,7 +8,7 @@ import Footer from '../Footer'
 import SideDrawer from './SideDrawer'
 
 const PageLayout = ({ children }: { children: ReactElement }): ReactElement => {
-  const [isSidebarOpen, setSidebarOpen] = useState<boolean>(false)
+  const [isSidebarOpen, setSidebarOpen] = useState<boolean>(true)
 
   const toggleSidebar = () => {
     setSidebarOpen((prev) => !prev)


### PR DESCRIPTION
## What it solves

updated sidebar to be opened by default

## How this PR fixes it

```
const [isSidebarOpen, setSidebarOpen] = useState<boolean>(true)
```
