### PR TITLE
DON'T MERGE: fix: poll on tag change

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@gnosis.pm/safe-deployments": "^1.15.0",
     "@gnosis.pm/safe-ethers-lib": "^1.6.1",
     "@gnosis.pm/safe-modules-deployments": "^1.0.0",
-    "@gnosis.pm/safe-react-gateway-sdk": "^3.5.0",
+    "@gnosis.pm/safe-react-gateway-sdk": "^3.5.1",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.9.3",
     "@mui/x-date-pickers": "^5.0.0-beta.6",

--- a/src/hooks/loadables/useLoadSafeMessages.ts
+++ b/src/hooks/loadables/useLoadSafeMessages.ts
@@ -6,23 +6,16 @@ import useAsync from '@/hooks/useAsync'
 import { logError, Errors } from '@/services/exceptions'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import type { AsyncResult } from '@/hooks/useAsync'
-import { POLLING_INTERVAL } from '@/config/constants'
-import useIntervalCounter from '@/hooks/useIntervalCounter'
 
 export const useLoadMessages = (): AsyncResult<SafeMessageListPage> => {
-  const { safe, safeAddress, safeLoaded } = useSafeInfo()
-  const [pollCount, resetPolling] = useIntervalCounter(POLLING_INTERVAL)
+  const { safe, safeAddress, safeLoaded, messagesTag } = useSafeInfo()
 
   const [data, error, loading] = useAsync<SafeMessageListPage>(() => {
     if (!safeLoaded) {
       return
     }
     return getSafeMessages(safe.chainId, safeAddress)
-  }, [safeLoaded, safe.chainId, safeAddress, pollCount])
-
-  useEffect(() => {
-    resetPolling()
-  }, [resetPolling, safe.chainId, safeAddress])
+  }, [safeLoaded, safe.chainId, safeAddress, messagesTag])
 
   useEffect(() => {
     if (error) {


### PR DESCRIPTION
## What it solves

Improves #1159

## How this PR fixes it

Message loading now only happens initially and then when the Safe's `messagesTag` changes.

## How to test it

Later when the epic is finished: create a new message or add a confirmation to one and observe the next poll.

## Analytics changes

## Screenshots