### PR TITLE
Adjust safe token widget allocation formula

### DIFF
--- a/src/components/common/SafeTokenWidget/__tests__/SafeTokenWidget.test.tsx
+++ b/src/components/common/SafeTokenWidget/__tests__/SafeTokenWidget.test.tsx
@@ -1,4 +1,3 @@
-import * as useBalances from '@/hooks/useBalances'
 import * as nextRouter from 'next/router'
 import useChainId from '@/hooks/useChainId'
 import { render, waitFor } from '@/tests/test-utils'
@@ -53,29 +52,21 @@ describe('SafeTokenWidget', () => {
 
   it('Should render nothing for unsupported chains', () => {
     ;(useChainId as jest.Mock).mockImplementationOnce(jest.fn(() => '100'))
-
-    jest.spyOn(useBalances, 'default').mockImplementation(() => ({
-      balances: {
-        fiatTotal: '0',
-        items: [],
-      },
-      loading: true,
-      error: undefined,
-    }))
+    ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [BigNumber.from(0), false])
 
     const result = render(<SafeTokenWidget />)
     expect(result.baseElement).toContainHTML('<body><div /></body>')
   })
 
   it('Should display 0 if Safe has no SAFE token', async () => {
-    ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => BigNumber.from(0))
+    ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [BigNumber.from(0), false])
 
     const result = render(<SafeTokenWidget />)
     await waitFor(() => expect(result.baseElement).toHaveTextContent('0'))
   })
 
   it('Should display the value formatted correctly', async () => {
-    ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => BigNumber.from('472238796133701648384'))
+    ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [BigNumber.from('472238796133701648384'), false])
 
     // to avoid failing tests in some environments
     const NumberFormat = Intl.NumberFormat
@@ -91,7 +82,7 @@ describe('SafeTokenWidget', () => {
   })
 
   it('Should render a link to the claiming app', async () => {
-    ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => BigNumber.from(420000))
+    ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [BigNumber.from(420000), false])
 
     const result = render(<SafeTokenWidget />)
     await waitFor(() => {

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -5,7 +5,8 @@ import useChainId from '@/hooks/useChainId'
 import useSafeTokenAllocation from '@/hooks/useSafeTokenAllocation'
 import { OVERVIEW_EVENTS } from '@/services/analytics'
 import { formatVisualAmount } from '@/utils/formatters'
-import { Box, ButtonBase, Tooltip, Typography } from '@mui/material'
+import { Box, ButtonBase, Skeleton, Tooltip, Typography } from '@mui/material'
+import { BigNumber } from 'ethers'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import type { UrlObject } from 'url'
@@ -25,10 +26,10 @@ const SafeTokenWidget = () => {
   const [apps] = useRemoteSafeApps(SafeAppsTag.SAFE_CLAIMING_APP)
   const claimingApp = apps?.[0]
 
-  const allocation = useSafeTokenAllocation()
+  const [allocation, allocationLoading] = useSafeTokenAllocation()
 
   const tokenAddress = getSafeTokenAddress(chainId)
-  if (!tokenAddress || !allocation) {
+  if (!tokenAddress) {
     return null
   }
 
@@ -39,7 +40,7 @@ const SafeTokenWidget = () => {
       }
     : undefined
 
-  const flooredSafeBalance = formatVisualAmount(allocation, TOKEN_DECIMALS, 2)
+  const flooredSafeBalance = formatVisualAmount(allocation || BigNumber.from(0), TOKEN_DECIMALS, 2)
 
   return (
     <Box className={css.buttonContainer}>
@@ -54,8 +55,8 @@ const SafeTokenWidget = () => {
                 disabled={url === undefined}
               >
                 <SafeTokenIcon />
-                <Typography lineHeight="16px" fontWeight={700}>
-                  {flooredSafeBalance}
+                <Typography component="div" lineHeight="16px" fontWeight={700}>
+                  {allocationLoading ? <Skeleton width="16px" animation="wave" /> : flooredSafeBalance}
                 </Typography>
               </ButtonBase>
             </Link>

--- a/src/hooks/__tests__/useSafeTokenAllocation.test.ts
+++ b/src/hooks/__tests__/useSafeTokenAllocation.test.ts
@@ -1,8 +1,10 @@
 import { renderHook, waitFor } from '@/tests/test-utils'
-import { hexZeroPad, keccak256, parseEther, toUtf8Bytes } from 'ethers/lib/utils'
+import { defaultAbiCoder, hexZeroPad, keccak256, parseEther, toUtf8Bytes } from 'ethers/lib/utils'
 import useSafeTokenAllocation from '../useSafeTokenAllocation'
 import * as web3 from '../wallets/web3'
 import * as useSafeInfoHook from '@/hooks/useSafeInfo'
+import { ZERO_ADDRESS } from '@safe-global/safe-core-sdk/dist/src/utils/constants'
+import { BigNumber } from 'ethers'
 
 const setupFetchStub =
   (data: any, status: number = 200) =>
@@ -70,6 +72,8 @@ describe('useSafeTokenAllocation', () => {
 
   test('return 0 if no allocations / balances exist', async () => {
     global.fetch = jest.fn().mockImplementation(setupFetchStub('', 404))
+    const mockFetch = jest.spyOn(global, 'fetch')
+
     jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
       () =>
         ({
@@ -83,11 +87,10 @@ describe('useSafeTokenAllocation', () => {
         } as any),
     )
 
-    const mockFetch = jest.spyOn(global, 'fetch')
-
     const { result } = renderHook(() => useSafeTokenAllocation())
 
     await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled()
       expect(result.current[0]?.toNumber()).toEqual(0)
       expect(result.current[1]).toBeFalsy()
     })
@@ -95,6 +98,8 @@ describe('useSafeTokenAllocation', () => {
 
   test('return balance if no allocation exists', async () => {
     global.fetch = jest.fn().mockImplementation(setupFetchStub('', 404))
+    const mockFetch = jest.spyOn(global, 'fetch')
+
     jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
       () =>
         ({
@@ -108,13 +113,288 @@ describe('useSafeTokenAllocation', () => {
         } as any),
     )
 
+    const { result } = renderHook(() => useSafeTokenAllocation())
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled()
+      expect(result.current[0]?.eq(parseEther('100'))).toBeTruthy()
+      expect(result.current[1]).toBeFalsy()
+    })
+  })
+
+  test('always return allocation if it is rededeemed', async () => {
+    const mockAllocation = [
+      {
+        tag: 'user',
+        account: hexZeroPad('0x2', 20),
+        chainId: 1,
+        contract: hexZeroPad('0xabc', 20),
+        vestingId: hexZeroPad('0x4110', 32),
+        durationWeeks: 208,
+        startDate: 1657231200,
+        amount: '2000',
+        curve: 0,
+        proof: [],
+      },
+    ]
+
+    global.fetch = jest.fn().mockImplementation(setupFetchStub(mockAllocation, 200))
     const mockFetch = jest.spyOn(global, 'fetch')
+
+    jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
+      () =>
+        ({
+          call: (transaction: any, blockTag?: any) => {
+            const balanceOfSigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
+            const vestingsSigHash = keccak256(toUtf8Bytes('vestings(bytes32)')).slice(0, 10)
+
+            if (transaction.data?.startsWith(balanceOfSigHash)) {
+              return Promise.resolve(parseEther('0').toHexString())
+            }
+            if (transaction.data?.startsWith(vestingsSigHash)) {
+              return Promise.resolve(
+                defaultAbiCoder.encode(
+                  ['address', 'uint8', 'bool', 'uint16', 'uint64', 'uint128', 'uint128', 'uint64', 'bool'],
+                  [hexZeroPad('0x2', 20), '0x1', false, 208, 1657231200, 2000, 0, 0, false],
+                ),
+              )
+            }
+            return Promise.resolve('0x')
+          },
+        } as any),
+    )
 
     const { result } = renderHook(() => useSafeTokenAllocation())
 
     await waitFor(() => {
-      console.log(result.current[0]?.toString())
-      expect(result.current[0]?.eq(parseEther('100'))).toBeTruthy()
+      expect(mockFetch).toHaveBeenCalled()
+      expect(result.current[0]?.toNumber()).toEqual(2000)
+      expect(result.current[1]).toBeFalsy()
+    })
+  })
+
+  test('ignore not redeemed allocations if deadline has passed', async () => {
+    const mockAllocation = [
+      {
+        tag: 'user',
+        account: hexZeroPad('0x2', 20),
+        chainId: 1,
+        contract: hexZeroPad('0xabc', 20),
+        vestingId: hexZeroPad('0x4110', 32),
+        durationWeeks: 208,
+        startDate: 1657231200,
+        amount: '2000',
+        curve: 0,
+        proof: [],
+      },
+    ]
+
+    global.fetch = jest.fn().mockImplementation(setupFetchStub(mockAllocation, 200))
+    const mockFetch = jest.spyOn(global, 'fetch')
+
+    jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
+      () =>
+        ({
+          call: (transaction: any, blockTag?: any) => {
+            const balanceOfSigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
+            const vestingsSigHash = keccak256(toUtf8Bytes('vestings(bytes32)')).slice(0, 10)
+            const redeemDeadlineSigHash = keccak256(toUtf8Bytes('redeemDeadline()')).slice(0, 10)
+
+            if (transaction.data?.startsWith(balanceOfSigHash)) {
+              return Promise.resolve(parseEther('0').toHexString())
+            }
+            if (transaction.data?.startsWith(vestingsSigHash)) {
+              return Promise.resolve(
+                defaultAbiCoder.encode(
+                  ['address', 'uint8', 'bool', 'uint16', 'uint64', 'uint128', 'uint128', 'uint64', 'bool'],
+                  [ZERO_ADDRESS, 0, false, 0, 0, 0, 0, 0, false],
+                ),
+              )
+            }
+            if (transaction.data?.startsWith(redeemDeadlineSigHash)) {
+              // 30th Nov 2022
+              return Promise.resolve(defaultAbiCoder.encode(['uint64'], [1669766400]))
+            }
+            return Promise.resolve('0x')
+          },
+        } as any),
+    )
+
+    const { result } = renderHook(() => useSafeTokenAllocation())
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled()
+      expect(result.current[0]?.toNumber()).toEqual(0)
+      expect(result.current[1]).toBeFalsy()
+    })
+  })
+
+  test('add not redeemed allocations if deadline has not passed', async () => {
+    const mockAllocation = [
+      {
+        tag: 'user',
+        account: hexZeroPad('0x2', 20),
+        chainId: 1,
+        contract: hexZeroPad('0xabc', 20),
+        vestingId: hexZeroPad('0x4110', 32),
+        durationWeeks: 208,
+        startDate: 1657231200,
+        amount: '2000',
+        curve: 0,
+        proof: [],
+      },
+    ]
+
+    global.fetch = jest.fn().mockImplementation(setupFetchStub(mockAllocation, 200))
+    const mockFetch = jest.spyOn(global, 'fetch')
+
+    jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
+      () =>
+        ({
+          call: (transaction: any, blockTag?: any) => {
+            const balanceOfSigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
+            const vestingsSigHash = keccak256(toUtf8Bytes('vestings(bytes32)')).slice(0, 10)
+            const redeemDeadlineSigHash = keccak256(toUtf8Bytes('redeemDeadline()')).slice(0, 10)
+
+            if (transaction.data?.startsWith(balanceOfSigHash)) {
+              return Promise.resolve(parseEther('0').toHexString())
+            }
+            if (transaction.data?.startsWith(vestingsSigHash)) {
+              return Promise.resolve(
+                defaultAbiCoder.encode(
+                  ['address', 'uint8', 'bool', 'uint16', 'uint64', 'uint128', 'uint128', 'uint64', 'bool'],
+                  [ZERO_ADDRESS, 0, false, 0, 0, 0, 0, 0, false],
+                ),
+              )
+            }
+            if (transaction.data?.startsWith(redeemDeadlineSigHash)) {
+              // 08.Dec 2200
+              return Promise.resolve(defaultAbiCoder.encode(['uint64'], [7287610110]))
+            }
+            return Promise.resolve('0x')
+          },
+        } as any),
+    )
+
+    const { result } = renderHook(() => useSafeTokenAllocation())
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled()
+      expect(result.current[0]?.toNumber()).toEqual(2000)
+      expect(result.current[1]).toBeFalsy()
+    })
+  })
+
+  test('test formula: allocation - claimed + balance', async () => {
+    const mockAllocation = [
+      {
+        tag: 'user',
+        account: hexZeroPad('0x2', 20),
+        chainId: 1,
+        contract: hexZeroPad('0xabc', 20),
+        vestingId: hexZeroPad('0x4110', 32),
+        durationWeeks: 208,
+        startDate: 1657231200,
+        amount: '2000',
+        curve: 0,
+        proof: [],
+      },
+    ]
+
+    global.fetch = jest.fn().mockImplementation(setupFetchStub(mockAllocation, 200))
+    const mockFetch = jest.spyOn(global, 'fetch')
+
+    jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
+      () =>
+        ({
+          call: (transaction: any, blockTag?: any) => {
+            const balanceOfSigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
+            const vestingsSigHash = keccak256(toUtf8Bytes('vestings(bytes32)')).slice(0, 10)
+            const redeemDeadlineSigHash = keccak256(toUtf8Bytes('redeemDeadline()')).slice(0, 10)
+
+            if (transaction.data?.startsWith(balanceOfSigHash)) {
+              return Promise.resolve(BigNumber.from('400').toHexString())
+            }
+            if (transaction.data?.startsWith(vestingsSigHash)) {
+              return Promise.resolve(
+                defaultAbiCoder.encode(
+                  ['address', 'uint8', 'bool', 'uint16', 'uint64', 'uint128', 'uint128', 'uint64', 'bool'],
+                  // 1000 of 2000 tokens are claimed
+                  [hexZeroPad('0x2', 20), '0x1', false, 208, 1657231200, 2000, 1000, 0, false],
+                ),
+              )
+            }
+            if (transaction.data?.startsWith(redeemDeadlineSigHash)) {
+              // 08.Dec 2200
+              return Promise.resolve(defaultAbiCoder.encode(['uint64'], [7287610110]))
+            }
+            return Promise.resolve('0x')
+          },
+        } as any),
+    )
+
+    const { result } = renderHook(() => useSafeTokenAllocation())
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled()
+      expect(result.current[0]?.toNumber()).toEqual(2000 - 1000 + 400)
+      expect(result.current[1]).toBeFalsy()
+    })
+  })
+
+  test('test formula: allocation - claimed + balance, everything claimed and no balance', async () => {
+    const mockAllocation = [
+      {
+        tag: 'user',
+        account: hexZeroPad('0x2', 20),
+        chainId: 1,
+        contract: hexZeroPad('0xabc', 20),
+        vestingId: hexZeroPad('0x4110', 32),
+        durationWeeks: 208,
+        startDate: 1657231200,
+        amount: '2000',
+        curve: 0,
+        proof: [],
+      },
+    ]
+
+    global.fetch = jest.fn().mockImplementation(setupFetchStub(mockAllocation, 200))
+    const mockFetch = jest.spyOn(global, 'fetch')
+
+    jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
+      () =>
+        ({
+          call: (transaction: any, blockTag?: any) => {
+            const balanceOfSigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
+            const vestingsSigHash = keccak256(toUtf8Bytes('vestings(bytes32)')).slice(0, 10)
+            const redeemDeadlineSigHash = keccak256(toUtf8Bytes('redeemDeadline()')).slice(0, 10)
+
+            if (transaction.data?.startsWith(balanceOfSigHash)) {
+              return Promise.resolve(BigNumber.from('0').toHexString())
+            }
+            if (transaction.data?.startsWith(vestingsSigHash)) {
+              return Promise.resolve(
+                defaultAbiCoder.encode(
+                  ['address', 'uint8', 'bool', 'uint16', 'uint64', 'uint128', 'uint128', 'uint64', 'bool'],
+                  // 1000 of 2000 tokens are claimed
+                  [hexZeroPad('0x2', 20), '0x1', false, 208, 1657231200, 2000, 2000, 0, false],
+                ),
+              )
+            }
+            if (transaction.data?.startsWith(redeemDeadlineSigHash)) {
+              // 08.Dec 2200
+              return Promise.resolve(defaultAbiCoder.encode(['uint64'], [7287610110]))
+            }
+            return Promise.resolve('0x')
+          },
+        } as any),
+    )
+
+    const { result } = renderHook(() => useSafeTokenAllocation())
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled()
+      expect(result.current[0]?.toNumber()).toEqual(0)
       expect(result.current[1]).toBeFalsy()
     })
   })

--- a/src/hooks/__tests__/useSafeTokenAllocation.test.ts
+++ b/src/hooks/__tests__/useSafeTokenAllocation.test.ts
@@ -1,0 +1,121 @@
+import { renderHook, waitFor } from '@/tests/test-utils'
+import { hexZeroPad, keccak256, parseEther, toUtf8Bytes } from 'ethers/lib/utils'
+import useSafeTokenAllocation from '../useSafeTokenAllocation'
+import * as web3 from '../wallets/web3'
+import * as useSafeInfoHook from '@/hooks/useSafeInfo'
+
+const setupFetchStub =
+  (data: any, status: number = 200) =>
+  (_url: string) => {
+    return Promise.resolve({
+      json: () => Promise.resolve(data),
+      status,
+      ok: status === 200,
+    })
+  }
+
+describe('useSafeTokenAllocation', () => {
+  afterEach(() => {
+    //@ts-ignore
+    global.fetch?.mockClear?.()
+  })
+
+  afterAll(() => {
+    // @ts-ignore
+    delete global.fetch
+  })
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    jest.spyOn(useSafeInfoHook, 'default').mockImplementation(
+      () =>
+        ({
+          safeAddress: hexZeroPad('0x2', 20),
+          safe: {
+            address: hexZeroPad('0x2', 20),
+            chainId: '1',
+          },
+        } as any),
+    )
+  })
+
+  test('return undefined without safe address', async () => {
+    jest.spyOn(useSafeInfoHook, 'default').mockImplementation(
+      () =>
+        ({
+          safeAddress: undefined,
+          safe: {
+            address: undefined,
+            chainId: '1',
+          },
+        } as any),
+    )
+
+    const { result } = renderHook(() => useSafeTokenAllocation())
+
+    await waitFor(() => {
+      expect(result.current[1]).toBeFalsy()
+      expect(result.current[0]).toBeUndefined()
+    })
+  })
+
+  test('return 0 without web3Provider', async () => {
+    const { result } = renderHook(() => useSafeTokenAllocation())
+
+    await waitFor(() => {
+      expect(result.current[1]).toBeFalsy()
+      expect(result.current[0]?.toNumber()).toEqual(0)
+    })
+  })
+
+  test('return 0 if no allocations / balances exist', async () => {
+    global.fetch = jest.fn().mockImplementation(setupFetchStub('', 404))
+    jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
+      () =>
+        ({
+          call: (transaction: any, blockTag?: any) => {
+            const sigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
+            if (transaction.data?.startsWith(sigHash)) {
+              return Promise.resolve('0x0')
+            }
+            return Promise.resolve('0x')
+          },
+        } as any),
+    )
+
+    const mockFetch = jest.spyOn(global, 'fetch')
+
+    const { result } = renderHook(() => useSafeTokenAllocation())
+
+    await waitFor(() => {
+      expect(result.current[0]?.toNumber()).toEqual(0)
+      expect(result.current[1]).toBeFalsy()
+    })
+  })
+
+  test('return balance if no allocation exists', async () => {
+    global.fetch = jest.fn().mockImplementation(setupFetchStub('', 404))
+    jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
+      () =>
+        ({
+          call: (transaction: any, blockTag?: any) => {
+            const sigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
+            if (transaction.data?.startsWith(sigHash)) {
+              return Promise.resolve(parseEther('100').toHexString())
+            }
+            return Promise.resolve('0x')
+          },
+        } as any),
+    )
+
+    const mockFetch = jest.spyOn(global, 'fetch')
+
+    const { result } = renderHook(() => useSafeTokenAllocation())
+
+    await waitFor(() => {
+      console.log(result.current[0]?.toString())
+      expect(result.current[0]?.eq(parseEther('100'))).toBeTruthy()
+      expect(result.current[1]).toBeFalsy()
+    })
+  })
+})

--- a/src/hooks/useSafeTokenAllocation.ts
+++ b/src/hooks/useSafeTokenAllocation.ts
@@ -1,7 +1,12 @@
+import { getSafeTokenAddress } from '@/components/common/SafeTokenWidget'
+import { ZERO_ADDRESS } from '@safe-global/safe-core-sdk/dist/src/utils/constants'
+import { isPast } from 'date-fns'
 import { BigNumber } from 'ethers'
-import { useEffect, useState } from 'react'
+import { defaultAbiCoder, Interface } from 'ethers/lib/utils'
+import { useMemo } from 'react'
 import useAsync from './useAsync'
 import useSafeInfo from './useSafeInfo'
+import { getWeb3ReadOnly } from './wallets/web3'
 
 export const VESTING_URL = 'https://safe-claiming-app-data.gnosis-safe.io/allocations/'
 
@@ -16,6 +21,61 @@ type VestingData = {
   amount: string
   curve: 0 | 1
   proof: string[]
+}
+
+type Vesting = VestingData & {
+  isExpired: boolean
+  claimedTokens: string
+}
+
+// We currently do not have typechain as dependency so we fallback to human readable ABIs
+const airdropInterface = new Interface([
+  'function redeemDeadline() public returns (uint64)',
+  'function vestings(bytes32) public returns ({address account, uint8 curveType,bool managed, uint16 durationWeeks, uint64 startDate, uint128 amount, uint128 amountClaimed, uint64 pausingDate,bool cancelled})',
+])
+const tokenInterface = new Interface(['function balanceOf(address _owner) public view returns (uint256 balance)'])
+
+/**
+ * Add on-chain information to allocation.
+ * Fetches if a the redeem deadline is expired and the claimed tokens from on-chain
+ */
+const completeAllocation = async (allocation: VestingData): Promise<Vesting> => {
+  const web3ReadOnly = getWeb3ReadOnly()
+  if (!web3ReadOnly) {
+    throw new Error('Cannot fetch vesting without web3 provider')
+  }
+  const onChainVestingData = await web3ReadOnly?.call({
+    to: allocation.contract,
+    data: airdropInterface.encodeFunctionData('vestings', [allocation.vestingId]),
+  })
+
+  if (!onChainVestingData) {
+    throw new Error(`Could not load vesting information for vesting with id ${allocation.vestingId}`)
+  }
+
+  const decodedVestingData = defaultAbiCoder.decode(
+    ['address', 'uint8', 'bool', 'uint16', 'uint64', 'uint128', 'uint128', 'uint64', 'bool'],
+    onChainVestingData,
+  )
+  if (decodedVestingData[0].toLowerCase() !== ZERO_ADDRESS.toLowerCase()) {
+    // allocation is redeemed, return the amountClaimed from on-chain
+    return { ...allocation, isExpired: false, claimedTokens: decodedVestingData[6] }
+  }
+
+  // Allocation is not yet redeemed => check the redeemDeadline
+  const redeemDeadline = await web3ReadOnly?.call({
+    to: allocation.contract,
+    data: airdropInterface.encodeFunctionData('redeemDeadline'),
+  })
+
+  if (!redeemDeadline) {
+    throw new Error(`No redeemDeadline found for contract ${allocation.contract}`)
+  }
+
+  const redeemDeadlineDate = new Date(BigNumber.from(redeemDeadline).mul(1000).toNumber())
+
+  // Allocation is valid if redeem deadline is in future
+  return { ...allocation, isExpired: isPast(redeemDeadlineDate), claimedTokens: '0' }
 }
 
 const fetchAllocation = async (chainId: string, safeAddress: string): Promise<VestingData[]> => {
@@ -39,25 +99,65 @@ const fetchAllocation = async (chainId: string, safeAddress: string): Promise<Ve
   }
 }
 
-const useSafeTokenAllocation = (): BigNumber | undefined => {
-  const [allocation, setAllocation] = useState<BigNumber>()
+const fetchTokenBalance = async (chainId: string, safeAddress: string): Promise<string> => {
+  try {
+    const web3ReadOnly = getWeb3ReadOnly()
+    const safeTokenAddress = getSafeTokenAddress(chainId)
+    if (!safeTokenAddress || !web3ReadOnly) return '0'
+
+    const tokenBalance = await web3ReadOnly?.call({
+      to: safeTokenAddress,
+      data: tokenInterface.encodeFunctionData('balanceOf', [safeAddress]),
+    })
+
+    console.log('Token balance', tokenBalance)
+
+    return tokenBalance || '0'
+  } catch (err) {
+    throw Error(`Error fetching Safe token balance:  ${err}`)
+  }
+}
+
+/**
+ * The Safe token allocation is equal to the voting power.
+ * It is computed by adding all vested tokens - claimed tokens + token balance
+ */
+const useSafeTokenAllocation = (): [BigNumber | undefined, boolean] => {
   const { safe, safeAddress } = useSafeInfo()
   const chainId = safe.chainId
 
-  const [allocationData] = useAsync<VestingData[]>(() => {
+  const [allocationData, _, allocationLoading] = useAsync<Vesting[] | undefined>(async () => {
     if (!safeAddress) return
-    return fetchAllocation(chainId, safeAddress)
-  }, [chainId, safeAddress])
+    const allocations = await Promise.all(
+      await fetchAllocation(chainId, safeAddress).then((allocations) =>
+        allocations.map((allocation) => completeAllocation(allocation)),
+      ),
+    )
+    return allocations
+    // If the history tag changes we could have claimed / redeemed tokens
+  }, [chainId, safeAddress, safe.txHistoryTag])
 
-  useEffect(() => {
-    if (!allocationData) return
+  const [balance, _error, balanceLoading] = useAsync<string>(() => {
+    if (!safeAddress) return
+    return fetchTokenBalance(chainId, safeAddress)
+    // If the history tag changes we could have claimed / redeemed tokens
+  }, [chainId, safeAddress, safe.txHistoryTag])
 
-    const totalAllocation = allocationData.reduce((acc, data) => acc.add(data.amount), BigNumber.from(0))
+  const allocation = useMemo(() => {
+    if (!allocationData && !balance) return
 
-    setAllocation(totalAllocation)
-  }, [allocationData])
+    const tokensInVesting =
+      allocationData?.reduce(
+        (acc, data) => (data.isExpired ? acc : acc.add(data.amount).sub(data.claimedTokens)),
+        BigNumber.from(0),
+      ) || BigNumber.from(0)
 
-  return allocation
+    // add balance
+    const totalAllocation = tokensInVesting.add(balance || '0')
+    return totalAllocation
+  }, [allocationData, balance])
+
+  return [allocation, allocationLoading || balanceLoading]
 }
 
 export default useSafeTokenAllocation

--- a/src/hooks/useSafeTokenAllocation.ts
+++ b/src/hooks/useSafeTokenAllocation.ts
@@ -110,8 +110,6 @@ const fetchTokenBalance = async (chainId: string, safeAddress: string): Promise<
       data: tokenInterface.encodeFunctionData('balanceOf', [safeAddress]),
     })
 
-    console.log('Token balance', tokenBalance)
-
     return tokenBalance || '0'
   } catch (err) {
     throw Error(`Error fetching Safe token balance:  ${err}`)

--- a/src/hooks/useSafeTokenAllocation.ts
+++ b/src/hooks/useSafeTokenAllocation.ts
@@ -99,12 +99,10 @@ const fetchTokenBalance = async (chainId: string, safeAddress: string): Promise<
     const safeTokenAddress = getSafeTokenAddress(chainId)
     if (!safeTokenAddress || !web3ReadOnly) return '0'
 
-    const tokenBalance = await web3ReadOnly.call({
+    return await web3ReadOnly.call({
       to: safeTokenAddress,
       data: tokenInterface.encodeFunctionData('balanceOf', [safeAddress]),
     })
-
-    return tokenBalance
   } catch (err) {
     throw Error(`Error fetching Safe token balance:  ${err}`)
   }
@@ -137,11 +135,10 @@ const useSafeTokenAllocation = (): [BigNumber | undefined, boolean] => {
   const allocation = useMemo(() => {
     if (!allocationData || !balance) return
 
-    const tokensInVesting =
-      allocationData?.reduce(
-        (acc, data) => (data.isExpired ? acc : acc.add(data.amount).sub(data.amountClaimed)),
-        BigNumber.from(0),
-      ) || BigNumber.from(0)
+    const tokensInVesting = allocationData.reduce(
+      (acc, data) => (data.isExpired ? acc : acc.add(data.amount).sub(data.amountClaimed)),
+      BigNumber.from(0),
+    )
 
     // add balance
     const totalAllocation = tokensInVesting.add(balance || '0')


### PR DESCRIPTION
## What it solves
The token widget did not take token balance and the redeem deadline into account.

## TODOs
- [x] add more tests
- [x] Port the hook + tests into the safe claiming app

Resolves #1208 

## How this PR fixes it
Adjusts the formula to `totalAllocation - tokensClaimed + balance`
When computing the total allocation after the `redeemDeadline` has passed we ignore unredeemed allocations.

## How to test it
- On görli the redeem deadline was on 30th of November, meaning unredeemed allocations should not be counted anymore:
  - Safe with only user airdrop but not ecosystem airdrop redeemed `gor:0x5f310dc66F4ecDE9a1769f1B7D75224dA592201e`
- On mainnet this date is on the 27th of Dec

## Analytics changes
None
