### PR TITLE
fix: Change banner to a notification

### DIFF
--- a/src/components/common/Notifications/index.tsx
+++ b/src/components/common/Notifications/index.tsx
@@ -12,6 +12,7 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
 import Track from '../Track'
 import { isRelativeUrl } from '@/utils/url'
+import classNames from 'classnames'
 
 const toastStyle = { position: 'static', margin: 1 }
 
@@ -50,6 +51,7 @@ const Toast = ({
   link,
   onClose,
   id,
+  autoHide = true,
 }: {
   variant: AlertColor
   onClose: () => void
@@ -70,7 +72,7 @@ const Toast = ({
   const autoHideDuration = variant === 'info' || variant === 'success' ? 5000 : undefined
 
   return (
-    <Snackbar open onClose={handleClose} sx={toastStyle} autoHideDuration={autoHideDuration}>
+    <Snackbar open onClose={handleClose} sx={toastStyle} autoHideDuration={autoHide ? autoHideDuration : null}>
       <Alert severity={variant} onClose={handleClose} elevation={3} sx={{ width: '340px' }}>
         {message}
 
@@ -98,6 +100,7 @@ const Notifications = (): ReactElement | null => {
 
   const handleClose = useCallback(
     (item: Notification) => {
+      item.onClose?.()
       dispatch(closeNotification(item))
     },
     [dispatch],
@@ -120,7 +123,7 @@ const Notifications = (): ReactElement | null => {
   return (
     <div className={css.container}>
       {visible.map((item) => (
-        <div className={css.row} key={item.id}>
+        <div className={classNames(css.row, { [css.banner]: item.isBanner })} key={item.id}>
           <Toast {...item} onClose={() => handleClose(item)} />
         </div>
       ))}

--- a/src/components/common/Notifications/styles.module.css
+++ b/src/components/common/Notifications/styles.module.css
@@ -1,8 +1,12 @@
 .container {
+  width: 100%;
+  padding: 0 var(--space-2);
   position: fixed;
-  top: var(--header-height);
+  top: calc(var(--header-height) / 2);
   right: 0;
   z-index: 2000;
+  display: flex;
+  flex-direction: column;
 }
 
 .row {
@@ -10,6 +14,16 @@
   display: flex;
   justify-content: flex-end;
   word-break: break-word;
+  align-self: flex-end;
+}
+
+.banner {
+  align-self: center;
+  max-width: 100%;
+}
+
+.banner :global .MuiPaper-root {
+  width: auto;
 }
 
 .link {

--- a/src/store/notificationsSlice.ts
+++ b/src/store/notificationsSlice.ts
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react'
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import type { AlertColor } from '@mui/material'
 import type { AppThunk, RootState } from '@/store'
@@ -5,7 +6,7 @@ import type { LinkProps } from 'next/link'
 
 export type Notification = {
   id: string
-  message: string
+  message: string | ReactElement
   detailedMessage?: string
   groupKey: string
   variant: AlertColor
@@ -13,6 +14,9 @@ export type Notification = {
   isDismissed?: boolean
   isRead?: boolean
   link?: { href: LinkProps['href']; title: string }
+  autoHide?: boolean
+  isBanner?: boolean
+  onClose?: () => void
 }
 
 export type NotificationState = Notification[]


### PR DESCRIPTION
## What it solves

Resolves #1202 

## How this PR fixes it

- Changes the `PsaBanner` to be a notification that is dispatched
- Extends `Notification` to allow disabling `autoHide`
- Extends `Notification` to allow a centered position and larger size for notifications through the `isBanner` argument
- Extends `Notification` to allow an `onClose` handler being passed

## How to test it

1. Open the Safe on Firefox in a private window
2. Observe that there is no banner that is overlapping the entire header anymore
3. Observe a notification popping up on the center screen
4. Create a transaction
5. Observe that those notifications still look and behave the same as before

## Screenshots
<img width="448" alt="Screenshot 2022-12-07 at 16 25 46" src="https://user-images.githubusercontent.com/5880855/206221370-8ea9ee40-3583-4052-ae2d-ac105ca666b1.png">
<img width="1512" alt="Screenshot 2022-12-07 at 16 25 38" src="https://user-images.githubusercontent.com/5880855/206221374-6caf619e-ee6b-4efc-af1d-9b26f7f6a869.png">
