### PR TITLE
Chore: replace the CLA action with a simple comment

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post a comment if the PR is from a fork
-        if: ${{ github.event.pull_request.head.repo.full_name != 'safe-global/web-core' }}
+        #if: ${{ github.event.pull_request.head.repo.full_name != 'safe-global/web-core' }}
         uses: mshick/add-pr-comment@v2
         with:
           message-id: cla-comment

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,23 +1,24 @@
 name: 'CLA Assistant'
 
 on:
-  issue_comment:
-    types: [created]
-
   pull_request:
-    types: [opened, closed, synchronize]
 
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest
     steps:
-      - name: 'CLA Assistant'
-        if: contains(github.event.comment.body, 'recheckcla') || contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request'
-        uses: gnosis/github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Post a comment if the PR is from a fork
+        if: ${{ github.event.pull_request.head.repo.full_name != 'safe-global/web-core' }}
+        uses: mshick/add-pr-comment@v2
         with:
-          path-to-cla-document: 'https://safe.global/cla/'
-          branch: 'cla-signatures'
-          path-to-signatures: 'signatures/version1/cla.json'
-          allowlist: lukasschor,mikheevm,rmeissner,germartinez,Uxio0,dasanra,francovenica,tschubotz,luarx,gnosis-info,bot*,DaniSomoza,iamacook,yagopv,usame-algan,schmanu,DiogoSoaress,JagoFigueroa
+          message-id: cla-comment
+          message: |
+            Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://safe.global/cla/) before we can accept your contribution. You can sign the CLA just by posting a comment as per the format below:
+
+            ---
+
+            I have read the CLA Document and I hereby sign the CLA
+
+            ---
+
+            Thank you! ✍️ ✅

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -3,6 +3,8 @@ name: CLA
 on:
   pull_request:
 
+  pull_request_review_comment:
+
   issue_comment:
 
 jobs:
@@ -10,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA has been signed in this PR
+        if: ${{ github.event.pull_request.head.repo.full_name != 'safe-global/web-core' }}
         uses: peter-evans/find-comment@v2
         id: fc
         with:
@@ -18,8 +21,7 @@ jobs:
           body-includes: 'I have read the CLA Document and I hereby sign the CLA'
 
       - name: Post a comment if the PR is from a fork
-        #if: ${{ github.event.pull_request.head.repo.full_name != 'safe-global/web-core' }}
-        if: ${{ steps.fc.outputs.comment-id == 0 }}
+        if: ${{ github.event.pull_request.head.repo.full_name != 'safe-global/web-core' && steps.fc.outputs.comment-id == 0 }}
         uses: mshick/add-pr-comment@v2
         with:
           message-id: cla-comment
@@ -28,7 +30,7 @@ jobs:
 
             ---
 
-            **I have read the CLA Document and I hereby sign the CLA**
+            *I have read the CLA Document and I hereby sign the CLA*
 
             ---
 
@@ -40,4 +42,4 @@ jobs:
         with:
           message-id: cla-comment
           message: |
-            All contributors have signed the [CLA](https://safe.global/cla/) ✍️ ✅
+            All contributors have signed the CLA ✍️ ✅

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,14 +1,25 @@
-name: 'CLA Assistant'
+name: CLA
 
 on:
   pull_request:
+
+  issue_comment:
 
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest
     steps:
+      - name: Check if CLA has been signed in this PR
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-author: ${{ github.event.pull_request.user.login }}
+          body-includes: 'I have read the CLA Document and I hereby sign the CLA'
+
       - name: Post a comment if the PR is from a fork
         #if: ${{ github.event.pull_request.head.repo.full_name != 'safe-global/web-core' }}
+        if: ${{ steps.fc.outputs.comment-id == 0 }}
         uses: mshick/add-pr-comment@v2
         with:
           message-id: cla-comment
@@ -17,8 +28,16 @@ jobs:
 
             ---
 
-            I have read the CLA Document and I hereby sign the CLA
+            **I have read the CLA Document and I hereby sign the CLA**
 
             ---
 
-            Thank you! ✍️ ✅
+            Thank you!
+
+      - name: Post a comment confirming the CLA was signed
+        if: ${{ steps.fc.outputs.comment-id != 0 }}
+        uses: mshick/add-pr-comment@v2
+        with:
+          message-id: cla-comment
+          message: |
+            All contributors have signed the [CLA](https://safe.global/cla/) ✍️ ✅


### PR DESCRIPTION
## What it solves
The action we've been using has stopped working for external contributors. I've replaced it with a simple comment for non-org members, urging to sign the CLA.