### PR TITLE
Chore: branch name instead of pr number

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,15 +66,18 @@ jobs:
       - name: Deploy PR branch
         if: github.ref != 'refs/heads/dev' && github.ref != 'refs/heads/main'
         env:
-          BUCKET: s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/webcore/pr${{ github.event.number }}
+          BRANCH: ${{ github.head_ref }}
+          BUCKET: s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/webcore/pr${BRANCH//\//-}
         run: bash ./scripts/github/s3_upload.sh
 
       - name: 'Post the deployment links in the PR'
         if: success() && github.ref != 'refs/heads/dev' && github.ref != 'refs/heads/main'
         uses: mshick/add-pr-comment@v1
+        env:
+          BRANCH: ${{ github.head_ref }}
         with:
           message: |
             ## Branch preview
-            https://pr${{ github.event.number }}--webcore.review-react-br.5afe.dev
+            https://pr${{ github.head_ref }}--webcore.review-react-br.5afe.dev
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'


### PR DESCRIPTION
Testing if we can use branch names instead of PR numbers.