### PR TITLE
fix: allow resetting to recommended nonce of 0

### DIFF
--- a/src/components/tx/NonceForm/index.tsx
+++ b/src/components/tx/NonceForm/index.tsx
@@ -89,7 +89,7 @@ const NonceForm = ({ name, nonce, recommendedNonce, readonly }: NonceFormProps):
   const label = fieldState.error?.message || nonceWarning || 'Safe transaction nonce'
 
   const onResetNonce = () => {
-    if (recommendedNonce) {
+    if (typeof recommendedNonce === 'number') {
       setValue(name, recommendedNonce, { shouldValidate: true })
     }
   }

--- a/src/components/tx/NonceForm/index.tsx
+++ b/src/components/tx/NonceForm/index.tsx
@@ -89,7 +89,7 @@ const NonceForm = ({ name, nonce, recommendedNonce, readonly }: NonceFormProps):
   const label = fieldState.error?.message || nonceWarning || 'Safe transaction nonce'
 
   const onResetNonce = () => {
-    if (typeof recommendedNonce === 'number') {
+    if (recommendedNonce != null) {
       setValue(name, recommendedNonce, { shouldValidate: true })
     }
   }


### PR DESCRIPTION
## What it solves

Resolves #1311

## How this PR fixes it

The `typeof  recommendedNonce` is checked that it is a `'number'` instead of whether it is truthy.

## How to test it

1. Create a new Safe and create a new transaction.
2. Edit the nonce to >0 and reset the nonce to the recommended value.
3. Observe that it sets to 0.

## Screenshots

![recommended nonce](https://user-images.githubusercontent.com/20442784/206437277-5e46d979-0c3b-4c67-bd27-29c4cd962726.gif)