### PR TITLE
Fix: link to old app from the import page

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,5 +20,6 @@ jobs:
         with:
           path-to-document: 'https://github.com/safe-global/web-core/blob/dev/CLA.md'
           branch: 'cla-signatures'
+          path-to-signatures: 'signatures/version1/cla.json'
           allowlist: lukasschor,mikheevm,rmeissner,germartinez,Uxio0,dasanra,francovenica,tschubotz,luarx,gnosis-info,bot*,DaniSomoza,iamacook,yagopv,usame-algan,schmanu,DiogoSoaress,JagoFigueroa
           lock-pullrequest-aftermerge: true

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'CLA Assistant'
-        if: github.event_name == 'pull_request' || github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
-        uses: contributor-assistant/github-action@v2.2.0
+        if: contains(github.event.comment.body, 'recheck') || contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request'
+        uses: contributor-assistant/github-action@v2.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ASSISTANT_ACCESS_TOKEN }}

--- a/src/components/settings/DataManagement/index.tsx
+++ b/src/components/settings/DataManagement/index.tsx
@@ -1,9 +1,7 @@
-import InfoIcon from '@/public/images/notifications/info.svg'
-
+import { useState } from 'react'
+import { Paper, Grid, Typography, Button, Link } from '@mui/material'
 import Track from '@/components/common/Track'
 import { SETTINGS_EVENTS } from '@/services/analytics'
-import { Paper, Grid, Typography, Tooltip, SvgIcon, Button } from '@mui/material'
-import { useState } from 'react'
 import ImportAllDialog from '../ImportAllDialog'
 
 const DataManagement = () => {
@@ -15,23 +13,20 @@ const DataManagement = () => {
         <Grid item sm={4} xs={12}>
           <Typography variant="h4" fontWeight={700}>
             Data import
-            <Tooltip
-              placement="top"
-              title="The imported data will overwrite all added Safes and all address book entries"
-            >
-              <span>
-                <SvgIcon
-                  component={InfoIcon}
-                  inheritViewBox
-                  fontSize="small"
-                  color="border"
-                  sx={{ verticalAlign: 'middle', ml: 0.5 }}
-                />
-              </span>
-            </Tooltip>
           </Typography>
         </Grid>
-        <Grid item xs justifyContent="flex-end" display="flex">
+
+        <Grid item xs>
+          <Typography>
+            You can export your data from the{' '}
+            <Link target="_blank" href="https://gnosis-safe.io/app/export">
+              old app
+            </Link>
+            .
+          </Typography>
+
+          <Typography mb={3}>The imported data will overwrite all added Safes and all address book entries.</Typography>
+
           <Track {...SETTINGS_EVENTS.DATA.IMPORT_ALL_BUTTON}>
             <Button size="small" variant="contained" onClick={() => setModalOpen(true)}>
               Import all data

--- a/src/components/settings/ImportAllDialog/index.tsx
+++ b/src/components/settings/ImportAllDialog/index.tsx
@@ -146,16 +146,12 @@ const ImportAllDialog = ({ handleClose }: { handleClose: () => void }): ReactEle
         <div className={css.horizontalDivider} />
 
         <Typography>Only JSON files exported from a Safe can be imported.</Typography>
-
-        {!!jsonData && (
-          <Alert severity="warning" sx={{ mt: 3 }}>
-            <AlertTitle sx={{ fontWeight: 700 }}>Overwrite your current data?</AlertTitle>
-            This action will overwrite your currently added Safes and address book entries with those from the imported
-            file.
-          </Alert>
-        )}
+        <Alert severity="warning" sx={{ mt: 3 }}>
+          <AlertTitle sx={{ fontWeight: 700 }}>Overwrite your current data?</AlertTitle>
+          This action will overwrite your currently added Safes and address book entries with those from the imported
+          file.
+        </Alert>
       </DialogContent>
-
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
         <Button

--- a/src/components/settings/ImportAllDialog/index.tsx
+++ b/src/components/settings/ImportAllDialog/index.tsx
@@ -146,12 +146,16 @@ const ImportAllDialog = ({ handleClose }: { handleClose: () => void }): ReactEle
         <div className={css.horizontalDivider} />
 
         <Typography>Only JSON files exported from a Safe can be imported.</Typography>
-        <Alert severity="warning" sx={{ mt: 3 }}>
-          <AlertTitle sx={{ fontWeight: 700 }}>Overwrite your current data?</AlertTitle>
-          This action will overwrite your currently added Safes and address book entries with those from the imported
-          file.
-        </Alert>
+
+        {!!jsonData && (
+          <Alert severity="warning" sx={{ mt: 3 }}>
+            <AlertTitle sx={{ fontWeight: 700 }}>Overwrite your current data?</AlertTitle>
+            This action will overwrite your currently added Safes and address book entries with those from the imported
+            file.
+          </Alert>
+        )}
       </DialogContent>
+
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
         <Button

--- a/src/pages/import.tsx
+++ b/src/pages/import.tsx
@@ -6,7 +6,7 @@ const Import: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Data Import</title>
+        <title>Data import</title>
       </Head>
 
       <main>


### PR DESCRIPTION
* Add a link to the old app on the import page
* Make the tooltip text inline
* Show the "Overwrite data?" alert only after dropping a file

<img width="1230" alt="Screenshot 2022-12-05 at 08 44 06" src="https://user-images.githubusercontent.com/381895/205581845-e5b28416-5548-42e3-aa43-3fc4efdbb4ff.png">
