### PR TITLE
fix: dont overlay banner over header

### DIFF
--- a/src/components/common/PageLayout/SideDrawer.tsx
+++ b/src/components/common/PageLayout/SideDrawer.tsx
@@ -43,12 +43,13 @@ const SideDrawer = ({ isOpen, onToggle }: SideDrawerProps): ReactElement => {
   return (
     <>
       <Drawer
+        className={css.drawer}
         variant={isSmallScreen ? 'temporary' : 'persistent'}
         anchor="left"
         open={isOpen}
         onClose={() => onToggle(false)}
       >
-        <aside>
+        <aside className={css.sidebar}>
           <Sidebar />
         </aside>
       </Drawer>

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -15,21 +15,23 @@ const PageLayout = ({ children }: { children: ReactElement }): ReactElement => {
   }
 
   return (
-    <>
+    <div className={css.wrapper}>
       <header className={css.header}>
         <Header onMenuToggle={toggleSidebar} />
       </header>
 
-      <SideDrawer isOpen={isSidebarOpen} onToggle={setSidebarOpen} />
+      <div className={css.container}>
+        <SideDrawer isOpen={isSidebarOpen} onToggle={setSidebarOpen} />
 
-      <div className={classnames(css.main, !isSidebarOpen && css.mainNoSidebar)}>
-        <div className={css.content}>
-          <SafeLoadingError>{children}</SafeLoadingError>
+        <div className={classnames(css.main, !isSidebarOpen && css.mainNoSidebar)}>
+          <div className={css.content}>
+            <SafeLoadingError>{children}</SafeLoadingError>
+          </div>
+
+          <Footer />
         </div>
-
-        <Footer />
       </div>
-    </>
+    </div>
   )
 }
 

--- a/src/components/common/PageLayout/styles.module.css
+++ b/src/components/common/PageLayout/styles.module.css
@@ -1,5 +1,18 @@
+.container {
+  display: flex;
+}
+
+.wrapper {
+  position: relative;
+  top: 0;
+}
+
+.sidebar {
+  height: 100%;
+}
+
 .header {
-  position: fixed;
+  position: sticky;
   left: 0;
   top: 0;
   width: 100%;
@@ -8,9 +21,8 @@
 
 .main {
   background-color: var(--color-background-main);
-  padding-left: 230px;
-  padding-top: var(--header-height);
   min-height: 100vh;
+  width: 100%;
   display: flex;
   flex-direction: column;
   transition: padding 225ms cubic-bezier(0, 0, 0.2, 1) 0ms;
@@ -78,5 +90,20 @@
 @media (max-width: 600px) {
   .main main {
     padding: var(--space-2);
+  }
+}
+
+@media (min-width: 900px) {
+  .drawer {
+    position: sticky;
+    top: var(--header-height);
+    width: 230px;
+    overflow: auto;
+    height: calc(100vh - var(--header-height));
+  }
+
+  .drawer :global .MuiPaper-root {
+    position: relative;
+    border-radius: 0;
   }
 }

--- a/src/components/common/PsaBanner/index.module.css
+++ b/src/components/common/PsaBanner/index.module.css
@@ -1,6 +1,6 @@
 .banner {
-  position: fixed;
-  z-index: 10000;
+  position: relative;
+  z-index: var(--onboard-modal-z-index);
   top: 0;
   left: 0;
   right: 0;

--- a/src/components/sidebar/Sidebar/styles.module.css
+++ b/src/components/sidebar/Sidebar/styles.module.css
@@ -1,7 +1,6 @@
 .container,
 .drawer {
-  height: 100vh;
-  padding-top: var(--header-height);
+  height: 100%;
   display: flex;
   overflow: hidden;
   flex-direction: column;
@@ -23,14 +22,10 @@
 }
 
 .drawer {
+  text-align: center;
+  border-right: 1px solid var(--color-border-light);
   width: 400px;
   max-width: 90vw;
-}
-
-.drawer {
-  text-align: center;
-  padding: var(--header-height) 0 0 0;
-  border-right: 1px solid var(--color-border-light);
 }
 
 .noSafeHeader {
@@ -65,10 +60,6 @@
 }
 
 @media (max-width: 900px) {
-  .container {
-    padding-top: var(--header-height);
-  }
-
   .drawer {
     max-width: 90vw;
   }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -502,6 +502,16 @@ const initTheme = (darkMode: boolean) => {
           }),
         },
       },
+      MuiDrawer: {
+        styleOverrides: {
+          root: ({ theme }) => ({
+            zIndex: theme.zIndex.snackbar,
+          }),
+          paper: {
+            borderRadius: 0,
+          },
+        },
+      },
     },
   })
 }


### PR DESCRIPTION
## What it solves

Resolves #1202 

## How this PR fixes it

- Gives the banner a relative position so it doesn't overlay the header
- Changes the header and sidebar to have a sticky position instead of fixed
- As a result the sidebar drawers don't have a fixed offset anymore but are aligned to the top of the window

## How to test it

1. Open the safe with the banner open (clear local storage if needed)
2. Observe that the header is visible
3. Scroll down
4. Observe that the banner disappears but the header and sidebar are fixed
5. Close the banner
6. Observe the that header and sidebar still have a fixed position
7. Open the safe list sidebar
8. Observe that it overlays everything else and is positioned at the top of the window
9. Switch to a smaller screen
10. Open the sidebar and safe list sidebar
11. Observe that they overlay everything else and are positioned at the top of the window

## Screenshots

<img width="1512" alt="Screenshot 2022-12-01 at 20 22 26" src="https://user-images.githubusercontent.com/5880855/205141318-b75e34e5-9e41-482a-80f3-c02d4f44e005.png">
<img width="1512" alt="Screenshot 2022-12-01 at 20 22 36" src="https://user-images.githubusercontent.com/5880855/205141353-71674406-5b25-40aa-a143-4f2b08fe5d26.png">
<img width="1512" alt="Screenshot 2022-12-01 at 20 22 47" src="https://user-images.githubusercontent.com/5880855/205141381-85b4ac4c-1422-4f49-9423-2f40a15d0d60.png">
<img width="422" alt="Screenshot 2022-12-01 at 20 23 15" src="https://user-images.githubusercontent.com/5880855/205141465-d599e7c9-d5a1-4566-9c36-5346934b9f37.png">
