### PR TITLE
Fix format amount review modal

### DIFF
--- a/src/components/tx/modals/TokenTransferModal/ReviewTokenTx.tsx
+++ b/src/components/tx/modals/TokenTransferModal/ReviewTokenTx.tsx
@@ -8,7 +8,7 @@ import { SendTxType } from '@/components/tx/modals/TokenTransferModal/SendAssets
 import TokenIcon from '@/components/common/TokenIcon'
 import ReviewSpendingLimitTx from '@/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx'
 import ReviewMultisigTx from '@/components/tx/modals/TokenTransferModal/ReviewMultisigTx'
-import { localeNumberFormatter } from '@/utils/formatNumber'
+import { formatAmount } from '@/utils/formatNumber'
 
 export const TokenTransferReview = ({
   amount,
@@ -19,8 +19,6 @@ export const TokenTransferReview = ({
   tokenInfo: TokenInfo
   children?: ReactNode
 }) => {
-  const localeAmount = localeNumberFormatter(amount)
-
   return (
     <Box className={css.tokenPreview}>
       <Box className={css.tokenIcon}>
@@ -29,7 +27,7 @@ export const TokenTransferReview = ({
 
       <Box mt={1} fontSize={20}>
         {children}
-        {localeAmount} {tokenInfo.symbol}
+        {formatAmount(amount)} {tokenInfo.symbol}
       </Box>
     </Box>
   )

--- a/src/components/tx/modals/TokenTransferModal/ReviewTokenTx.tsx
+++ b/src/components/tx/modals/TokenTransferModal/ReviewTokenTx.tsx
@@ -8,6 +8,7 @@ import { SendTxType } from '@/components/tx/modals/TokenTransferModal/SendAssets
 import TokenIcon from '@/components/common/TokenIcon'
 import ReviewSpendingLimitTx from '@/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx'
 import ReviewMultisigTx from '@/components/tx/modals/TokenTransferModal/ReviewMultisigTx'
+import { localeNumberFormatter } from '@/utils/formatNumber'
 
 export const TokenTransferReview = ({
   amount,
@@ -18,6 +19,8 @@ export const TokenTransferReview = ({
   tokenInfo: TokenInfo
   children?: ReactNode
 }) => {
+  const localeAmount = localeNumberFormatter(amount)
+
   return (
     <Box className={css.tokenPreview}>
       <Box className={css.tokenIcon}>
@@ -26,7 +29,7 @@ export const TokenTransferReview = ({
 
       <Box mt={1} fontSize={20}>
         {children}
-        {amount} {tokenInfo.symbol}
+        {localeAmount} {tokenInfo.symbol}
       </Box>
     </Box>
   )

--- a/src/components/tx/modals/TokenTransferModal/ReviewTokenTx.tsx
+++ b/src/components/tx/modals/TokenTransferModal/ReviewTokenTx.tsx
@@ -8,7 +8,7 @@ import { SendTxType } from '@/components/tx/modals/TokenTransferModal/SendAssets
 import TokenIcon from '@/components/common/TokenIcon'
 import ReviewSpendingLimitTx from '@/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx'
 import ReviewMultisigTx from '@/components/tx/modals/TokenTransferModal/ReviewMultisigTx'
-import { formatAmount } from '@/utils/formatNumber'
+import { formatAmountPrecise } from '@/utils/formatNumber'
 
 export const TokenTransferReview = ({
   amount,
@@ -27,7 +27,7 @@ export const TokenTransferReview = ({
 
       <Box mt={1} fontSize={20}>
         {children}
-        {formatAmount(amount)} {tokenInfo.symbol}
+        {formatAmountPrecise(amount, tokenInfo.decimals)} {tokenInfo.symbol}
       </Box>
     </Box>
   )

--- a/src/utils/__tests__/formatNumber.test.ts
+++ b/src/utils/__tests__/formatNumber.test.ts
@@ -1,4 +1,4 @@
-import { formatAmount, formatCurrency } from '@/utils/formatNumber'
+import { formatAmount, formatAmountPrecise, formatCurrency } from '@/utils/formatNumber'
 
 describe('formatNumber', () => {
   describe('formatAmount', () => {
@@ -266,6 +266,34 @@ describe('formatNumber', () => {
       expect(formatCurrency(amount4, 'EUR')).toBe('< -0.01 EUR')
       expect(formatCurrency(amount4, 'GBP')).toBe('< -0.01 GBP')
       expect(formatCurrency(amount4, 'BHD')).toBe('< -0.001 BHD')
+    })
+  })
+
+  describe('formatAmountPrecise', () => {
+    it('should format amounts without the compact notation', () => {
+      const tokenDecimals = 18
+
+      const amount1 = 100_000_000.00001 // 100M
+      expect(formatAmountPrecise(amount1, tokenDecimals)).toEqual('100,000,000.00001')
+
+      const amount2 = 1_000_000_000.00001 // 1B
+      expect(formatAmountPrecise(amount2, tokenDecimals)).toEqual('1,000,000,000.00001')
+
+      const amount3 = 1_234_567_898.123456789 // 1.235B
+      expect(formatAmountPrecise(amount3, tokenDecimals)).toEqual('1,234,567,898.1234567')
+    })
+
+    it('should preserve the max fraction digits', () => {
+      const tokenDecimals = 18
+
+      const amount1 = 0.000001 // < 0.00001
+      expect(formatAmountPrecise(amount1, tokenDecimals)).toEqual('0.000001')
+
+      const amount2 = 0.00000123456789 // 14 decimals
+      expect(formatAmountPrecise(amount2, tokenDecimals)).toEqual('0.00000123456789') // 14 decimals
+
+      const amount3 = 0.00000123456789012345 // 20 decimals
+      expect(formatAmountPrecise(amount3, tokenDecimals)).toEqual('0.000001234567890123') // 18 decimals
     })
   })
 })

--- a/src/utils/__tests__/formatNumber.test.ts
+++ b/src/utils/__tests__/formatNumber.test.ts
@@ -1,4 +1,4 @@
-import { formatAmount, formatCurrency } from '@/utils/formatNumber'
+import { formatAmount, formatCurrency, localeNumberFormatter } from '@/utils/formatNumber'
 
 describe('formatNumber', () => {
   describe('formatAmount', () => {
@@ -266,6 +266,26 @@ describe('formatNumber', () => {
       expect(formatCurrency(amount4, 'EUR')).toBe('< -0.01 EUR')
       expect(formatCurrency(amount4, 'GBP')).toBe('< -0.01 GBP')
       expect(formatCurrency(amount4, 'BHD')).toBe('< -0.001 BHD')
+    })
+  })
+
+  describe('localeNumberFormatter', () => {
+    it('should format numbers with commas and decimals', () => {
+      // only integer
+      const amount1 = 1_000_000
+      expect(localeNumberFormatter(amount1)).toBe('1,000,000')
+
+      // integer and decimal parts
+      const amount2 = 1_000_000.123456789
+      expect(localeNumberFormatter(amount2)).toBe('1,000,000.123456789')
+
+      // 18 decimals
+      const amount3 = 0.123456789012345678
+      expect(localeNumberFormatter(amount3)).toBe('0.12345678901234568')
+
+      // trailing zeros
+      const amount4 = '0.123456789012340000'
+      expect(localeNumberFormatter(amount4)).toBe('0.12345678901234')
     })
   })
 })

--- a/src/utils/__tests__/formatNumber.test.ts
+++ b/src/utils/__tests__/formatNumber.test.ts
@@ -1,4 +1,4 @@
-import { formatAmount, formatCurrency, localeNumberFormatter } from '@/utils/formatNumber'
+import { formatAmount, formatCurrency } from '@/utils/formatNumber'
 
 describe('formatNumber', () => {
   describe('formatAmount', () => {
@@ -266,26 +266,6 @@ describe('formatNumber', () => {
       expect(formatCurrency(amount4, 'EUR')).toBe('< -0.01 EUR')
       expect(formatCurrency(amount4, 'GBP')).toBe('< -0.01 GBP')
       expect(formatCurrency(amount4, 'BHD')).toBe('< -0.001 BHD')
-    })
-  })
-
-  describe('localeNumberFormatter', () => {
-    it('should format numbers with commas and decimals', () => {
-      // only integer
-      const amount1 = 1_000_000
-      expect(localeNumberFormatter(amount1)).toBe('1,000,000')
-
-      // integer and decimal parts
-      const amount2 = 1_000_000.123456789
-      expect(localeNumberFormatter(amount2)).toBe('1,000,000.123456789')
-
-      // 18 decimals
-      const amount3 = 0.123456789012345678
-      expect(localeNumberFormatter(amount3)).toBe('0.12345678901234568')
-
-      // trailing zeros
-      const amount4 = '0.123456789012340000'
-      expect(localeNumberFormatter(amount4)).toBe('0.12345678901234')
     })
   })
 })

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -194,21 +194,16 @@ export const formatCurrency = (number: string | number, currency: string): strin
   return format(number, currencyFormatter, minimum)
 }
 
-export const localeNumberFormatter = (amount: number | string): string => {
-  // get locale decimal separator
+export const localeNumberFormatter = (amount: number | string, locale?: string): string => {
+  // get locale thousand and decimal separator
   const number = 123456.789
-  const localeNumber = number.toLocaleString()
-  // Find localeNumber thousand and decimal separators
-  const [thousandSeparator, decimalSeparator] = localeNumber.match(/[^0-9]/g) || []
+  const parts = new Intl.NumberFormat(locale).formatToParts(number)
 
+  const decimalSeparator = parts.find((p) => p.type === 'decimal')!.value
   const [integerString, decimalString] = amount.toString().split(decimalSeparator)
 
-  const decimalFinal = decimalString ? `${decimalSeparator}${decimalString}` : ''
+  const integerFinal = Number(integerString).toLocaleString()
+  const decimalFinal = decimalString ? `${decimalSeparator}${decimalString}`.replace(/0+$/, '') : ''
 
-  // trailing zeros
-  const decimalFinalWithoutTrailingZeros = decimalString ? decimalFinal.replace(/0+$/, '') : ''
-
-  const integerFinal = integerString.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSeparator)
-
-  return `${integerFinal}${decimalFinalWithoutTrailingZeros}`
+  return integerFinal + decimalFinal
 }

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -193,3 +193,23 @@ export const formatCurrency = (number: string | number, currency: string): strin
 
   return format(number, currencyFormatter, minimum)
 }
+
+export const localeNumberFormatter = (amount: number | string): string => {
+  // get locale decimal separator
+  const number = 123456.789
+  const localeNumber = number.toLocaleString()
+  // Find localeNumber thousand and decimal separators
+  const [thousandSeparator, decimalSeparator] = localeNumber.match(/[^0-9]/g) || []
+
+  const [integerString, decimalString] = amount.toString().split(decimalSeparator)
+
+  // get decimal final
+  const decimalFinal = decimalString ? `${decimalSeparator}${decimalString}` : ''
+
+  // get integer final
+  const mainFinal = integerString.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSeparator)
+
+  const amountFinal = `${mainFinal}${decimalFinal}`
+
+  return amountFinal
+}

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -203,13 +203,12 @@ export const localeNumberFormatter = (amount: number | string): string => {
 
   const [integerString, decimalString] = amount.toString().split(decimalSeparator)
 
-  // get decimal final
   const decimalFinal = decimalString ? `${decimalSeparator}${decimalString}` : ''
 
-  // get integer final
-  const mainFinal = integerString.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSeparator)
+  // trailing zeros
+  const decimalFinalWithoutTrailingZeros = decimalString ? decimalFinal.replace(/0+$/, '') : ''
 
-  const amountFinal = `${mainFinal}${decimalFinal}`
+  const integerFinal = integerString.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSeparator)
 
-  return amountFinal
+  return `${integerFinal}${decimalFinalWithoutTrailingZeros}`
 }

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -193,17 +193,3 @@ export const formatCurrency = (number: string | number, currency: string): strin
 
   return format(number, currencyFormatter, minimum)
 }
-
-export const localeNumberFormatter = (amount: number | string, locale?: string): string => {
-  // get locale thousand and decimal separator
-  const number = 123456.789
-  const parts = new Intl.NumberFormat(locale).formatToParts(number)
-
-  const decimalSeparator = parts.find((p) => p.type === 'decimal')!.value
-  const [integerString, decimalString] = amount.toString().split(decimalSeparator)
-
-  const integerFinal = Number(integerString).toLocaleString()
-  const decimalFinal = decimalString ? `${decimalSeparator}${decimalString}`.replace(/0+$/, '') : ''
-
-  return integerFinal + decimalFinal
-}

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -115,7 +115,7 @@ export const formatAmountPrecise = (number: string | number, precision: number):
     maximumFractionDigits: precision,
   })
 
-  return formatter.format(Number(float))
+  return formatter.format(float)
 }
 
 // Fiat formatting

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -103,6 +103,21 @@ export const formatAmount = (number: string | number, precision?: number): strin
   return format(number, formatter.format)
 }
 
+/**
+ * Returns a formatted number with a defined precision not adhering to our style guide notation
+ * @param number Number to format
+ * @param precision Fraction digits to show
+ */
+export const formatAmountPrecise = (number: string | number, precision: number): string => {
+  const float = Number(number)
+
+  const formatter = new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: precision,
+  })
+
+  return formatter.format(Number(float))
+}
+
 // Fiat formatting
 
 const getMinimumCurrencyDenominator = memoize((currency: string): number => {

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -104,7 +104,7 @@ export const formatAmount = (number: string | number, precision?: number): strin
 }
 
 /**
- * Returns a formatted number with a defined precision not adhering to our style guide notation
+ * Returns a formatted number with a defined precision not adhering to our style guide compact notation
  * @param number Number to format
  * @param precision Fraction digits to show
  */


### PR DESCRIPTION
## What it solves

Resolves #705

## How this PR fixes it
Implements a new formatter `formatAmountPrecise` to format a number with a passed precision without adhering to our style guide notation.
Uses the app `formatAmountPrecise` formatter for review modal header's amounts.

## How to test it
1. Click to create a transaction with thousands and decimals
2. Observe the review modal displays the amount formatted as per locale

## Analytics changes
N/A

## Screenshots
![Screenshot 2022-12-07 at 15 49 12](https://user-images.githubusercontent.com/32431609/206211307-81862bbf-bcdb-43f0-8728-dbc20a880011.png)

