### PR TITLE
fix: replace nonce 0, flicker, no spending limit + disable duplite rejections

### DIFF
--- a/src/components/transactions/RejectTxButton/index.tsx
+++ b/src/components/transactions/RejectTxButton/index.tsx
@@ -3,8 +3,7 @@ import { Button, Tooltip, SvgIcon } from '@mui/material'
 
 import type { SyntheticEvent, ReactElement } from 'react'
 import { useState, Suspense } from 'react'
-import { useQueuedTxByNonce } from '@/hooks/useTxQueue'
-import { isCustomTxInfo, isMultisigExecutionInfo } from '@/utils/transaction-guards'
+import { isMultisigExecutionInfo } from '@/utils/transaction-guards'
 import dynamic from 'next/dynamic'
 import useIsPending from '@/hooks/useIsPending'
 import IconButton from '@mui/material/IconButton'
@@ -25,10 +24,6 @@ const RejectTxButton = ({
   const [open, setOpen] = useState<boolean>(false)
   const isSafeOwner = useIsSafeOwner()
   const txNonce = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo.nonce : undefined
-  const queuedTxsByNonce = useQueuedTxByNonce(txNonce)
-  const canCancel = !queuedTxsByNonce?.some(
-    (item) => isCustomTxInfo(item.transaction.txInfo) && item.transaction.txInfo.isCancellation,
-  )
   const isPending = useIsPending(txSummary.id)
 
   const isDisabled = isPending || !isSafeOwner
@@ -37,8 +32,6 @@ const RejectTxButton = ({
     e.stopPropagation()
     setOpen(true)
   }
-
-  if (!canCancel) return null
 
   return (
     <>

--- a/src/components/tx/NonceForm/index.tsx
+++ b/src/components/tx/NonceForm/index.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo, useState } from 'react'
 import type { ReactElement } from 'react'
 import { useController, useFormContext, useWatch } from 'react-hook-form'
-import { Autocomplete, Backdrop, IconButton, InputAdornment, MenuItem, Popper, TextField, Tooltip } from '@mui/material'
+import { Autocomplete, Backdrop, IconButton, InputAdornment, MenuItem, TextField, Tooltip } from '@mui/material'
 import RotateLeftIcon from '@mui/icons-material/RotateLeft'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useTxQueue, { useQueuedTxByNonce } from '@/hooks/useTxQueue'
@@ -39,10 +39,7 @@ const NonceFormOption = memo(({ nonce, ...props }: { nonce: number } & MenuItemP
 const NonceForm = ({ name, nonce, recommendedNonce, readonly }: NonceFormProps): ReactElement => {
   const { safe } = useSafeInfo()
   const safeNonce = safe.nonce || 0
-  const [popper, setPopper] = useState<{ open: boolean; anchorEl: (EventTarget & Element) | null }>({
-    open: false,
-    anchorEl: null,
-  })
+  const [backdrop, setBackdrop] = useState(false)
 
   // Initialise form field
   const { setValue, control } = useFormContext() || {}
@@ -98,61 +95,59 @@ const NonceForm = ({ name, nonce, recommendedNonce, readonly }: NonceFormProps):
   }
 
   return (
-    <Autocomplete
-      value={value}
-      freeSolo
-      // On option select or free text entry
-      onInputChange={(_, value) => {
-        onChange(value ? Number(value) : '')
-      }}
-      options={options}
-      disabled={nonce == null || readonly}
-      getOptionLabel={(option) => option.toString()}
-      renderOption={(props, option) => <NonceFormOption nonce={option} {...props} />}
-      disableClearable
-      onClose={() => {
-        setPopper({ anchorEl: null, open: false })
-      }}
-      onOpen={(e) => {
-        setPopper({ anchorEl: e.currentTarget, open: true })
-      }}
-      PopperComponent={(props) => (
-        <Backdrop open={popper.open}>
-          <Popper anchorEl={popper.anchorEl} {...props} />
-        </Backdrop>
-      )}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          name={name}
-          onBlur={onBlur}
-          inputRef={ref}
-          type="number"
-          autoComplete="off"
-          error={!!fieldState.error}
-          label={label}
-          InputProps={{
-            ...params.InputProps,
-            endAdornment: !readonly &&
-              recommendedNonce !== undefined &&
-              recommendedNonce !== params.inputProps.value && (
-                <InputAdornment position="end">
-                  <Tooltip title="Reset to recommended nonce">
-                    <IconButton onClick={onResetNonce} size="small" color="primary">
-                      <RotateLeftIcon />
-                    </IconButton>
-                  </Tooltip>
-                </InputAdornment>
-              ),
-            readOnly: readonly,
-          }}
-          InputLabelProps={{
-            ...params.InputLabelProps,
-            shrink: true,
-          }}
-        />
-      )}
-    />
+    <>
+      <Backdrop open={backdrop} />
+      <Autocomplete
+        value={value}
+        freeSolo
+        // On option select or free text entry
+        onInputChange={(_, value) => {
+          onChange(value ? Number(value) : '')
+        }}
+        options={options}
+        disabled={nonce == null || readonly}
+        getOptionLabel={(option) => option.toString()}
+        renderOption={(props, option) => <NonceFormOption nonce={option} {...props} />}
+        disableClearable
+        onClose={() => {
+          setBackdrop(false)
+        }}
+        onOpen={(e) => {
+          setBackdrop(true)
+        }}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            name={name}
+            onBlur={onBlur}
+            inputRef={ref}
+            type="number"
+            autoComplete="off"
+            error={!!fieldState.error}
+            label={label}
+            InputProps={{
+              ...params.InputProps,
+              endAdornment: !readonly &&
+                recommendedNonce !== undefined &&
+                recommendedNonce !== params.inputProps.value && (
+                  <InputAdornment position="end">
+                    <Tooltip title="Reset to recommended nonce">
+                      <IconButton onClick={onResetNonce} size="small" color="primary">
+                        <RotateLeftIcon />
+                      </IconButton>
+                    </Tooltip>
+                  </InputAdornment>
+                ),
+              readOnly: readonly,
+            }}
+            InputLabelProps={{
+              ...params.InputLabelProps,
+              shrink: true,
+            }}
+          />
+        )}
+      />
+    </>
   )
 }
 

--- a/src/components/tx/NonceForm/index.tsx
+++ b/src/components/tx/NonceForm/index.tsx
@@ -1,7 +1,7 @@
-import { memo, useMemo, useState } from 'react'
+import { memo, useMemo } from 'react'
 import type { ReactElement } from 'react'
 import { useController, useFormContext, useWatch } from 'react-hook-form'
-import { Autocomplete, Backdrop, IconButton, InputAdornment, MenuItem, TextField, Tooltip } from '@mui/material'
+import { Autocomplete, IconButton, InputAdornment, MenuItem, TextField, Tooltip } from '@mui/material'
 import RotateLeftIcon from '@mui/icons-material/RotateLeft'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useTxQueue, { useQueuedTxByNonce } from '@/hooks/useTxQueue'
@@ -39,7 +39,6 @@ const NonceFormOption = memo(({ nonce, ...props }: { nonce: number } & MenuItemP
 const NonceForm = ({ name, nonce, recommendedNonce, readonly }: NonceFormProps): ReactElement => {
   const { safe } = useSafeInfo()
   const safeNonce = safe.nonce || 0
-  const [backdrop, setBackdrop] = useState(false)
 
   // Initialise form field
   const { setValue, control } = useFormContext() || {}
@@ -95,59 +94,55 @@ const NonceForm = ({ name, nonce, recommendedNonce, readonly }: NonceFormProps):
   }
 
   return (
-    <>
-      <Backdrop open={backdrop} />
-      <Autocomplete
-        value={value}
-        freeSolo
-        // On option select or free text entry
-        onInputChange={(_, value) => {
-          onChange(value ? Number(value) : '')
-        }}
-        options={options}
-        disabled={nonce == null || readonly}
-        getOptionLabel={(option) => option.toString()}
-        renderOption={(props, option) => <NonceFormOption nonce={option} {...props} />}
-        disableClearable
-        onClose={() => {
-          setBackdrop(false)
-        }}
-        onOpen={(e) => {
-          setBackdrop(true)
-        }}
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            name={name}
-            onBlur={onBlur}
-            inputRef={ref}
-            type="number"
-            autoComplete="off"
-            error={!!fieldState.error}
-            label={label}
-            InputProps={{
-              ...params.InputProps,
-              endAdornment: !readonly &&
-                recommendedNonce !== undefined &&
-                recommendedNonce !== params.inputProps.value && (
-                  <InputAdornment position="end">
-                    <Tooltip title="Reset to recommended nonce">
-                      <IconButton onClick={onResetNonce} size="small" color="primary">
-                        <RotateLeftIcon />
-                      </IconButton>
-                    </Tooltip>
-                  </InputAdornment>
-                ),
-              readOnly: readonly,
-            }}
-            InputLabelProps={{
-              ...params.InputLabelProps,
-              shrink: true,
-            }}
-          />
-        )}
-      />
-    </>
+    <Autocomplete
+      value={value}
+      freeSolo
+      // On option select or free text entry
+      onInputChange={(_, value) => {
+        onChange(value ? Number(value) : '')
+      }}
+      options={options}
+      disabled={nonce == null || readonly}
+      getOptionLabel={(option) => option.toString()}
+      renderOption={(props, option) => <NonceFormOption nonce={option} {...props} />}
+      disableClearable
+      componentsProps={{
+        paper: {
+          elevation: 2,
+        },
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          name={name}
+          onBlur={onBlur}
+          inputRef={ref}
+          type="number"
+          autoComplete="off"
+          error={!!fieldState.error}
+          label={label}
+          InputProps={{
+            ...params.InputProps,
+            endAdornment: !readonly &&
+              recommendedNonce !== undefined &&
+              recommendedNonce !== params.inputProps.value && (
+                <InputAdornment position="end">
+                  <Tooltip title="Reset to recommended nonce">
+                    <IconButton onClick={onResetNonce} size="small" color="primary">
+                      <RotateLeftIcon />
+                    </IconButton>
+                  </Tooltip>
+                </InputAdornment>
+              ),
+            readOnly: readonly,
+          }}
+          InputLabelProps={{
+            ...params.InputLabelProps,
+            shrink: true,
+          }}
+        />
+      )}
+    />
   )
 }
 

--- a/src/components/tx/NonceForm/index.tsx
+++ b/src/components/tx/NonceForm/index.tsx
@@ -79,7 +79,7 @@ const NonceForm = ({ name, nonce, recommendedNonce, readonly }: NonceFormProps):
   const options = useMemo(() => {
     return queuedTxs
       .map((tx) => (isMultisigExecutionInfo(tx.executionInfo) ? tx.executionInfo.nonce : undefined))
-      .filter(Boolean)
+      .filter((nonce) => nonce !== undefined)
   }, [queuedTxs])
 
   // Warn about a higher nonce

--- a/src/components/tx/modals/NewTxModal/ReplacementModal.tsx
+++ b/src/components/tx/modals/NewTxModal/ReplacementModal.tsx
@@ -18,6 +18,8 @@ import RocketIcon from '@/public/images/transactions/rocket.svg'
 import CheckIcon from '@mui/icons-material/Check'
 import DeleteIcon from '@/public/images/common/delete.svg'
 import { SendTokensButton, SendNFTsButton } from './TxButton'
+import { useQueuedTxByNonce } from '@/hooks/useTxQueue'
+import { isCustomTxInfo } from '@/utils/transaction-guards'
 
 import css from './styles.module.css'
 
@@ -69,6 +71,11 @@ const ReplacementModal = ({
   onNFTModalOpen: () => void
   onRejectModalOpen: () => void
 }) => {
+  const queuedTxsByNonce = useQueuedTxByNonce(txNonce)
+  const canCancel = !queuedTxsByNonce?.some(
+    (item) => isCustomTxInfo(item.transaction.txInfo) && item.transaction.txInfo.isCancellation,
+  )
+
   return (
     <ModalDialog open={open} dialogTitle={`Replace transaction with nonce ${txNonce}`} onClose={onClose}>
       <DialogContent className={css.container}>
@@ -127,9 +134,23 @@ const ReplacementModal = ({
             alignItems="center"
             flexDirection={flexDirection}
           >
-            <Button onClick={onRejectModalOpen} variant="outlined" fullWidth sx={{ mb: 1, ...btnWidth }}>
-              Rejection transaction
-            </Button>
+            <Tooltip
+              arrow
+              placement="top"
+              title={canCancel ? '' : `Transaction with nonce ${txNonce} already has a reject transaction`}
+            >
+              <span>
+                <Button
+                  onClick={onRejectModalOpen}
+                  variant="outlined"
+                  fullWidth
+                  sx={{ mb: 1, ...btnWidth }}
+                  disabled={!canCancel}
+                >
+                  Rejection transaction
+                </Button>
+              </span>
+            </Tooltip>
 
             <div>
               <Typography variant="caption" display="flex" alignItems="center">

--- a/src/components/tx/modals/NewTxModal/index.tsx
+++ b/src/components/tx/modals/NewTxModal/index.tsx
@@ -64,12 +64,17 @@ const NewTxModal = ({
       )}
 
       {tokenModalOpen && (
-        <TokenTransferModal onClose={onClose} initialData={[{ [SendAssetsField.recipient]: recipient }, { txNonce }]} />
+        <TokenTransferModal
+          onClose={onClose}
+          initialData={[{ [SendAssetsField.recipient]: recipient, disableSpendingLimit: isReplacement }, { txNonce }]}
+        />
       )}
 
       {nftsModalOpen && <NftTransferModal onClose={onClose} initialData={[{ recipient }, { txNonce }]} />}
 
-      {rejectModalOpen && txNonce && <RejectTxModal onClose={onClose} initialData={[txNonce]} />}
+      {rejectModalOpen && typeof txNonce === 'number' ? (
+        <RejectTxModal onClose={onClose} initialData={[txNonce]} />
+      ) : null}
     </>
   )
 }

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -67,10 +67,11 @@ export type SendAssetsFormData = {
 
 type SendAssetsFormProps = {
   formData?: SendAssetsFormData
+  disableSpendingLimit?: boolean
   onSubmit: (formData: SendAssetsFormData) => void
 }
 
-const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactElement => {
+const SendAssetsForm = ({ onSubmit, formData, disableSpendingLimit = false }: SendAssetsFormProps): ReactElement => {
   const { balances } = useBalances()
   const addressBook = useAddressBook()
   const chainId = useChainId()
@@ -82,7 +83,9 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
       [SendAssetsField.recipient]: formData?.[SendAssetsField.recipient] || '',
       [SendAssetsField.tokenAddress]: formData?.[SendAssetsField.tokenAddress] || '',
       [SendAssetsField.amount]: formData?.[SendAssetsField.amount] || '',
-      [SendAssetsField.type]: formData?.[SendAssetsField.type] || SendTxType.multiSig,
+      [SendAssetsField.type]: disableSpendingLimit
+        ? SendTxType.multiSig
+        : formData?.[SendAssetsField.type] || SendTxType.multiSig,
     },
     mode: 'onChange',
     delayError: 500,
@@ -171,7 +174,7 @@ const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactEleme
             </Box>
           )}
 
-          {!!spendingLimit && (
+          {!disableSpendingLimit && !!spendingLimit && (
             <SpendingLimitRow spendingLimit={spendingLimit} selectedToken={selectedToken?.tokenInfo} />
           )}
 

--- a/src/components/tx/modals/TokenTransferModal/index.tsx
+++ b/src/components/tx/modals/TokenTransferModal/index.tsx
@@ -8,19 +8,25 @@ import type { TxModalProps } from '@/components/tx/TxModal'
 import TxModal from '@/components/tx/TxModal'
 
 export type TokenTransferModalProps = {
-  params: SendAssetsFormData & { txNonce?: number }
+  params: SendAssetsFormData & { txNonce?: number; disableSpendingLimit?: boolean }
   onSubmit: (txId: string) => void
 }
 
 export const TokenTransferSteps: TxStepperProps['steps'] = [
   {
     label: 'Send tokens',
-    render: (data, onSubmit) => <SendAssetsForm onSubmit={onSubmit} formData={data as SendAssetsFormData} />,
+    render: (data, onSubmit) => {
+      const { disableSpendingLimit, ...formData } = data as SendAssetsFormData & { disableSpendingLimit?: boolean }
+      return <SendAssetsForm onSubmit={onSubmit} formData={formData} disableSpendingLimit={disableSpendingLimit} />
+    },
   },
   {
     label: 'Review transaction',
     render: (data, onSubmit) => (
-      <ReviewTokenTx onSubmit={onSubmit} params={data as TokenTransferModalProps['params']} />
+      <ReviewTokenTx
+        onSubmit={onSubmit}
+        params={data as Omit<TokenTransferModalProps['params'], 'disableSpendingLimit'>}
+      />
     ),
   },
 ]

--- a/src/store/safeInfoSlice.ts
+++ b/src/store/safeInfoSlice.ts
@@ -16,6 +16,7 @@ export const defaultSafeInfo: SafeInfo = {
   collectiblesTag: '',
   txQueuedTag: '',
   txHistoryTag: '',
+  messagesTag: '',
 }
 
 const { slice, selector } = makeLoadableSlice('safeInfo', undefined as SafeInfo | undefined)

--- a/src/store/safeInfoSlice.ts
+++ b/src/store/safeInfoSlice.ts
@@ -16,7 +16,6 @@ export const defaultSafeInfo: SafeInfo = {
   collectiblesTag: '',
   txQueuedTag: '',
   txHistoryTag: '',
-  messagesTag: '',
 }
 
 const { slice, selector } = makeLoadableSlice('safeInfo', undefined as SafeInfo | undefined)


### PR DESCRIPTION
## What it solves

Resolves isses found [here](https://github.com/safe-global/web-core/pull/1079#issuecomment-1333132981).

## How this PR fixes it

1. Spending limit transactions are not shown creating a transaction via the replacement flow.
2. The backdrop no longer flickers whent the autocomplete dropdown is open.
3. Transactions with nonce 0 now open the replacement modal.
4. Disable duplicate rejection transactions.

## How to test it

1. Attempt to replace a transaction. Observe that spending limit options are not displayed.
2. Open the nonce autocomplete limit and observe no backdrop flicker.
3. Attempt to replace a transaction with nonce 0. Clicking "Replace transaction" in the modal should open the next step.
4. The replacement button is now always shown. Attempting to replace a transaction that already has a rejection transaction will render a disabled rejeection button in the modal.