### PR TITLE
fix: alter threshold change warning text

### DIFF
--- a/src/components/transactions/TxDetails/TxData/SettingsChange/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/SettingsChange/index.tsx
@@ -46,7 +46,7 @@ export const SettingsChangeTxInfo = ({ settingsInfo }: SettingsChangeTxInfoProps
               customAvatar={settingsInfo.owner?.logoUri}
               {...addressInfoProps}
             />
-            <InfoDetails title="Increase/decrease confirmation policy to:">{settingsInfo.threshold}</InfoDetails>
+            <InfoDetails title="Required confirmations for new transactions:">{settingsInfo.threshold}</InfoDetails>
           </InfoDetails>
         </>
       )
@@ -77,7 +77,7 @@ export const SettingsChangeTxInfo = ({ settingsInfo }: SettingsChangeTxInfoProps
       return (
         <>
           <ThresholdWarning />
-          <InfoDetails title="Increase/decrease confirmation policy to:">{settingsInfo.threshold}</InfoDetails>
+          <InfoDetails title="Required confirmations for new transactions:">{settingsInfo.threshold}</InfoDetails>
         </>
       )
     }

--- a/src/components/transactions/Warning/index.tsx
+++ b/src/components/transactions/Warning/index.tsx
@@ -55,7 +55,7 @@ export const DelegateCallWarning = ({ showWarning }: { showWarning: boolean }): 
 
 export const ThresholdWarning = (): ReactElement => (
   <Warning
-    title="This transaction potentially alters the number of confirmations required to execute a transaction."
+    title="This transaction potentially alters the number of confirmations required to execute a transaction. Please verify before signing."
     severity="warning"
     text="Confirmation policy change"
   />


### PR DESCRIPTION
## What it solves

Resolves #1328

## How this PR fixes it

The transaction details of threshold altering transactions has been changed from "Increase/decrease confirmation policy to:" to "Required confirmations for new transactions:". The associated tooltip from "This transaction potentially alters the number of confirmations required to execute a transaction." to "This transaction potentially alters the number of confirmations required to execute a transaction. Please verify before signing."

## How to test it

Create a transaction that alters the threshold of the Safe and observe the new details/tooltip.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/206496139-e8874989-4d79-43d2-80f4-ce4be68b1e9b.png)