### PR TITLE
[PoC] feat: return signature for 1/n threshold Safes

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@gnosis.pm/safe-deployments": "^1.15.0",
     "@gnosis.pm/safe-ethers-lib": "^1.6.1",
     "@gnosis.pm/safe-modules-deployments": "^1.0.0",
-    "@gnosis.pm/safe-react-gateway-sdk": "^3.5.0",
+    "@gnosis.pm/safe-react-gateway-sdk": "^3.5.1",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.9.3",
     "@mui/x-date-pickers": "^5.0.0-beta.6",

--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -36,6 +36,7 @@ import useSignMessageModal from '../SignMessageModal/useSignMessageModal'
 import TransactionQueueBar, { TRANSACTION_BAR_HEIGHT } from './TransactionQueueBar'
 import PermissionsPrompt from '../PermissionsPrompt'
 import { PermissionStatus } from '../types'
+import MsgModal from '@/components/safeMessages/MsgModal'
 
 import css from './styles.module.css'
 
@@ -248,20 +249,29 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
           />
         )}
 
-        {signMessageModalState.isOpen && (
-          <SafeAppsSignMessageModal
-            onClose={onSafeAppsModalClose}
-            initialData={[
-              {
-                app: safeAppFromManifest,
-                appId: remoteApp?.id,
-                requestId: signMessageModalState.requestId,
-                message: signMessageModalState.message,
-                method: signMessageModalState.method as Methods.signMessage | Methods.signTypedMessage,
-              },
-            ]}
-          />
-        )}
+        {signMessageModalState.isOpen &&
+          (signMessageModalState.offChain ? (
+            <MsgModal
+              onClose={onSafeAppsModalClose}
+              logoUri={remoteApp?.iconUrl || ''}
+              name={remoteApp?.name || ''}
+              message={signMessageModalState.message}
+              safeAppId={remoteApp?.id}
+            />
+          ) : (
+            <SafeAppsSignMessageModal
+              onClose={onSafeAppsModalClose}
+              initialData={[
+                {
+                  app: safeAppFromManifest,
+                  appId: remoteApp?.id,
+                  requestId: signMessageModalState.requestId,
+                  message: signMessageModalState.message,
+                  method: signMessageModalState.method as Methods.signMessage | Methods.signTypedMessage,
+                },
+              ]}
+            />
+          ))}
 
         {permissionsRequest && (
           <PermissionsPrompt

--- a/src/components/safe-apps/SignMessageModal/useSignMessageModal.ts
+++ b/src/components/safe-apps/SignMessageModal/useSignMessageModal.ts
@@ -1,14 +1,22 @@
 import { useState, useCallback } from 'react'
 import type { EIP712TypedData } from '@gnosis.pm/safe-apps-sdk'
 import { Methods } from '@gnosis.pm/safe-apps-sdk'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
-type StateType = { isOpen: boolean; message: string | EIP712TypedData; requestId: string; method: Methods }
+type StateType = {
+  isOpen: boolean
+  message: string | EIP712TypedData
+  requestId: string
+  method: Methods
+  offChain: boolean
+}
 
 const INITIAL_MODAL_STATE: StateType = {
   isOpen: false,
   message: '',
   requestId: '',
   method: Methods.signMessage,
+  offChain: false,
 }
 
 type ReturnType = [
@@ -22,17 +30,24 @@ type ReturnType = [
 ]
 
 const useSignMessageModal = (): ReturnType => {
-  const [signMessageModalState, setSignMessageModalState] = useState<StateType>(INITIAL_MODAL_STATE)
+  const { safe } = useSafeInfo()
+  const offChain = safe.threshold === 1
 
-  const openSignMessageModal = useCallback((message: string | EIP712TypedData, requestId: string, method: Methods) => {
-    setSignMessageModalState({
-      ...INITIAL_MODAL_STATE,
-      isOpen: true,
-      message,
-      requestId,
-      method,
-    })
-  }, [])
+  const [signMessageModalState, setSignMessageModalState] = useState<StateType>({ ...INITIAL_MODAL_STATE, offChain })
+
+  const openSignMessageModal = useCallback(
+    (message: string | EIP712TypedData, requestId: string, method: Methods) => {
+      setSignMessageModalState({
+        ...INITIAL_MODAL_STATE,
+        isOpen: true,
+        message,
+        requestId,
+        method,
+        offChain,
+      })
+    },
+    [offChain],
+  )
 
   const closeSignMessageModal = useCallback(() => {
     setSignMessageModalState(INITIAL_MODAL_STATE)

--- a/src/components/safeMessages/MsgModal/index.tsx
+++ b/src/components/safeMessages/MsgModal/index.tsx
@@ -11,6 +11,7 @@ import RequiredIcon from '@/public/images/messages/required.svg'
 import { dispatchSafeMsgConfirmation, dispatchSafeMsgProposal } from '@/services/safe-messages/safeMsgSender'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { getSafeMessageHash } from '@/utils/safe-messages'
+import type { RequestId } from '@gnosis.pm/safe-apps-sdk'
 
 import txStepperCss from '@/components/tx/TxStepper/styles.module.css'
 
@@ -23,12 +24,14 @@ type BaseProps = {
 // Custom Safe Apps do not have a `safeAppId`
 type ProposeProps = BaseProps & {
   safeAppId?: number
+  requestId: RequestId
   messageHash?: never
 }
 
 // A proposed message does not return the `safeAppId` but the `logoUri` and `name` of the Safe App that proposed it
 type ConfirmProps = BaseProps & {
   safeAppId?: never
+  requestId?: never
   messageHash: string
 }
 
@@ -39,6 +42,7 @@ const MsgModal = ({
   message,
   messageHash,
   safeAppId,
+  requestId,
 }: ProposeProps | ConfirmProps): ReactElement => {
   const { safe } = useSafeInfo()
 
@@ -50,11 +54,12 @@ const MsgModal = ({
     return getSafeMessageHash(message)
   }, [message, messageHash])
 
-  const onSign = () => {
-    if (message) {
-      dispatchSafeMsgProposal(safe, message, hash, safeAppId)
+  const onSign = async () => {
+    const isProposal = message && requestId
+    if (isProposal) {
+      await dispatchSafeMsgProposal(safe, message, hash, requestId, safeAppId)
     } else {
-      dispatchSafeMsgConfirmation(safe, hash)
+      await dispatchSafeMsgConfirmation(safe, hash)
     }
 
     onClose()

--- a/src/hooks/__tests__/useSafeMessageNotifications.test.ts
+++ b/src/hooks/__tests__/useSafeMessageNotifications.test.ts
@@ -15,7 +15,7 @@ describe('useSafeMessageNotifications', () => {
   it('should show a notification when a message is created', () => {
     renderHook(() => useSafeMessageNotifications())
 
-    safeMsgDispatch(SafeMsgEvent.PROPOSE, { messageHash: '0x123' })
+    safeMsgDispatch(SafeMsgEvent.PROPOSE, { messageHash: '0x123', signature: '0x456', requestId: '123' })
 
     expect(showNotification).toHaveBeenCalledWith({
       message: 'You successfully signed the message.',

--- a/src/hooks/__tests__/useSafeMessagePendingStatuses.test.ts
+++ b/src/hooks/__tests__/useSafeMessagePendingStatuses.test.ts
@@ -20,7 +20,7 @@ describe('useSafeMessagePendingStatuses', () => {
   it('should set a message as pending when it is created', () => {
     renderHook(() => useSafeMessagePendingStatuses())
 
-    safeMsgDispatch(SafeMsgEvent.PROPOSE, { messageHash: '0x123' })
+    safeMsgDispatch(SafeMsgEvent.PROPOSE, { messageHash: '0x123', signature: '0x456', requestId: '789' })
 
     expect(clearPendingSafeMessage).not.toHaveBeenCalled()
     expect(setPendingSafeMessage).toHaveBeenCalledWith('0x123')

--- a/src/services/safe-messages/safeMsgEvents.ts
+++ b/src/services/safe-messages/safeMsgEvents.ts
@@ -1,4 +1,5 @@
 import EventBus from '../EventBus'
+import type { RequestId } from '@gnosis.pm/safe-apps-sdk'
 
 export enum SafeMsgEvent {
   // Create message
@@ -20,7 +21,7 @@ export enum SafeMsgEvent {
 type SafeMessageHash = { messageHash: string }
 
 interface SignedMessageEvents {
-  [SafeMsgEvent.PROPOSE]: SafeMessageHash
+  [SafeMsgEvent.PROPOSE]: SafeMessageHash & { signature: string; requestId: RequestId }
   [SafeMsgEvent.PROPOSE_FAILED]: SafeMessageHash & { error: Error }
   [SafeMsgEvent.CONFIRM_PROPOSE]: SafeMessageHash
   [SafeMsgEvent.CONFIRM_PROPOSE_FAILED]: SafeMessageHash & { error: Error }

--- a/src/services/safe-messages/safeMsgSender.ts
+++ b/src/services/safe-messages/safeMsgSender.ts
@@ -4,7 +4,8 @@ import type { TypedDataDomain } from 'ethers'
 
 import { safeMsgDispatch, SafeMsgEvent } from './safeMsgEvents'
 import { getWeb3 } from '@/hooks/wallets/web3'
-import { generateSafeMessageTypes, getSafeMessageHash } from '@/utils/safe-messages'
+import { generateSafeMessageTypes } from '@/utils/safe-messages'
+import type { RequestId } from '@gnosis.pm/safe-apps-sdk'
 
 /**
  * Sign a message hash as a `SafeMessage` `message`
@@ -29,13 +30,13 @@ export const dispatchSafeMsgProposal = async (
   safe: SafeInfo,
   message: SafeMessage['message'],
   messageHash: string,
+  requestId: RequestId,
   safeAppId?: number,
 ): Promise<void | string> => {
   let signature: string
 
   try {
     signature = await signMessageHash(safe, messageHash)
-
     await proposeSafeMessage(safe.chainId, safe.address.value, {
       message,
       signature,
@@ -52,6 +53,8 @@ export const dispatchSafeMsgProposal = async (
 
   safeMsgDispatch(SafeMsgEvent.PROPOSE, {
     messageHash,
+    signature,
+    requestId,
   })
 
   return safe.threshold === 1 ? signature : undefined

--- a/src/services/safe-messages/safeMsgSender.ts
+++ b/src/services/safe-messages/safeMsgSender.ts
@@ -24,15 +24,17 @@ const signMessageHash = async (safe: SafeInfo, messageHash: SafeMessage['message
   return web3.getSigner()._signTypedData(domain as TypedDataDomain, types, message)
 }
 
+// TODO: Modify pending/notifications for immediately returned signatures, e.g. 1/n threshold
 export const dispatchSafeMsgProposal = async (
   safe: SafeInfo,
   message: SafeMessage['message'],
-  safeAppId: number,
-): Promise<void> => {
-  const messageHash = getSafeMessageHash(message)
+  messageHash: string,
+  safeAppId?: number,
+): Promise<void | string> => {
+  let signature: string
 
   try {
-    const signature = await signMessageHash(safe, messageHash)
+    signature = await signMessageHash(safe, messageHash)
 
     await proposeSafeMessage(safe.chainId, safe.address.value, {
       message,
@@ -51,8 +53,11 @@ export const dispatchSafeMsgProposal = async (
   safeMsgDispatch(SafeMsgEvent.PROPOSE, {
     messageHash,
   })
+
+  return safe.threshold === 1 ? signature : undefined
 }
 
+// TODO: Handle immediately returned strings
 export const dispatchSafeMsgConfirmation = async (
   safe: SafeInfo,
   messageHash: SafeMessage['messageHash'],

--- a/src/store/safeInfoSlice.ts
+++ b/src/store/safeInfoSlice.ts
@@ -16,6 +16,7 @@ export const defaultSafeInfo: SafeInfo = {
   collectiblesTag: '',
   txQueuedTag: '',
   txHistoryTag: '',
+  messagesTag: '',
 }
 
 const { slice, selector } = makeLoadableSlice('safeInfo', undefined as SafeInfo | undefined)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2470,10 +2470,10 @@
   dependencies:
     cross-fetch "^3.1.5"
 
-"@gnosis.pm/safe-react-gateway-sdk@^3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-3.5.0.tgz#62d41dd02f893a74ff955a551389cfb5fda13ac9"
-  integrity sha512-MopdJNBzkaniwGB31K4wIMMPICC0jlJQ3Yg4xQkSfe7MtiDvtBuHl0Gkc7zAFMZi32DDa5veOzHF3iFI+gHtXQ==
+"@gnosis.pm/safe-react-gateway-sdk@^3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-3.5.1.tgz#093727bda49c3801c1ed2ad1e8f60fe35a490a5d"
+  integrity sha512-fgMFtOJs07VhG8SJsQuxySF+nkUz3+F6ZMwa9UaPQAcqb9p7rW3whv03FXiZabX6t4Sosurb2OCp6XBBlY8FhA==
   dependencies:
     cross-fetch "^3.1.5"
 


### PR DESCRIPTION
## What it solves

Proof of concept for immediately returning signatures for https://github.com/safe-global/web-core/issues/1206

## How this PR fixes it

If a signing is requested, off-chain is chosen when the Safe threshold is 1/n and the signature is immediately returned.

This builds upon proposed `safe-apps-sdk` changes [here](https://github.com/safe-global/safe-apps-sdk/pull/411).