### PR TITLE
fix: Change status colors in safe creation

### DIFF
--- a/src/components/new-safe/steps/Step4/StatusMessage.tsx
+++ b/src/components/new-safe/steps/Step4/StatusMessage.tsx
@@ -58,7 +58,7 @@ const getStep = (status: SafeCreationStatus) => {
 const StatusMessage = ({ status, isError }: { status: SafeCreationStatus; isError: boolean }) => {
   const stepInfo = getStep(status)
 
-  const color = isError ? 'success' : 'warning'
+  const color = isError ? 'error' : 'info'
 
   return (
     <>


### PR DESCRIPTION
## What it solves

Resolves #1299 

## How this PR fixes it

- Error color on the status screen is now red instead of green
- Every other status is now colored blue instead of orange

## How to test it

1. Open the new safe creation flow
2. Submit the form
3. Observe a blue status message
4. Reject the transaction
5. Observe a red status message

## Screenshots
<img width="795" alt="Screenshot 2022-12-09 at 12 20 46" src="https://user-images.githubusercontent.com/5880855/206691576-9b275703-138c-4c5c-8c63-eb4a23c97319.png">
<img width="798" alt="Screenshot 2022-12-09 at 12 20 42" src="https://user-images.githubusercontent.com/5880855/206691582-68fd5fa0-45aa-4ffc-9235-961e78dd13e3.png">
