### PR TITLE
add safe token address to goerli

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -31,6 +31,7 @@ export const CYPRESS_MNEMONIC = process.env.NEXT_PUBLIC_CYPRESS_MNEMONIC || ''
 export const SAFE_TOKEN_ADDRESSES: { [chainId: string]: string } = {
   [chains.eth]: '0x5aFE3855358E112B5647B952709E6165e1c1eEEe',
   [chains.rin]: '0xCFf1b0FdE85C102552D1D96084AF148f478F964A',
+  [chains.gor]: '0x61fD3b6d656F39395e32f46E2050953376c3f5Ff',
 }
 
 // Safe Apps


### PR DESCRIPTION
## What it solves
Shows the token badget with the allocated tokens.

Resolves #1272

## How this PR fixes it
- adds the goerli safe token address

## How to test it
Open a safe with allocation on goerli (i.e. `gor:0xAecDFD3A19f777F0c03e6bf99AAfB59937d6467b`)
