### PR TITLE
fix: Revert accordion transitions

### DIFF
--- a/src/components/safe-apps/AppFrame/TransactionQueueBar/index.tsx
+++ b/src/components/safe-apps/AppFrame/TransactionQueueBar/index.tsx
@@ -49,6 +49,7 @@ const TransactionQueueBar = ({
                 enter: 0,
                 exit: 500,
               },
+              unmountOnExit: true,
               mountOnEnter: true,
             }}
             sx={{

--- a/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
+++ b/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
@@ -29,6 +29,10 @@ export const ExpandableTransactionItem = ({
   return (
     <Accordion
       disableGutters
+      TransitionProps={{
+        mountOnEnter: false,
+        unmountOnExit: true,
+      }}
       elevation={0}
       defaultExpanded={!!txDetails}
       className={classNames(css.accordion, { [css.batched]: isBatched })}


### PR DESCRIPTION
## What it solves

Reverts #1064 

Also added an enhancement issue to look at this again in the future #1303

## How this PR fixes it

- Reverts changes done in #1064 that resulted in too many network requests on page load

## How to test it

- Open the Transaction history/queue
- Observe that there are no network requests for tx details
- Open a transaction accordion
- Observe that there is one network request for its details
