### PR TITLE
fix: Display available spending limit amount

### DIFF
--- a/src/components/tx/SpendingLimitRow/index.tsx
+++ b/src/components/tx/SpendingLimitRow/index.tsx
@@ -1,25 +1,25 @@
 import { FormControl, FormControlLabel, Radio, RadioGroup, Typography } from '@mui/material'
 import { Controller, useFormContext } from 'react-hook-form'
-import { formatVisualAmount } from '@/utils/formatters'
+import type { BigNumber } from '@ethersproject/bignumber'
+import { safeFormatUnits } from '@/utils/formatters'
 import type { TokenInfo } from '@safe-global/safe-gateway-typescript-sdk'
-import type { SpendingLimitState } from '@/store/spendingLimitsSlice'
 import { SendAssetsField, SendTxType } from '@/components/tx/modals/TokenTransferModal/SendAssetsForm'
 
 const SpendingLimitRow = ({
-  spendingLimit,
+  availableAmount,
   selectedToken,
 }: {
-  spendingLimit: SpendingLimitState
+  availableAmount: BigNumber
   selectedToken: TokenInfo | undefined
 }) => {
   const { control } = useFormContext()
 
-  const formattedAmount = formatVisualAmount(spendingLimit.amount, selectedToken?.decimals)
+  const formattedAmount = safeFormatUnits(availableAmount, selectedToken?.decimals)
 
   return (
     <>
       <Typography>Send as</Typography>
-      <FormControl sx={{ mb: 2 }}>
+      <FormControl>
         <Controller
           rules={{ required: true }}
           control={control}


### PR DESCRIPTION
## What it solves

Resolves #1310 

## How this PR fixes it

- Displays the available spending limit amount (amount-spent) with more precision

## How to test it

1. Open a safe with a spending limit in place
2. Create a new transaction
3. Select the token that has a spending limit
4. Observe the amount is displayed with enough precision
5. Press Max
6. Observe the same amount in the input field

## Screenshots
<img width="634" alt="Screenshot 2022-12-12 at 11 57 37" src="https://user-images.githubusercontent.com/5880855/207032123-b8c09a54-2c7e-493d-8f6f-8617ade90183.png">

