### PR TITLE
Fix: reload widget on safe change + catch errors

### DIFF
--- a/src/components/dashboard/GovernanceSection/styles.module.css
+++ b/src/components/dashboard/GovernanceSection/styles.module.css
@@ -23,25 +23,15 @@
   pointer-events: auto;
 }
 
-.loadErrorWrapper {
-  display: flex;
-}
-
-.widgetWrapper,
-.loadErrorWrapper {
+.widgetWrapper {
   border: none;
   height: 300px;
 }
 
 /* iframe sm breakpoint + paddings */
 @media (max-width: 662px) {
-  .widgetWrapper,
-  .loadErrorWrapper {
+  .widgetWrapper {
     height: 624px;
-  }
-
-  .loadErrorWrapper {
-    flex-direction: column;
   }
 }
 

--- a/src/components/safe-apps/AppFrame/SafeAppIframe.tsx
+++ b/src/components/safe-apps/AppFrame/SafeAppIframe.tsx
@@ -1,11 +1,11 @@
-import type { ReactElement } from 'react'
+import type { MutableRefObject, ReactElement } from 'react'
 import css from './styles.module.css'
 
 type SafeAppIFrameProps = {
   appUrl: string
   allowedFeaturesList: string
   title?: string
-  iframeRef?: React.MutableRefObject<HTMLIFrameElement | null>
+  iframeRef?: MutableRefObject<HTMLIFrameElement | null>
   onLoad?: () => void
 }
 


### PR DESCRIPTION
## What it solves

Resolves #1317

## How this PR fixes it

I've added a check for `safeLoading`, like in the big AppFrame. It will re-mount the component on Safe change.

Also an error fallback is now rendered if the manifest fails to load. I've adjusted the error fallback to only show the error message once for both widget. It makes little sense to have two of the same.