### PR TITLE
fix: get Compatibility Fallback Handler from SDK

### DIFF
--- a/src/components/create-safe/logic/index.ts
+++ b/src/components/create-safe/logic/index.ts
@@ -42,7 +42,7 @@ export const getSafeDeployProps = (
     safeAccountConfig: {
       threshold: safeParams.threshold,
       owners: safeParams.owners,
-      fallbackHandler: fallbackHandler.address,
+      fallbackHandler: fallbackHandler.getAddress(),
     },
     safeDeploymentConfig: {
       saltNonce: safeParams.saltNonce.toString(),
@@ -90,7 +90,7 @@ export const encodeSafeCreationTx = ({
     threshold,
     ZERO_ADDRESS,
     EMPTY_DATA,
-    fallbackHandlerContract.address,
+    fallbackHandlerContract.getAddress(),
     ZERO_ADDRESS,
     '0',
     ZERO_ADDRESS,

--- a/src/components/create-safe/status/__tests__/useSafeCreation.test.ts
+++ b/src/components/create-safe/status/__tests__/useSafeCreation.test.ts
@@ -4,12 +4,15 @@ import * as web3 from '@/hooks/wallets/web3'
 import * as chain from '@/hooks/useChains'
 import * as wallet from '@/hooks/wallets/useWallet'
 import * as logic from '@/components/create-safe/logic'
+import * as contracts from '@/services/contracts/safeContracts'
 import { JsonRpcProvider, Web3Provider } from '@ethersproject/providers'
 import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import type { ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { BigNumber } from '@ethersproject/bignumber'
 import { waitFor } from '@testing-library/react'
 import type Safe from '@safe-global/safe-core-sdk'
+import { hexZeroPad } from 'ethers/lib/utils'
+import type CompatibilityFallbackHandlerEthersContract from '@safe-global/safe-ethers-lib/dist/src/contracts/CompatibilityFallbackHandler/CompatibilityFallbackHandlerEthersContract'
 
 const mockSafeInfo = {
   data: '0x',
@@ -48,6 +51,9 @@ describe('useSafeCreation', () => {
     jest.spyOn(chain, 'useCurrentChain').mockImplementation(() => mockChain)
     jest.spyOn(wallet, 'default').mockReturnValue({} as ConnectedWallet)
     jest.spyOn(logic, 'getSafeCreationTxInfo').mockReturnValue(Promise.resolve(mockSafeInfo))
+    jest
+      .spyOn(contracts, 'getFallbackHandlerContractInstance')
+      .mockReturnValue({ getAddress: () => hexZeroPad('0x123', 20) } as CompatibilityFallbackHandlerEthersContract)
   })
 
   it('should create a safe if there is no txHash and status is AWAITING', async () => {

--- a/src/components/create-safe/steps/ReviewStep.tsx
+++ b/src/components/create-safe/steps/ReviewStep.tsx
@@ -56,7 +56,7 @@ const ReviewStep = ({ params, onSubmit, setStep, onBack }: Props) => {
       safeAccountConfig: {
         threshold: params.threshold,
         owners: params.owners.map((owner) => owner.address),
-        fallbackHandler: fallbackHandler.address,
+        fallbackHandler: fallbackHandler.getAddress(),
       },
       safeDeploymentConfig: {
         saltNonce: saltNonce.toString(),

--- a/src/components/new-safe/steps/Step3/index.tsx
+++ b/src/components/new-safe/steps/Step3/index.tsx
@@ -73,7 +73,7 @@ const CreateSafeStep3 = ({ data, onSubmit, onBack, setStep }: StepRenderProps<Ne
       safeAccountConfig: {
         threshold: data.threshold,
         owners: data.owners.map((owner) => owner.address),
-        fallbackHandler: fallbackHandler.address,
+        fallbackHandler: fallbackHandler.getAddress(),
       },
       safeDeploymentConfig: {
         saltNonce: saltNonce.toString(),

--- a/src/services/tx/safeUpdateParams.ts
+++ b/src/services/tx/safeUpdateParams.ts
@@ -21,7 +21,7 @@ export const createUpdateSafeTxs = (safe: SafeInfo, chain: ChainInfo): MetaTrans
   // @ts-expect-error this was removed in 1.3.0 but we need to support it for older safe versions
   const changeMasterCopyCallData = safeContractInstance.encode('changeMasterCopy', [latestMasterCopy.getAddress()])
 
-  const fallbackHandlerAddress = getFallbackHandlerContractInstance(chain.chainId).address
+  const fallbackHandlerAddress = getFallbackHandlerContractInstance(chain.chainId).getAddress()
   const changeFallbackHandlerCallData = safeContractInstance.encode('setFallbackHandler', [fallbackHandlerAddress])
 
   const txs: MetaTransactionData[] = [


### PR DESCRIPTION
## What it solves

Resolves #1236

## How this PR fixes it

The Compatibility Fallback Handler is now retrieved via `safe-core-sdk`.

## How to test it

Safe creation should function as normal.