### PR TITLE
fix: adjust text of buttons in transfer modal

### DIFF
--- a/src/components/tx/modals/NewTxModal/ReplacementModal.tsx
+++ b/src/components/tx/modals/NewTxModal/ReplacementModal.tsx
@@ -101,7 +101,7 @@ const ReplacementModal = ({
         <Grid container alignItems="center" justifyContent="center" flexDirection={flexDirection}>
           <Grid item xs={12}>
             <Typography variant="body2" textAlign="center" fontWeight={700} mb={3}>
-              Select how would you like to replace this transaction
+              Select how you would like to replace this transaction
             </Typography>
           </Grid>
           <Grid

--- a/src/components/tx/modals/NewTxModal/ReplacementModal.tsx
+++ b/src/components/tx/modals/NewTxModal/ReplacementModal.tsx
@@ -101,7 +101,7 @@ const ReplacementModal = ({
         <Grid container alignItems="center" justifyContent="center" flexDirection={flexDirection}>
           <Grid item xs={12}>
             <Typography variant="body2" textAlign="center" fontWeight={700} mb={3}>
-              Select the type of replacement transaction
+              Select how would you like to replace this transaction
             </Typography>
           </Grid>
           <Grid
@@ -139,7 +139,7 @@ const ReplacementModal = ({
               placement="top"
               title={canCancel ? '' : `Transaction with nonce ${txNonce} already has a reject transaction`}
             >
-              <span>
+              <span style={{ width: '100%' }}>
                 <Button
                   onClick={onRejectModalOpen}
                   variant="outlined"
@@ -147,7 +147,7 @@ const ReplacementModal = ({
                   sx={{ mb: 1, ...btnWidth }}
                   disabled={!canCancel}
                 >
-                  Rejection transaction
+                  Reject transaction
                 </Button>
               </span>
             </Tooltip>

--- a/src/components/tx/modals/NewTxModal/TxButton.tsx
+++ b/src/components/tx/modals/NewTxModal/TxButton.tsx
@@ -10,13 +10,13 @@ const TxButton = ({ sx, ...props }: ButtonProps) => (
 
 export const SendTokensButton = ({ onClick, ...props }: ButtonProps) => (
   <TxButton onClick={onClick} startIcon={<SvgIcon component={AssetsIcon} inheritViewBox />} {...props}>
-    Send tokens
+    Token transfer
   </TxButton>
 )
 
 export const SendNFTsButton = ({ onClick, ...props }: ButtonProps) => (
   <TxButton onClick={onClick} startIcon={<SvgIcon component={NftIcon} inheritViewBox />} {...props}>
-    Send NFTs
+    NFT transfer
   </TxButton>
 )
 

--- a/src/components/tx/modals/NewTxModal/TxButton.tsx
+++ b/src/components/tx/modals/NewTxModal/TxButton.tsx
@@ -10,13 +10,13 @@ const TxButton = ({ sx, ...props }: ButtonProps) => (
 
 export const SendTokensButton = ({ onClick, ...props }: ButtonProps) => (
   <TxButton onClick={onClick} startIcon={<SvgIcon component={AssetsIcon} inheritViewBox />} {...props}>
-    Token transfer
+    Send tokens
   </TxButton>
 )
 
 export const SendNFTsButton = ({ onClick, ...props }: ButtonProps) => (
   <TxButton onClick={onClick} startIcon={<SvgIcon component={NftIcon} inheritViewBox />} {...props}>
-    NFT transfer
+    Send NFTs
   </TxButton>
 )
 


### PR DESCRIPTION
## What it solves

Mixture of nouns and verbs in the transfer modal.

## How this PR fixes it

The "Contract interaction" text has been changed to "Build transaction" and the title of the replacement button area to "Select how you would like to replace this transaction" in order to match the semantics of the buttons that are all now titled with verbs ("Rejection transaction" is now "Reject transaction").

## How to test it

1. Open the new transaction modal either by the sidebar or transaction replacement.
2. Observe the new text.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/206734778-88fbeb51-4c3d-4d55-b451-da44f519e3b9.png)

![image](https://user-images.githubusercontent.com/20442784/206734764-9ba4f50f-ec21-40bb-adf9-3cb020d7790e.png)