### PR TITLE
fix: Safe cration text changes

### DIFF
--- a/src/components/dashboard/CreationDialog/index.tsx
+++ b/src/components/dashboard/CreationDialog/index.tsx
@@ -60,7 +60,7 @@ const CreationDialog = () => {
           <HintItem
             Icon={HelpCenterIcon}
             title="Help center"
-            description="HHave any questions? Check out our collection of articles."
+            description="Have any questions? Check out our collection of articles."
           />
         </Grid>
         <Box display="flex" justifyContent="center">

--- a/src/components/new-safe/CreateSafe/index.tsx
+++ b/src/components/new-safe/CreateSafe/index.tsx
@@ -33,7 +33,7 @@ const staticHints: Record<
   { title: string; variant: AlertColor; steps: { title: string; text: string | ReactElement }[] }
 > = {
   1: {
-    title: 'Safe Creation',
+    title: 'Safe creation',
     variant: 'info',
     steps: [
       {
@@ -47,7 +47,7 @@ const staticHints: Record<
     ],
   },
   2: {
-    title: 'Safe Creation',
+    title: 'Safe creation',
     variant: 'info',
     steps: [
       {
@@ -59,7 +59,7 @@ const staticHints: Record<
         text: 'You can always change the number of owners and required confirmations in your Safe after creation.',
       },
       {
-        title: 'Safe Setup',
+        title: 'Safe setup',
         text: (
           <>
             Not sure how many owners and confirmations you need for your Safe?
@@ -82,7 +82,7 @@ const staticHints: Record<
     ],
   },
   3: {
-    title: 'Safe Creation',
+    title: 'Safe creation',
     variant: 'info',
     steps: [
       {
@@ -92,7 +92,7 @@ const staticHints: Record<
     ],
   },
   4: {
-    title: 'Safe Usage',
+    title: 'Safe usage',
     variant: 'success',
     steps: [
       {

--- a/src/components/new-safe/steps/Step2/useSafeSetupHints.ts
+++ b/src/components/new-safe/steps/Step2/useSafeSetupHints.ts
@@ -12,7 +12,7 @@ export const useSafeSetupHints = (
     // 1/n warning
     if (threshold === 1) {
       safeSetupWarningSteps.push({
-        title: `1/${noOwners}`,
+        title: `1/${noOwners} policy`,
         text: 'We recommend using a threshold higher than one to prevent losing access to your Safe in case an owner key is lost or compromised.',
       })
     }
@@ -20,12 +20,12 @@ export const useSafeSetupHints = (
     // n/n warning
     if (threshold === noOwners && noOwners > 1) {
       safeSetupWarningSteps.push({
-        title: `${noOwners}/${noOwners}`,
+        title: `${noOwners}/${noOwners} policy`,
         text: 'We recommend using a threshold which is lower than the total number of owners of your Safe in case an owner loses access to their account and needs to be replaced.',
       })
     }
 
-    setHint({ title: 'Safe Setup', variant: 'warning', steps: safeSetupWarningSteps })
+    setHint({ title: 'Safe setup', variant: 'warning', steps: safeSetupWarningSteps })
 
     // Clear dynamic hints when the step / hook unmounts
     return () => {

--- a/src/components/new-safe/steps/Step4/StatusMessage.tsx
+++ b/src/components/new-safe/steps/Step4/StatusMessage.tsx
@@ -43,7 +43,7 @@ const getStep = (status: SafeCreationStatus) => {
       }
     case SafeCreationStatus.INDEXED:
       return {
-        description: 'Your Safe was successfully indexed!',
+        description: 'Your Safe is ready!',
         instruction: '',
       }
     case SafeCreationStatus.INDEX_FAILED:


### PR DESCRIPTION
## What it solves

Part of #864 

## How this PR fixes it

- Fixes a typo in the safe creation modal
- Removes uppercase from hint tags
- Adjusts threshold hint title to include "policy"
- Adjusts the message shown once the safe is successfully indexed
