### PR TITLE
fix: Send current step with tracking event

### DIFF
--- a/src/components/new-safe/CardStepper/useCardStepper.ts
+++ b/src/components/new-safe/CardStepper/useCardStepper.ts
@@ -45,13 +45,13 @@ export const useCardStepper = <TData>({
   const handleNext = () => {
     setActiveStep((prevActiveStep) => prevActiveStep + 1)
     setWidgetStep && setWidgetStep((prevActiveStep) => prevActiveStep + 1)
-    trackEvent({ category: eventCategory, action: lastStep ? 'Submit' : 'Next' })
+    trackEvent({ category: eventCategory, action: lastStep ? 'Submit' : 'Next', label: activeStep })
   }
 
   const handleBack = (data?: Partial<TData>) => {
     setActiveStep((prevActiveStep) => prevActiveStep - 1)
     setWidgetStep && setWidgetStep((prevActiveStep) => prevActiveStep - 1)
-    trackEvent({ category: eventCategory, action: firstStep ? 'Cancel' : 'Back' })
+    trackEvent({ category: eventCategory, action: firstStep ? 'Cancel' : 'Back', label: activeStep })
 
     if (data) {
       setStepData((previous) => ({ ...previous, ...data }))

--- a/src/components/tx/TxStepper/useTxStepper.ts
+++ b/src/components/tx/TxStepper/useTxStepper.ts
@@ -42,12 +42,12 @@ export const useTxStepper = ({
 
   const handleNext = () => {
     setActiveStep((prevActiveStep) => prevActiveStep + 1)
-    trackEvent({ category: eventCategory, action: lastStep ? 'Submit' : 'Next' })
+    trackEvent({ category: eventCategory, action: lastStep ? 'Submit' : 'Next', label: activeStep })
   }
 
   const handleBack = (data?: unknown) => {
     setActiveStep((prevActiveStep) => prevActiveStep - 1)
-    trackEvent({ category: eventCategory, action: firstStep ? 'Cancel' : 'Back' })
+    trackEvent({ category: eventCategory, action: firstStep ? 'Cancel' : 'Back', label: activeStep })
 
     if (data) {
       updateStepData(data)


### PR DESCRIPTION
## What it solves

Resolves #1248 

## How this PR fixes it

- Adds the current step as label to the tracked event

## How to test it

1. Open the safe creation
2. Click Next
3. Observe that the GTM event in the console contains the current step as label
