### PR TITLE
feat: pass dark theme flag in url hash

### DIFF
--- a/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
+++ b/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
@@ -60,7 +60,8 @@ const GovernanceSection = () => {
               {claimingApp ? (
                 <SafeAppsErrorBoundary render={() => <WidgetLoadErrorFallback />}>
                   <AppFrame
-                    appUrl={`${claimingApp.url}?theme=${theme}#widget`}
+                    key={theme}
+                    appUrl={`${claimingApp.url}#widget+${theme}`}
                     allowedFeaturesList={getAllowedFeaturesList(claimingApp.url)}
                     isQueueBarDisabled
                   />


### PR DESCRIPTION
_Note:_ I've branched from `one-governance-widget` but it will be merged into `epic-governance`

## What it solves
Part of https://github.com/safe-global/web-core/issues/1221

## How this PR fixes it
The theme is passed to the `<AppFrame>` together with the widget ID as `#<widget_id>+<theme>`

## How to test it
Can be tested against the https://github.com/safe-global/safe-react-apps/pull/588 PR deployment