### PR TITLE
Fix: comment out the untrusted badge

### DIFF
--- a/src/components/create-safe/InfoWidget/styles.module.css
+++ b/src/components/create-safe/InfoWidget/styles.module.css
@@ -3,7 +3,7 @@
 }
 
 .title {
-  width:fit-content;
+  width: fit-content;
   padding: 4px var(--space-1);
   border-radius: 6px;
   display: flex;

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -46,9 +46,12 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
   const awaitingExecution = isAwaitingExecution(txSummary.txStatus)
   const isUnsigned =
     isMultisigExecutionInfo(txSummary.executionInfo) && txSummary.executionInfo.confirmationsSubmitted === 0
+
+  // FIXME: remove "&& false" after https://github.com/safe-global/web-core/issues/1261 is fixed
   const isUntrusted =
     isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo) &&
-    txDetails.detailedExecutionInfo.trusted === false
+    txDetails.detailedExecutionInfo.trusted === false &&
+    false
 
   return (
     <>


### PR DESCRIPTION
Temporarily comment out the Untrusted tx badge from #1220.

To be restored after #1261 is closed.