### PR TITLE
Added sandbox attribute to Safe App iframe

### DIFF
--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -46,6 +46,10 @@ type AppFrameProps = {
   allowedFeaturesList: string
 }
 
+// see sandbox mdn docs for more details https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
+const IFRAME_SANDBOX_ALLOWED_FEATURES =
+  'allow-scripts allow-same-origin allow-popups allow-forms allow-downloads allow-orientation-lock'
+
 const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement => {
   const chainId = useChainId()
   const [txModalState, openTxModal, closeTxModal] = useTxModal()
@@ -218,6 +222,7 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
           src={appUrl}
           title={safeAppFromManifest?.name}
           onLoad={onIframeLoad}
+          sandbox={IFRAME_SANDBOX_ALLOWED_FEATURES}
           allow={allowedFeaturesList}
           style={{
             display: appIsLoading ? 'none' : 'block',

--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -48,7 +48,7 @@ type AppFrameProps = {
 
 // see sandbox mdn docs for more details https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
 const IFRAME_SANDBOX_ALLOWED_FEATURES =
-  'allow-scripts allow-same-origin allow-popups allow-forms allow-downloads allow-orientation-lock'
+  'allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-forms allow-downloads allow-orientation-lock'
 
 const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement => {
   const chainId = useChainId()


### PR DESCRIPTION
## What it solves

Resolves #1246 

## How this PR fixes it

Added a [`sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox) attribute to the Safe Apps iframe in the past

We discussed in [this Problem Statement](https://www.notion.so/gnosis-safe/Alternative-to-iframes-e6f93ee4cd834fa99f57b5f420cf7b5a) the possibility of adding the sandbox attribute in the iframe.

```
const IFRAME_SANDBOX_ALLOWED_FEATURES = 'allow-scripts allow-same-origin allow-popups allow-forms allow-downloads allow-orientation-lock'
```

### Allowed features

- `allow-scripts` : Lets the resource run scripts (needed for all the Safe Apps)
- `allow-same-origin` : Needed to the [same-origin policy](https://developer.mozilla.org/en-US/docs/Glossary/Same-origin_policy) (Most of Safe App access to [data storage/cookies](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#cross-origin_data_storage_access) and some JavaScript APIs).
- `allow-forms` : Allows Safe Apps to submit forms. Example: Transaction Builder Safe App
- `allow-orientation-lock` : Lets the resource [lock the screen orientation](https://developer.mozilla.org/en-US/docs/Web/API/Screen/lockOrientation). 
- `allow-popups` : Most of Safe Apps, to allow new tab redirections (Etherscan links, docs links...) 
- `allow-popups-to-escape-sandbox`: Allows a sandboxed document to open new windows without forcing the sandboxing flags upon them (needed for some redirections like twitter see:)

<img width="1728" alt="Captura de pantalla 2022-11-28 a las 16 49 16" src="https://user-images.githubusercontent.com/26763673/204322813-c8387c9d-a6ab-476d-9fbe-83fc9efc8a15.png">


### Restrictions

You can not access to the parent Safe localStorage directly from a Safe App:

```
  console.log('main Safe frame localstorage: ', window.parent.localStorage)
```

<img width="913" alt="Captura de pantalla 2022-11-28 a las 13 22 19" src="https://user-images.githubusercontent.com/26763673/204277114-d9a86b9a-f210-4947-8294-b23509b86f0d.png">

Preventing top-level navigation:

![Captura de pantalla 2022-11-25 a las 13 20 24](https://user-images.githubusercontent.com/26763673/203984978-20389b72-6ad2-4e15-94e2-dba45ee3ca23.png)

## How to test it

1. Go to [this preview branch](https://pr1252--webcore.review-react-br.5afe.dev/).
2. Add this URL as a Custom Safe App:
      ```
       https%3A%2F%2Ffcbii9.csb.app
      ```
3. Click on Scam link.
4. Expected Result: No top navigation is performed

## Screenshots

![Captura de pantalla 2022-11-25 a las 13 20 24](https://user-images.githubusercontent.com/26763673/203984978-20389b72-6ad2-4e15-94e2-dba45ee3ca23.png)



