### PR TITLE
feat: redesign (external) links

### DIFF
--- a/src/components/address-book/ExportDialog/index.tsx
+++ b/src/components/address-book/ExportDialog/index.tsx
@@ -1,7 +1,6 @@
 import DialogContent from '@mui/material/DialogContent'
 import DialogActions from '@mui/material/DialogActions'
 import Button from '@mui/material/Button'
-import Link from '@mui/material/Link'
 import Typography from '@mui/material/Typography'
 import { useCSVDownloader } from 'react-papaparse'
 import type { SyntheticEvent } from 'react'
@@ -11,6 +10,7 @@ import ModalDialog from '@/components/common/ModalDialog'
 import { type AddressBookState, selectAllAddressBooks } from '@/store/addressBookSlice'
 import { useAppSelector } from '@/store'
 import { trackEvent, ADDRESS_BOOK_EVENTS } from '@/services/analytics'
+import ExternalLink from '@/components/common/ExternalLink'
 
 const COL_1 = 'address'
 const COL_2 = 'name'
@@ -65,14 +65,12 @@ const ExportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
         </Typography>
 
         <Typography mt={1}>
-          <Link
-            href="https://help.gnosis-safe.io/en/articles/5299068-address-book-export-and-import"
-            target="_blank"
-            rel="noreferrer"
+          <ExternalLink
+            href="https://help.safe.global/en/articles/5299068-address-book-export-and-import"
             title="Learn about the address book import and export"
           >
             Learn about the address book import and export
-          </Link>
+          </ExternalLink>
         </Typography>
       </DialogContent>
 

--- a/src/components/address-book/ImportDialog/index.tsx
+++ b/src/components/address-book/ImportDialog/index.tsx
@@ -1,7 +1,6 @@
 import DialogContent from '@mui/material/DialogContent'
 import DialogActions from '@mui/material/DialogActions'
 import Button from '@mui/material/Button'
-import Link from '@mui/material/Link'
 import Typography from '@mui/material/Typography'
 import { useCSVReader, formatFileSize } from 'react-papaparse'
 import type { ParseResult } from 'papaparse'
@@ -17,6 +16,7 @@ import { abCsvReaderValidator, abOnUploadValidator } from './validation'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import { Errors, logError } from '@/services/exceptions'
 import FileUpload, { FileTypes, type FileInfo } from '@/components/common/FileUpload'
+import ExternalLink from '@/components/common/ExternalLink'
 
 type AddressBookCSVRow = ['address', 'name', 'chainId']
 
@@ -153,14 +153,12 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
         <Typography>
           Only CSV files exported from a Safe can be imported.
           <br />
-          <Link
-            href="https://help.gnosis-safe.io/en/articles/5299068-address-book-export-and-import"
-            target="_blank"
-            rel="noreferrer"
+          <ExternalLink
+            href="https://help.safe.global/en/articles/5299068-address-book-export-and-import"
             title="Learn about the address book import and export"
           >
             Learn about the address book import and export
-          </Link>
+          </ExternalLink>
         </Typography>
       </DialogContent>
       <DialogActions>

--- a/src/components/common/CookieBanner/index.tsx
+++ b/src/components/common/CookieBanner/index.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react'
 import { useEffect } from 'react'
-import { Button, Checkbox, FormControlLabel, Link, Typography, Paper, SvgIcon } from '@mui/material'
+import { Button, Checkbox, FormControlLabel, Typography, Paper, SvgIcon } from '@mui/material'
 import WarningIcon from '@/public/images/notifications/warning.svg'
 import { useForm } from 'react-hook-form'
 
@@ -9,6 +9,7 @@ import { selectCookies, CookieType, saveCookieConsent } from '@/store/cookiesSli
 import { selectCookieBanner, openCookieBanner, closeCookieBanner } from '@/store/popupSlice'
 
 import css from './styles.module.css'
+import ExternalLink from '../ExternalLink'
 
 const COOKIE_WARNING: Record<CookieType, string> = {
   [CookieType.NECESSARY]: '',
@@ -53,12 +54,9 @@ const CookieBannerPopup = ({ warningKey }: { warningKey?: CookieType }): ReactEl
 
       <Typography align="center">
         We use cookies to provide you with the best experience and to help improve our website and application. Please
-        read our{' '}
-        <Link href="https://gnosis-safe.io/cookie" target="_blank" rel="noopener noreferrer">
-          Cookie Policy
-        </Link>{' '}
-        for more information. By clicking &quot;Accept all&quot;, you agree to the storing of cookies on your device to
-        enhance site navigation, analyze site usage and provide customer support.
+        read our <ExternalLink href="https://safe.global/cookie">Cookie Policy</ExternalLink> for more information. By
+        clicking &quot;Accept all&quot;, you agree to the storing of cookies on your device to enhance site navigation,
+        analyze site usage and provide customer support.
       </Typography>
 
       <form className={css.grid}>

--- a/src/components/common/ErrorBoundary/index.tsx
+++ b/src/components/common/ErrorBoundary/index.tsx
@@ -8,6 +8,7 @@ import WarningIcon from '@/public/images/notifications/warning.svg'
 
 import css from '@/components/common/ErrorBoundary/styles.module.css'
 import CircularIcon from '../icons/CircularIcon'
+import ExternalLink from '../ExternalLink'
 
 const ErrorBoundary: FallbackRender = ({ error, componentStack }) => {
   return (
@@ -24,8 +25,8 @@ const ErrorBoundary: FallbackRender = ({ error, componentStack }) => {
         {IS_PRODUCTION ? (
           <Typography color="text.primary">
             In case the problem persists, please reach out to us via our{' '}
-            <Link href="https://help.gnosis-safe.io" passHref target="_blank" rel="noopener noreferrer">
-              <MuiLink>Help Center</MuiLink>
+            <Link href="https://help.safe.global" passHref target="_blank" rel="noopener noreferrer">
+              <ExternalLink>Help Center</ExternalLink>
             </Link>
           </Typography>
         ) : (

--- a/src/components/common/ExternalLink/index.tsx
+++ b/src/components/common/ExternalLink/index.tsx
@@ -1,0 +1,23 @@
+import { OpenInNewRounded } from '@mui/icons-material'
+import { Box, Link, type LinkProps } from '@mui/material'
+
+/**
+ * Renders an external Link which always sets the noopener and noreferrer rel attribute and the target to _blank.
+ * It also always adds the external link icon as end adornment.
+ */
+const ExternalLink = ({
+  suppressIcon = false,
+  children,
+  ...props
+}: Omit<LinkProps, 'target' | 'rel'> & { suppressIcon?: boolean }) => {
+  return (
+    <Link rel="noreferrer noopener" target="_blank" {...props}>
+      <Box display="inline-flex" alignItems="center" gap={0.2}>
+        {children}
+        {!suppressIcon && <OpenInNewRounded fontSize="small" />}
+      </Box>
+    </Link>
+  )
+}
+
+export default ExternalLink

--- a/src/components/common/Footer/index.tsx
+++ b/src/components/common/Footer/index.tsx
@@ -7,6 +7,7 @@ import { openCookieBanner } from '@/store/popupSlice'
 import { AppRoutes } from '@/config/routes'
 import packageJson from '../../../../package.json'
 import AppstoreButton from '../AppStoreButton'
+import ExternalLink from '../ExternalLink'
 
 const footerPages = [AppRoutes.welcome, AppRoutes.settings.index]
 
@@ -30,42 +31,38 @@ const Footer = (): ReactElement | null => {
           <Typography variant="caption">&copy;2022 Safe Ecosystem Foundation</Typography>
         </li>
         <li>
-          <Link rel="noopener noreferrer" target="_blank" href="https://gnosis-safe.io/terms">
+          <ExternalLink suppressIcon href="https://safe.global/terms">
             Terms
-          </Link>
+          </ExternalLink>
         </li>
         <li>
-          <Link rel="noopener noreferrer" target="_blank" href="https://gnosis-safe.io/privacy">
+          <ExternalLink suppressIcon href="https://safe.global/privacy">
             Privacy
-          </Link>
+          </ExternalLink>
         </li>
         <li>
-          <Link rel="noopener noreferrer" target="_blank" href="https://gnosis-safe.io/licenses">
+          <ExternalLink suppressIcon href="https://safe.global/licenses">
             Licenses
-          </Link>
+          </ExternalLink>
         </li>
         <li>
-          <Link rel="noopener noreferrer" target="_blank" href="https://gnosis-safe.io/imprint">
+          <ExternalLink suppressIcon href="https://safe.global/imprint">
             Imprint
-          </Link>
+          </ExternalLink>
         </li>
         <li>
-          <Link rel="noopener noreferrer" target="_blank" href="https://gnosis-safe.io/cookie">
+          <ExternalLink suppressIcon href="https://safe.global/cookie">
             Cookie Policy
-          </Link>
+          </ExternalLink>
           &nbsp;&mdash;&nbsp;
           <Link href="#" onClick={onCookieClick}>
             Preferences
           </Link>
         </li>
         <li>
-          <Link
-            rel="noopener noreferrer"
-            target="_blank"
-            href={`${packageJson.homepage}/releases/tag/v${packageJson.version}`}
-          >
+          <ExternalLink suppressIcon href={`${packageJson.homepage}/releases/tag/v${packageJson.version}`}>
             v{packageJson.version}
-          </Link>
+          </ExternalLink>
         </li>
         <li>
           <AppstoreButton placement="footer" />

--- a/src/components/common/PairingDetails/PairingDescription.tsx
+++ b/src/components/common/PairingDetails/PairingDescription.tsx
@@ -1,9 +1,10 @@
-import { Typography, Link } from '@mui/material'
+import { Typography } from '@mui/material'
 import type { ReactElement } from 'react'
 
 import AppStoreButton from '@/components/common/AppStoreButton'
+import ExternalLink from '../ExternalLink'
 
-const HELP_ARTICLE = 'https://help.gnosis-safe.io/en/articles/5584901-desktop-pairing'
+const HELP_ARTICLE = 'https://help.safe.global/en/articles/5584901-desktop-pairing'
 
 const PairingDescription = (): ReactElement => {
   return (
@@ -11,9 +12,9 @@ const PairingDescription = (): ReactElement => {
       <Typography variant="caption" align="center">
         Scan this code in the Safe mobile app to sign transactions with your mobile device.
         <br />
-        <Link href={HELP_ARTICLE} target="_blank" rel="noreferrer" title="Learn more about mobile pairing.">
+        <ExternalLink href={HELP_ARTICLE} title="Learn more about mobile pairing.">
           Learn more about this feature.
-        </Link>
+        </ExternalLink>
       </Typography>
 
       <AppStoreButton placement="pairing" />

--- a/src/components/load-safe/steps/SetAddressStep.tsx
+++ b/src/components/load-safe/steps/SetAddressStep.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Button, CircularProgress, Divider, Grid, InputAdornment, Link, Paper, Typography } from '@mui/material'
+import { Box, Button, CircularProgress, Divider, Grid, InputAdornment, Paper, Typography } from '@mui/material'
 import { useForm, FormProvider } from 'react-hook-form'
 import type { StepRenderProps } from '@/components/tx/TxStepper/useTxStepper'
 import ChainIndicator from '@/components/common/ChainIndicator'
@@ -13,6 +13,7 @@ import { useAddressResolver } from '@/hooks/useAddressResolver'
 import { useMnemonicSafeName } from '@/hooks/useMnemonicName'
 import type { SafeFormData } from '@/components/create-safe/types'
 import { trackEvent, LOAD_SAFE_EVENTS } from '@/services/analytics'
+import ExternalLink from '@/components/common/ExternalLink'
 
 type Props = {
   params: SafeFormData
@@ -90,13 +91,9 @@ const SetAddressStep = ({ params, onSubmit, onBack }: Props) => {
 
             <Typography mb={3}>
               Don&apos;t have the address of the Safe you created?{' '}
-              <Link
-                href="https://help.gnosis-safe.io/en/articles/4971293-i-don-t-remember-my-safe-address-where-can-i-find-it"
-                target="_blank"
-                rel="noreferrer"
-              >
+              <ExternalLink href="https://help.safe.globaL/en/articles/4971293-i-don-t-remember-my-safe-address-where-can-i-find-it">
                 This article explains how to find it.
-              </Link>
+              </ExternalLink>
             </Typography>
 
             <Box marginBottom={2} paddingRight={6} width={{ lg: '70%' }}>
@@ -121,14 +118,8 @@ const SetAddressStep = ({ params, onSubmit, onBack }: Props) => {
 
             <Typography mt={2}>
               By continuing you consent to the{' '}
-              <Link href="https://gnosis-safe.io/terms" target="_blank" rel="noreferrer">
-                terms of use
-              </Link>{' '}
-              and{' '}
-              <Link href="https://gnosis-safe.io/privacy" target="_blank" rel="noreferrer">
-                privacy policy
-              </Link>
-              .
+              <ExternalLink href="https://safe.global/terms">terms of use</ExternalLink> and{' '}
+              <ExternalLink href="https://safe.global/privacy">privacy policy</ExternalLink>.
             </Typography>
           </Box>
 

--- a/src/components/safe-apps/AddCustomAppModal/index.tsx
+++ b/src/components/safe-apps/AddCustomAppModal/index.tsx
@@ -9,7 +9,6 @@ import {
   TextField,
   FormControlLabel,
   Checkbox,
-  Link,
   Box,
   FormHelperText,
 } from '@mui/material'
@@ -29,6 +28,7 @@ import CustomAppPlaceholder from './CustomAppPlaceholder'
 import CustomApp from './CustomApp'
 
 import css from './styles.module.css'
+import ExternalLink from '@/components/common/ExternalLink'
 
 type Props = {
   open: boolean
@@ -44,7 +44,7 @@ type CustomAppFormData = {
   safeApp: SafeAppData
 }
 
-const HELP_LINK = 'https://docs.gnosis-safe.io/build/sdks/safe-apps'
+const HELP_LINK = 'https://docs.safe.global/build/sdks/safe-apps'
 const APP_ALREADY_IN_THE_LIST_ERROR = 'This app is already in the list'
 const MANIFEST_ERROR = "The app doesn't support Safe App functionality"
 const INVALID_URL_ERROR = 'The url is invalid'
@@ -152,15 +152,10 @@ export const AddCustomAppModal = ({ open, onClose, onSave, safeAppsList }: Props
           <div className={css.addCustomAppHelp}>
             <InfoOutlinedIcon className={css.addCustomAppHelpIcon} />
             <Typography ml={0.5}>Learn more about building</Typography>
-            <Link
-              className={css.addCustomAppHelpLink}
-              href={HELP_LINK}
-              target="_blank"
-              rel="noreferrer"
-              fontWeight={700}
-            >
-              Safe Apps.
-            </Link>
+            <ExternalLink className={css.addCustomAppHelpLink} href={HELP_LINK} fontWeight={700}>
+              Safe Apps
+            </ExternalLink>
+            .
           </div>
         </DialogContent>
 

--- a/src/components/safe-apps/AppFrame/ThirdPartyCookiesWarning.tsx
+++ b/src/components/safe-apps/AppFrame/ThirdPartyCookiesWarning.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
-import { Alert, Link, AlertTitle } from '@mui/material'
+import { Alert, AlertTitle } from '@mui/material'
+import ExternalLink from '@/components/common/ExternalLink'
 
 type ThirdPartyCookiesWarningProps = {
   onClose: () => void
 }
 
 const HELP_LINK =
-  'https://help.gnosis-safe.io/en/articles/5955031-why-do-i-need-to-enable-third-party-cookies-for-safe-apps'
+  'https://help.safe.global/en/articles/5955031-why-do-i-need-to-enable-third-party-cookies-for-safe-apps'
 
 export const ThirdPartyCookiesWarning = ({ onClose }: ThirdPartyCookiesWarningProps): React.ReactElement => {
   return (
@@ -23,9 +24,9 @@ export const ThirdPartyCookiesWarning = ({ onClose }: ThirdPartyCookiesWarningPr
       <AlertTitle>
         Third party cookies are disabled. Safe Apps may therefore not work properly. You can find out more information
         about this{' '}
-        <Link href={HELP_LINK} target="_blank" fontSize="inherit">
+        <ExternalLink href={HELP_LINK} fontSize="inherit">
           here
-        </Link>
+        </ExternalLink>
       </AlertTitle>
     </Alert>
   )

--- a/src/components/safe-apps/SafeAppsErrorBoundary/SafeAppsLoadError.tsx
+++ b/src/components/safe-apps/SafeAppsErrorBoundary/SafeAppsLoadError.tsx
@@ -1,12 +1,11 @@
 import Typography from '@mui/material/Typography'
-import Link from '@mui/material/Link'
 import Button from '@mui/material/Button'
 import SvgIcon from '@mui/material/SvgIcon'
-import OpenInNew from '@mui/icons-material/OpenInNew'
 import { SAFE_APPS_SUPPORT_CHAT_URL } from '@/config/constants'
 import NetworkError from '@/public/images/apps/network-error.svg'
 
 import css from './styles.module.css'
+import ExternalLink from '@/components/common/ExternalLink'
 
 type SafeAppsLoadErrorProps = {
   onBackToApps: () => void
@@ -22,10 +21,9 @@ const SafeAppsLoadError = ({ onBackToApps }: SafeAppsLoadErrorProps): React.Reac
 
         <div>
           <Typography component="span">In case the problem persists, please reach out to us via </Typography>
-          <Link target="_blank" href={SAFE_APPS_SUPPORT_CHAT_URL} fontSize="medium">
+          <ExternalLink href={SAFE_APPS_SUPPORT_CHAT_URL} fontSize="medium">
             Discord
-            <OpenInNew fontSize="small" color="primary" className={css.icon} />
-          </Link>
+          </ExternalLink>
         </div>
 
         <Button href="#back" color="primary" onClick={onBackToApps}>

--- a/src/components/safe-apps/SafeAppsInfoModal/LegalDisclaimer.tsx
+++ b/src/components/safe-apps/SafeAppsInfoModal/LegalDisclaimer.tsx
@@ -1,4 +1,5 @@
-import { Link, Typography } from '@mui/material'
+import ExternalLink from '@/components/common/ExternalLink'
+import { Typography } from '@mui/material'
 
 import css from './styles.module.css'
 
@@ -22,14 +23,9 @@ const LegalDisclaimer = (): JSX.Element => (
 
       <Typography>
         I have read and understood the{' '}
-        <Link
-          href="https://gnosis-safe.io/terms"
-          rel="noopener noreferrer"
-          target="_blank"
-          sx={{ textDecoration: 'none' }}
-        >
+        <ExternalLink href="https://safe.global/terms" sx={{ textDecoration: 'none' }}>
           Terms
-        </Link>{' '}
+        </ExternalLink>{' '}
         and this Disclaimer, and agree to be bound by them.
       </Typography>
     </div>

--- a/src/components/settings/ContractVersion/UpdateSafeDialog.tsx
+++ b/src/components/settings/ContractVersion/UpdateSafeDialog.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Link, Typography } from '@mui/material'
+import { Box, Button, Typography } from '@mui/material'
 import { useState } from 'react'
 
 import { LATEST_SAFE_VERSION } from '@/config/constants'
@@ -15,6 +15,7 @@ import { createUpdateSafeTxs } from '@/services/tx/safeUpdateParams'
 
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useCurrentChain } from '@/hooks/useChains'
+import ExternalLink from '@/components/common/ExternalLink'
 
 const UpdateSafeSteps: TxStepperProps['steps'] = [
   {
@@ -59,13 +60,9 @@ const ReviewUpdateSafeStep = ({ onSubmit }: { onSubmit: (txId: string) => void }
 
       <Typography mb={2}>
         To check details about updates added by this smart contract version please visit{' '}
-        <Link
-          rel="noreferrer noopener"
-          href={`https://github.com/gnosis/safe-contracts/releases/tag/v${LATEST_SAFE_VERSION}`}
-          target="_blank"
-        >
+        <ExternalLink href={`https://github.com/safe-global/safe-contracts/releases/tag/v${LATEST_SAFE_VERSION}`}>
           latest Safe contracts changelog
-        </Link>
+        </ExternalLink>
       </Typography>
 
       <Typography mb={2}>

--- a/src/components/settings/ContractVersion/index.tsx
+++ b/src/components/settings/ContractVersion/index.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react'
-import { Box, Link, Typography } from '@mui/material'
-import OpenInNewRounded from '@mui/icons-material/OpenInNewRounded'
+import { Typography } from '@mui/material'
 import { ImplementationVersionState } from '@gnosis.pm/safe-react-gateway-sdk'
 import { LATEST_SAFE_VERSION } from '@/config/constants'
 import { sameAddress } from '@/utils/addresses'
@@ -9,6 +8,7 @@ import { MasterCopyDeployer, useMasterCopies } from '@/hooks/useMasterCopies'
 import useSafeInfo from '@/hooks/useSafeInfo'
 
 import UpdateSafeDialog from './UpdateSafeDialog'
+import ExternalLink from '@/components/common/ExternalLink'
 
 export const ContractVersion = ({ isGranted }: { isGranted: boolean }) => {
   const [masterCopies] = useMasterCopies()
@@ -32,14 +32,10 @@ export const ContractVersion = ({ isGranted }: { isGranted: boolean }) => {
       <Typography variant="h4" fontWeight={700} marginBottom={1}>
         Contract version
       </Typography>
-
-      <Link rel="noreferrer noopener" href={safeMasterCopy?.deployerRepoUrl} target="_blank">
-        <Box display="flex" alignItems="center" gap={0.2}>
-          {safe.version}
-          {getSafeVersionUpdate()}
-          <OpenInNewRounded fontSize="small" />
-        </Box>
-      </Link>
+      <ExternalLink href={safeMasterCopy?.deployerRepoUrl}>
+        {safe.version}
+        {getSafeVersionUpdate()}
+      </ExternalLink>
 
       {showUpdateDialog && isGranted && <UpdateSafeDialog />}
     </div>

--- a/src/components/settings/SafeModules/index.tsx
+++ b/src/components/settings/SafeModules/index.tsx
@@ -1,10 +1,11 @@
 import EthHashInfo from '@/components/common/EthHashInfo'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { Paper, Grid, Typography, Box, Link } from '@mui/material'
+import { Paper, Grid, Typography, Box } from '@mui/material'
 
 import css from './styles.module.css'
 import { RemoveModule } from '@/components/settings/SafeModules/RemoveModule'
 import useIsGranted from '@/hooks/useIsGranted'
+import ExternalLink from '@/components/common/ExternalLink'
 
 const NoModules = () => {
   return (
@@ -50,9 +51,7 @@ const SafeModules = () => {
             <Typography>
               Modules allow you to customize the access-control logic of your Safe. Modules are potentially risky, so
               make sure to only use modules from trusted sources. Learn more about modules{' '}
-              <Link href="https://docs.gnosis-safe.io/contracts/modules-1" rel="noreferrer noopener" target="_blank">
-                here
-              </Link>
+              <ExternalLink href="https://docs.safe.global/contracts/modules-1">here</ExternalLink>
             </Typography>
             {safeModules.length === 0 ? (
               <NoModules />

--- a/src/components/settings/TransactionGuards/index.tsx
+++ b/src/components/settings/TransactionGuards/index.tsx
@@ -1,11 +1,12 @@
 import EthHashInfo from '@/components/common/EthHashInfo'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { Paper, Grid, Link, Typography, Box } from '@mui/material'
+import { Paper, Grid, Typography, Box } from '@mui/material'
 import { gte } from 'semver'
 import { RemoveGuard } from './RemoveGuard'
 import useIsGranted from '@/hooks/useIsGranted'
 
 import css from './styles.module.css'
+import ExternalLink from '@/components/common/ExternalLink'
 
 const NoTransactionGuard = () => {
   return (
@@ -52,13 +53,9 @@ const TransactionGuards = () => {
               Transaction guards impose additional constraints that are checked prior to executing a Safe transaction.
               Transaction guards are potentially risky, so make sure to only use transaction guards from trusted
               sources. Learn more about transaction guards{' '}
-              <Link
-                href="https://help.gnosis-safe.io/en/articles/5324092-what-is-a-transaction-guard"
-                rel="noreferrer noopener"
-                target="_blank"
-              >
+              <ExternalLink href="https://help.safe.global/en/articles/5324092-what-is-a-transaction-guard">
                 here
-              </Link>
+              </ExternalLink>
               .
             </Typography>
             {safe.guard ? (

--- a/src/components/sidebar/SidebarFooter/index.tsx
+++ b/src/components/sidebar/SidebarFooter/index.tsx
@@ -20,7 +20,7 @@ import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
 import { useCurrentChain } from '@/hooks/useChains'
 
-const WHATS_NEW_PATH = 'https://help.gnosis-safe.io/en/'
+const WHATS_NEW_PATH = 'https://help.safe.global/en/'
 
 const SidebarFooter = (): ReactElement => {
   const dispatch = useAppDispatch()

--- a/src/components/transactions/GroupedTxListItems/index.tsx
+++ b/src/components/transactions/GroupedTxListItems/index.tsx
@@ -1,12 +1,12 @@
 import type { ReactElement } from 'react'
 import { useContext } from 'react'
-import { Box, Link, Paper, Typography } from '@mui/material'
-import OpenInNewRoundedIcon from '@mui/icons-material/OpenInNewRounded'
+import { Box, Paper, Typography } from '@mui/material'
 import type { Transaction } from '@gnosis.pm/safe-react-gateway-sdk'
 import { isMultisigExecutionInfo } from '@/utils/transaction-guards'
 import ExpandableTransactionItem from '@/components/transactions/TxListItem/ExpandableTransactionItem'
 import css from './styles.module.css'
 import { ReplaceTxHoverContext, ReplaceTxHoverProvider } from './ReplaceTxHoverProvider'
+import ExternalLink from '@/components/common/ExternalLink'
 
 const Disclaimer = ({ nonce }: { nonce?: number }) => (
   <Box className={css.disclaimerContainer}>
@@ -15,16 +15,13 @@ const Disclaimer = ({ nonce }: { nonce?: number }) => (
       These transactions conflict as they use the same nonce. Executing one will automatically replace the other(s).
     </Typography>
 
-    <Link
-      href="https://help.gnosis-safe.io/en/articles/4730252-why-are-transactions-with-the-same-nonce-conflicting-with-each-other"
-      target="_blank"
-      rel="noreferrer"
+    <ExternalLink
+      href="https://help.safe.global/en/articles/4730252-why-are-transactions-with-the-same-nonce-conflicting-with-each-other"
       title="Why are transactions with the same nonce conflicting with each other?"
       className={css.link}
     >
       Learn more
-      <OpenInNewRoundedIcon fontSize="small" />
-    </Link>
+    </ExternalLink>
   </Box>
 )
 

--- a/src/components/transactions/TxDetails/TxData/Rejection/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/Rejection/index.tsx
@@ -1,6 +1,7 @@
+import ExternalLink from '@/components/common/ExternalLink'
 import { NOT_AVAILABLE } from '@/components/transactions/TxDetails'
 import type { MultisigExecutionDetails } from '@gnosis.pm/safe-react-gateway-sdk'
-import { Box, Link, Typography } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import React from 'react'
 
 interface Props {
@@ -21,10 +22,8 @@ const RejectionTxInfo = ({ nonce, isTxExecuted }: Props) => {
       <Typography mr={2}>{message}</Typography>
       {!isTxExecuted && (
         <Box mt={2} sx={{ width: 'fit-content' }}>
-          <Link
-            href="https://help.gnosis-safe.io/en/articles/4738501-why-do-i-need-to-pay-for-cancelling-a-transaction"
-            target="_blank"
-            rel="noreferrer"
+          <ExternalLink
+            href="https://help.safe.global/en/articles/4738501-why-do-i-need-to-pay-for-cancelling-a-transaction"
             title="Why do I need to pay for rejecting a transaction?"
           >
             <Box sx={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
@@ -32,7 +31,7 @@ const RejectionTxInfo = ({ nonce, isTxExecuted }: Props) => {
                 Why do I need to pay for rejecting a transaction?
               </Typography>
             </Box>
-          </Link>
+          </ExternalLink>
         </Box>
       )}
     </>

--- a/src/components/transactions/Warning/index.tsx
+++ b/src/components/transactions/Warning/index.tsx
@@ -1,9 +1,10 @@
 import type { ReactElement } from 'react'
-import { Alert, Link, SvgIcon, Tooltip } from '@mui/material'
+import { Alert, SvgIcon, Tooltip } from '@mui/material'
 import type { AlertColor } from '@mui/material'
 
 import InfoOutlinedIcon from '@/public/images/notifications/info.svg'
 import css from './styles.module.css'
+import ExternalLink from '@/components/common/ExternalLink'
 
 const Warning = ({
   title,
@@ -29,7 +30,7 @@ const Warning = ({
 }
 
 const UNEXPECTED_DELEGATE_ARTICLE =
-  'https://help.gnosis-safe.io/en/articles/6302452-why-do-i-see-an-unexpected-delegate-call-warning-in-my-transaction'
+  'https://help.safe.global/en/articles/6302452-why-do-i-see-an-unexpected-delegate-call-warning-in-my-transaction'
 
 export const DelegateCallWarning = ({ showWarning }: { showWarning: boolean }): ReactElement => {
   const severity = showWarning ? 'warning' : 'success'
@@ -41,9 +42,7 @@ export const DelegateCallWarning = ({ showWarning }: { showWarning: boolean }): 
           {showWarning && (
             <>
               <br />
-              <Link href={UNEXPECTED_DELEGATE_ARTICLE} rel="noopener noreferrer" target="_blank">
-                Learn more
-              </Link>
+              <ExternalLink href={UNEXPECTED_DELEGATE_ARTICLE}>Learn more</ExternalLink>
             </>
           )}
         </>

--- a/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
+++ b/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
@@ -1,6 +1,5 @@
 import { type SyntheticEvent } from 'react'
-import { Button, DialogActions, FormControl, Grid, TextField, Link, Typography, DialogContent } from '@mui/material'
-import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import { Button, DialogActions, FormControl, Grid, TextField, Typography, DialogContent } from '@mui/material'
 import { BigNumber } from 'ethers'
 import { FormProvider, useForm } from 'react-hook-form'
 import { safeFormatUnits, safeParseUnits } from '@/utils/formatters'
@@ -9,8 +8,9 @@ import NonceForm from '../NonceForm'
 import ModalDialog from '@/components/common/ModalDialog'
 import { AdvancedField, type AdvancedParameters } from './types.d'
 import GasLimitInput from './GasLimitInput'
+import ExternalLink from '@/components/common/ExternalLink'
 
-const HELP_LINK = 'https://help.gnosis-safe.io/en/articles/4738445-advanced-transaction-parameters'
+const HELP_LINK = 'https://help.safe.global/en/articles/4738445-advanced-transaction-parameters'
 
 type AdvancedParamsFormProps = {
   params: AdvancedParameters
@@ -182,10 +182,7 @@ const AdvancedParamsForm = ({ params, ...props }: AdvancedParamsFormProps) => {
 
             {/* Help link */}
             <Typography mt={2}>
-              <Link href={HELP_LINK} target="_blank" rel="noreferrer">
-                How can I configure these parameters manually?
-                <OpenInNewIcon fontSize="small" sx={{ verticalAlign: 'middle', marginLeft: 0.5 }} />
-              </Link>
+              <ExternalLink href={HELP_LINK}>How can I configure these parameters manually?</ExternalLink>
             </Typography>
           </DialogContent>
 

--- a/src/components/tx/TxSimulation/SimulationResult.tsx
+++ b/src/components/tx/TxSimulation/SimulationResult.tsx
@@ -1,10 +1,11 @@
-import { Alert, AlertTitle, Typography, Link } from '@mui/material'
+import { Alert, AlertTitle, Typography } from '@mui/material'
 import type { ReactElement } from 'react'
 
 import type { TenderlySimulation } from '@/components/tx/TxSimulation/types'
 import { FETCH_STATUS } from '@/components/tx/TxSimulation/types'
 
 import css from './styles.module.css'
+import ExternalLink from '@/components/common/ExternalLink'
 
 type SimulationResultProps = {
   simulationRequestStatus: string
@@ -45,10 +46,7 @@ export const SimulationResult = ({
           <Typography>
             The transaction failed during the simulation throwing error <b>{simulation?.transaction.error_message}</b>{' '}
             in the contract at <b>{simulation?.transaction.error_info?.address}</b>. Full simulation report is available{' '}
-            <Link href={simulationLink} target="_blank" rel="noreferrer">
-              <b>on Tenderly</b>
-            </Link>
-            .
+            <ExternalLink href={simulationLink}>on Tenderly</ExternalLink>.
           </Typography>
         )}
       </Alert>
@@ -64,10 +62,7 @@ export const SimulationResult = ({
 
       <Typography>
         The transaction was successfully simulated. Full simulation report is available{' '}
-        <Link href={simulationLink} target="_blank" rel="noreferrer">
-          <b>on Tenderly</b>
-        </Link>
-        .
+        <ExternalLink href={simulationLink}>on Tenderly</ExternalLink>.
       </Typography>
     </Alert>
   )

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -36,7 +36,7 @@ export const SAFE_TOKEN_ADDRESSES: { [chainId: string]: string } = {
 // Safe Apps
 export const SAFE_APPS_INFURA_TOKEN = process.env.NEXT_PUBLIC_SAFE_APPS_INFURA_TOKEN || INFURA_TOKEN
 export const SAFE_APPS_THIRD_PARTY_COOKIES_CHECK_URL = 'https://third-party-cookies-check.gnosis-safe.com'
-export const SAFE_APPS_SUPPORT_CHAT_URL = 'https://chat.gnosis-safe.io'
+export const SAFE_APPS_SUPPORT_CHAT_URL = 'https://chat.safe.global'
 export const SAFE_APPS_DEMO_SAFE_MAINNET = 'eth:0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7'
 
 // Google Tag Manager

--- a/src/pages/settings/appearance.tsx
+++ b/src/pages/settings/appearance.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, FormControlLabel, FormGroup, Grid, Link, Paper, Typography, Switch } from '@mui/material'
+import { Checkbox, FormControlLabel, FormGroup, Grid, Paper, Typography, Switch } from '@mui/material'
 import type { ChangeEvent } from 'react'
 import type { NextPage } from 'next'
 import Head from 'next/head'
@@ -8,6 +8,7 @@ import { selectSettings, setCopyShortName, setDarkMode, setShowShortName } from 
 import SettingsHeader from '@/components/settings/SettingsHeader'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import { useDarkMode } from '@/hooks/useDarkMode'
+import ExternalLink from '@/components/common/ExternalLink'
 
 const Appearance: NextPage = () => {
   const dispatch = useAppDispatch()
@@ -51,10 +52,8 @@ const Appearance: NextPage = () => {
             <Grid item xs>
               <Typography mb={2}>
                 Choose whether to prepend{' '}
-                <Link href="https://eips.ethereum.org/EIPS/eip-3770" target="_blank" rel="noopener noreferrer">
-                  EIP-3770
-                </Link>{' '}
-                address prefixes across all Safes.
+                <ExternalLink href="https://eips.ethereum.org/EIPS/eip-3770">EIP-3770</ExternalLink> address prefixes
+                across all Safes.
               </Typography>
               <FormGroup>
                 <FormControlLabel

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -488,7 +488,7 @@ const initTheme = (darkMode: boolean) => {
       MuiLink: {
         styleOverrides: {
           root: ({ theme }) => ({
-            textDecoration: 'none',
+            fontWeight: 700,
             '&:hover': {
               color: theme.palette.primary.light,
             },


### PR DESCRIPTION
## What it solves
Links look the same as normal text making it hard to see what is a clickable link and what is just text.

Resolves #1174 

## How this PR fixes it
- Redesigns all links to be bold and underlined
- New `ExternalLink` component which is similar to Link but always sets a secure `rel` attribute, the target to`_blank` and by default appends an external-link icon. 
- Replaces most `gnosis-safe.io` links by `safe.global`. For instance links to help articles, policies, etc.

## How to test it
Check the various external links in our interface:
- Settings -> Appearance
- Settings -> Modules
- Settings -> TransactionGuard
- SafeApps -> Add Custom App
- ....

## Analytics changes
None

## Screenshots
![Screenshot 2022-11-24 at 16 12 21](https://user-images.githubusercontent.com/2670790/203817021-311ccc43-f71d-4b4d-a9aa-abfcd212c81c.png)

