### PR TITLE
fix: Dislay an error when trying to transfer safe token

### DIFF
--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -30,7 +30,7 @@ import { getSafeTokenAddress } from '@/components/common/SafeTokenWidget'
 import useChainId from '@/hooks/useChainId'
 import { sameAddress } from '@/utils/addresses'
 import InfoIcon from '@/public/images/notifications/info.svg'
-import useSafeTokenWarning from '@/components/tx/modals/TokenTransferModal/useSafeTokenWarning'
+import useIsSafeTokenPaused from '@/components/tx/modals/TokenTransferModal/useIsSafeTokenPaused'
 
 export const AutocompleteItem = (item: { tokenInfo: TokenInfo; balance: string }): ReactElement => (
   <Grid container alignItems="center" gap={1}>
@@ -75,7 +75,7 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
   const addressBook = useAddressBook()
   const chainId = useChainId()
   const safeTokenAddress = getSafeTokenAddress(chainId)
-  const { isSafeTokenPaused } = useSafeTokenWarning()
+  const isSafeTokenPaused = useIsSafeTokenPaused()
 
   const formMethods = useForm<SendAssetsFormData>({
     defaultValues: {
@@ -166,7 +166,7 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
             <Box mt={1} display="flex" alignItems="center">
               <SvgIcon component={InfoIcon} color="error" fontSize="small" />
               <Typography variant="body2" color="error" ml={0.5}>
-                SAFE is currently non-transferable.
+                $SAFE is currently non-transferable.
               </Typography>
             </Box>
           )}

--- a/src/components/tx/modals/TokenTransferModal/useSafeTokenWarning.ts
+++ b/src/components/tx/modals/TokenTransferModal/useSafeTokenWarning.ts
@@ -1,0 +1,30 @@
+import useChainId from '@/hooks/useChainId'
+import { getSafeTokenAddress } from '@/components/common/SafeTokenWidget'
+import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
+import useAsync from '@/hooks/useAsync'
+import { Contract } from 'ethers'
+import { Interface } from '@ethersproject/abi'
+
+// TODO: Remove this hook after the safe token has been unpaused
+const useSafeTokenWarning = () => {
+  const chainId = useChainId()
+  const provider = useWeb3ReadOnly()
+
+  const [isSafeTokenPaused] = useAsync<boolean>(async () => {
+    const safeTokenAddress = getSafeTokenAddress(chainId)
+
+    const safeTokenContract = new Contract(
+      safeTokenAddress,
+      new Interface(['function paused() public view virtual returns (bool)']),
+      provider,
+    )
+
+    return safeTokenContract.paused()
+  }, [chainId, provider])
+
+  return {
+    isSafeTokenPaused,
+  }
+}
+
+export default useSafeTokenWarning

--- a/src/services/tx/safeUpdateParams.ts
+++ b/src/services/tx/safeUpdateParams.ts
@@ -4,6 +4,7 @@ import type { ChainInfo, SafeInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { getFallbackHandlerContractInstance, getGnosisSafeContractInstance } from '@/services/contracts/safeContracts'
 import { LATEST_SAFE_VERSION } from '@/config/constants'
 
+// TODO: Check if these are still needed
 export const CHANGE_MASTER_COPY_ABI = 'function changeMasterCopy(address _masterCopy)'
 export const CHANGE_FALLBACK_HANDLER_ABI = 'function setFallbackHandler(address handler)'
 


### PR DESCRIPTION
## What it solves

Resolves #1244 

## How this PR fixes it

- Checks the `unpaused` property of the safe token contract
- Displays an error message and disables the next button if the safe token is selected in the transfer modal

## How to test it

1. Open a Safe on Mainnet that has Safe Tokens
2. Try to transfer them
3. Observe an error message and the next button being disabled
4. Select a different token
5. Observe the Next button becoming enabled again

## Screenshots
<img width="638" alt="Screenshot 2022-11-25 at 12 19 59" src="https://user-images.githubusercontent.com/5880855/203975853-4a496f3c-826d-4baa-a2dc-bf47c86654b1.png">
