### PR TITLE
fix: Track safe creation events under the same category

### DIFF
--- a/src/components/tx/TxStepper/vertical.tsx
+++ b/src/components/tx/TxStepper/vertical.tsx
@@ -7,12 +7,19 @@ import { StepContent } from '@mui/material'
 import type { TxStepperProps } from '@/components/tx/TxStepper/useTxStepper'
 import { useTxStepper } from '@/components/tx/TxStepper/useTxStepper'
 
-const VerticalTxStepper = ({ steps, initialData, initialStep, onClose }: TxStepperProps): ReactElement => {
+const VerticalTxStepper = ({
+  steps,
+  initialData,
+  initialStep,
+  onClose,
+  eventCategory,
+}: TxStepperProps): ReactElement => {
   const { onBack, onSubmit, setStep, activeStep, stepData } = useTxStepper({
     steps,
     initialData,
     initialStep,
     onClose,
+    eventCategory,
   })
 
   return (


### PR DESCRIPTION
## What it solves

Related to #968 

## How this PR fixes it

- The vertical tx stepper passes the category parameter so that the creation flow uses the same `eventCategory` as the new safe creation flow

## How to test it

1. Open the safe with the AB test set to false
2. Navigate to `/welcome`
3. Create a new safe
4. Observe that the GTM events include `eventCategory: create-safe` instead of `modal`

## Analytics changes

- This will track all safe creation events under the same `eventCategory`