### PR TITLE
fix: updated tx queue bar zIndex to avoid overlaps

### DIFF
--- a/src/components/safe-apps/AppFrame/TransactionQueueBar/styles.module.css
+++ b/src/components/safe-apps/AppFrame/TransactionQueueBar/styles.module.css
@@ -3,7 +3,9 @@
   bottom: 0;
   right: 0;
   width: 100%;
-  z-index: 1;
+
+  /* MUI Drawer z-index default value see: https://mui.com/material-ui/customization/default-theme/?expand-path=$.zIndex */
+  z-index: 1200;
 
   /*this rule is needed to prevent the bar from being expanded outside the screen without scrolling on mobile devices*/
   max-height: 90vh;

--- a/src/components/safe-apps/AppFrame/TransactionQueueBar/styles.module.css
+++ b/src/components/safe-apps/AppFrame/TransactionQueueBar/styles.module.css
@@ -3,7 +3,7 @@
   bottom: 0;
   right: 0;
   width: 100%;
-  z-index: var(--onboard-modal-z-index, var(--modal-z-index));
+  z-index: 1;
 
   /*this rule is needed to prevent the bar from being expanded outside the screen without scrolling on mobile devices*/
   max-height: 90vh;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -69,9 +69,6 @@ const initTheme = (darkMode: boolean) => {
       darkMode ? `0 0 2px ${shadowColor}` : `0 8px 32px ${shadowColor}0a, 0 24px 60px ${shadowColor}14`,
       ...Array(20).fill('none'),
     ] as Shadows,
-    zIndex: {
-      modal: 1301,
-    },
     typography: {
       fontFamily: 'DM Sans, sans-serif',
       h1: {

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -69,6 +69,9 @@ const initTheme = (darkMode: boolean) => {
       darkMode ? `0 0 2px ${shadowColor}` : `0 8px 32px ${shadowColor}0a, 0 24px 60px ${shadowColor}14`,
       ...Array(20).fill('none'),
     ] as Shadows,
+    zIndex: {
+      modal: 1301,
+    },
     typography: {
       fontFamily: 'DM Sans, sans-serif',
       h1: {


### PR DESCRIPTION
## What it solves

The Tx queue is shown in front of the transaction modal, making interaction a little bit tricky:

![image](https://user-images.githubusercontent.com/26763673/204516907-a8ea7838-87ba-4764-a0d5-272addc3e247.png)

## How this PR fixes it

Adjusted the z-index value for the transaction queue bat to `z-index: 1200`:

```
.barWrapper {
  position: absolute;
  bottom: 0;
  right: 0;
  width: 100%;

  /* MUI Drawer z-index default value see: https://mui.com/material-ui/customization/default-theme/?expand-path=$.zIndex */
  z-index: 1200;

  /*this rule is needed to prevent the bar from being expanded outside the screen without scrolling on mobile devices*/
  max-height: 90vh;
}

```
## How to test it

1. Connect walletconnect with a safe with pending transactions.
2. click on the transaction queue.
3. Connect to Cow Swap Dapp.
4. Disconnect your wallet.
5. Click on connect wallet to see the onBoard Modal.
6. Create a eth-WETH swap transaction.
7. see the transaction modal.

## Screenshots
<img width="835" alt="Captura de pantalla 2022-11-29 a las 13 22 25" src="https://user-images.githubusercontent.com/26763673/204530485-cf167fc1-b4a6-4dcc-8ed0-ecb4c2ed6b2c.png">
<img width="837" alt="Captura de pantalla 2022-11-29 a las 13 22 51" src="https://user-images.githubusercontent.com/26763673/204530489-66d3b046-f912-4ce9-967d-b0d0b3502c5d.png">
<img width="838" alt="Captura de pantalla 2022-11-29 a las 13 23 07" src="https://user-images.githubusercontent.com/26763673/204530493-7ca4f90b-fcab-4145-ab11-998b84705f0f.png">
<img width="835" alt="Captura de pantalla 2022-11-29 a las 13 23 29" src="https://user-images.githubusercontent.com/26763673/204530494-eacb4762-8da2-4566-a068-1ed5c60e1092.png">
<img width="845" alt="Captura de pantalla 2022-11-29 a las 13 25 43" src="https://user-images.githubusercontent.com/26763673/204530497-f9a50114-3f93-4941-8073-2f5a683b2d1c.png">
<img width="849" alt="Captura de pantalla 2022-11-29 a las 13 25 50" src="https://user-images.githubusercontent.com/26763673/204530499-d970de4d-03e4-4302-8235-0532e6a44e7e.png">

