### PR TITLE
fix: Increase font-size for EthHashInfo

### DIFF
--- a/src/components/common/EthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/index.tsx
@@ -70,7 +70,7 @@ const EthHashInfo = ({
         )}
 
         <Box className={css.addressRow}>
-          <Typography variant="body2" fontWeight="inherit">
+          <Typography fontWeight="inherit" fontSize="inherit">
             {showPrefix && shouldPrefix && prefix && <b>{prefix}:</b>}
             <span className={css.mobileAddress}>{shortenAddress(address)}</span>
             <span className={css.desktopAddress}>{shortAddress ? shortenAddress(address) : address}</span>

--- a/src/components/safe-apps/SafeAppsTxModal/ReviewSafeAppsTx.tsx
+++ b/src/components/safe-apps/SafeAppsTxModal/ReviewSafeAppsTx.tsx
@@ -7,8 +7,7 @@ import { OperationType } from '@safe-global/safe-core-sdk-types'
 import { Box, Typography } from '@mui/material'
 import SendFromBlock from '@/components/tx/SendFromBlock'
 import Multisend from '@/components/transactions/TxDetails/TxData/DecodedData/Multisend'
-import { InfoDetails } from '@/components/transactions/InfoDetails'
-import EthHashInfo from '@/components/common/EthHashInfo'
+import SendToBlock from '@/components/tx/SendToBlock'
 import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import { generateDataRowValue } from '@/components/transactions/TxDetails/Summary/TxDataRow'
 import useAsync from '@/hooks/useAsync'
@@ -66,9 +65,7 @@ const ReviewSafeAppsTx = ({
 
         {safeTx && (
           <>
-            <InfoDetails title={getInteractionTitle(safeTx.data.value || '', chain)}>
-              <EthHashInfo address={safeTx.data.to} shortAddress={false} showCopyButton hasExplorer />
-            </InfoDetails>
+            <SendToBlock address={safeTx.data.to} title={getInteractionTitle(safeTx.data.value || '', chain)} />
 
             <Box pb={2}>
               <Typography mt={2} color="primary.light">

--- a/src/components/settings/SafeModules/RemoveModule/steps/ReviewRemoveModule.tsx
+++ b/src/components/settings/SafeModules/RemoveModule/steps/ReviewRemoveModule.tsx
@@ -3,7 +3,7 @@ import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import useTxSender from '@/hooks/useTxSender'
 import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import { Typography } from '@mui/material'
-import EthHashInfo from '@/components/common/EthHashInfo'
+import SendToBlock from '@/components/tx/SendToBlock'
 import type { RemoveModuleData } from '@/components/settings/SafeModules/RemoveModule'
 import { useEffect } from 'react'
 import { Errors, logError } from '@/services/exceptions'
@@ -35,8 +35,7 @@ export const ReviewRemoveModule = ({
 
   return (
     <SignOrExecuteForm safeTx={safeTx} onSubmit={onFormSubmit} error={safeTxError}>
-      <Typography sx={({ palette }) => ({ color: palette.primary.light })}>Module</Typography>
-      <EthHashInfo address={data.address} showCopyButton hasExplorer shortAddress={false} />
+      <SendToBlock address={data.address} title="Module" />
       <Typography my={2}>
         After removing this module, any feature or app that uses this module might no longer work. If this Safe requires
         more then one signature, the module removal will have to be confirmed by other owners as well.

--- a/src/components/tx/SendFromBlock/index.tsx
+++ b/src/components/tx/SendFromBlock/index.tsx
@@ -19,9 +19,9 @@ const SendFromBlock = (): ReactElement => {
         Sending from
       </Typography>
 
-      <Box>
+      <Typography variant="body2">
         <EthHashInfo address={address} shortAddress={false} hasExplorer showCopyButton />
-      </Box>
+      </Typography>
 
       {nativeToken && (
         <Box className={css.balance} bgcolor={(theme) => theme.palette.background.main}>

--- a/src/components/tx/SendToBlock/index.tsx
+++ b/src/components/tx/SendToBlock/index.tsx
@@ -1,0 +1,18 @@
+import { Box, Typography } from '@mui/material'
+import EthHashInfo from '@/components/common/EthHashInfo'
+
+const SendToBlock = ({ address, title = 'Recipient' }: { address: string; title?: string }) => {
+  return (
+    <Box mb={3}>
+      <Typography color={({ palette }) => palette.text.secondary} mb={1}>
+        {title}
+      </Typography>
+
+      <Typography variant="body2">
+        <EthHashInfo address={address} shortAddress={false} hasExplorer showCopyButton />
+      </Typography>
+    </Box>
+  )
+}
+
+export default SendToBlock

--- a/src/components/tx/modals/BatchExecuteModal/ReviewBatchExecute.tsx
+++ b/src/components/tx/modals/BatchExecuteModal/ReviewBatchExecute.tsx
@@ -6,7 +6,7 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import { encodeMultiSendData } from '@safe-global/safe-core-sdk/dist/src/utils/transactions/utils'
 import { useWeb3 } from '@/hooks/wallets/web3'
 import { Button, DialogContent, Typography } from '@mui/material'
-import EthHashInfo from '@/components/common/EthHashInfo'
+import SendToBlock from '@/components/tx/SendToBlock'
 import { useMemo, useState } from 'react'
 import useTxSender from '@/hooks/useTxSender'
 import { generateDataRowValue } from '@/components/transactions/TxDetails/Summary/TxDataRow'
@@ -75,10 +75,7 @@ const ReviewBatchExecute = ({ data, onSubmit }: { data: BatchExecuteData; onSubm
           over the execute button.
         </Typography>
 
-        <Typography color="primary.light">Interact with:</Typography>
-        {multiSendContract && (
-          <EthHashInfo address={multiSendContract.getAddress()} shortAddress={false} hasExplorer showCopyButton />
-        )}
+        {multiSendContract && <SendToBlock address={multiSendContract.getAddress()} title="Interact with:" />}
 
         {multiSendTxData && (
           <>

--- a/src/components/tx/modals/NftTransferModal/ReviewNftTx.tsx
+++ b/src/components/tx/modals/NftTransferModal/ReviewNftTx.tsx
@@ -3,7 +3,7 @@ import { type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { Box, Typography } from '@mui/material'
 import SendFromBlock from '../../SendFromBlock'
 import SignOrExecuteForm from '../../SignOrExecuteForm'
-import EthHashInfo from '@/components/common/EthHashInfo'
+import SendToBlock from '@/components/tx/SendToBlock'
 import useAsync from '@/hooks/useAsync'
 import { createNftTransferParams } from '@/services/tx/tokenTransferParams'
 import useTxSender from '@/hooks/useTxSender'
@@ -43,13 +43,7 @@ const ReviewNftTx = ({ params, onSubmit }: ReviewNftTxProps): ReactElement => {
 
       <SendFromBlock />
 
-      <Typography color={({ palette }) => palette.text.secondary} pb={1}>
-        Recipient
-      </Typography>
-
-      <Box mb={3}>
-        <EthHashInfo address={params.recipient} shortAddress={false} hasExplorer showCopyButton />
-      </Box>
+      <SendToBlock address={params.recipient} />
     </SignOrExecuteForm>
   )
 }

--- a/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
+++ b/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
@@ -21,7 +21,7 @@ import useCollectibles from '@/hooks/useCollectibles'
 import type { SafeCollectibleResponse } from '@safe-global/safe-gateway-typescript-sdk'
 import ImageFallback from '@/components/common/ImageFallback'
 import useAddressBook from '@/hooks/useAddressBook'
-import EthHashInfo from '@/components/common/EthHashInfo'
+import SendToBlock from '@/components/tx/SendToBlock'
 import InfiniteScroll from '@/components/common/InfiniteScroll'
 
 enum Field {
@@ -110,7 +110,7 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
           <FormControl fullWidth sx={{ mb: 2, mt: 1 }}>
             {addressBook[recipient] ? (
               <Box onClick={() => setValue(Field.recipient, '')}>
-                <EthHashInfo address={recipient} shortAddress={false} hasExplorer showCopyButton />
+                <SendToBlock address={recipient} />
               </Box>
             ) : (
               <AddressBookInput name={Field.recipient} label="Recipient" />

--- a/src/components/tx/modals/TokenTransferModal/ReviewMultisigTx.tsx
+++ b/src/components/tx/modals/TokenTransferModal/ReviewMultisigTx.tsx
@@ -1,5 +1,4 @@
 import { type ReactElement } from 'react'
-import { Box, Typography } from '@mui/material'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 
 import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
@@ -7,7 +6,7 @@ import { createTokenTransferParams } from '@/services/tx/tokenTransferParams'
 import useBalances from '@/hooks/useBalances'
 import useAsync from '@/hooks/useAsync'
 import useTxSender from '@/hooks/useTxSender'
-import EthHashInfo from '@/components/common/EthHashInfo'
+import SendToBlock from '@/components/tx/SendToBlock'
 import SendFromBlock from '../../SendFromBlock'
 import type { TokenTransferModalProps } from '.'
 import { TokenTransferReview } from '@/components/tx/modals/TokenTransferModal/ReviewTokenTx'
@@ -32,13 +31,7 @@ const ReviewMultisigTx = ({ params, onSubmit }: TokenTransferModalProps): ReactE
 
       <SendFromBlock />
 
-      <Typography color={({ palette }) => palette.text.secondary} pb={1}>
-        Recipient
-      </Typography>
-
-      <Box mb={3}>
-        <EthHashInfo address={params.recipient} shortAddress={false} hasExplorer showCopyButton />
-      </Box>
+      <SendToBlock address={params.recipient} />
     </SignOrExecuteForm>
   )
 }

--- a/src/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx.tsx
+++ b/src/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx.tsx
@@ -1,9 +1,9 @@
 import type { ReactElement, SyntheticEvent } from 'react'
 import { useMemo, useState } from 'react'
 import type { BigNumberish, BytesLike } from 'ethers'
-import { Box, Button, DialogContent, Typography } from '@mui/material'
+import { Button, DialogContent, Typography } from '@mui/material'
 import SendFromBlock from '@/components/tx/SendFromBlock'
-import EthHashInfo from '@/components/common/EthHashInfo'
+import SendToBlock from '@/components/tx/SendToBlock'
 import type { TokenTransferModalProps } from '.'
 import { TokenTransferReview } from '@/components/tx/modals/TokenTransferModal/ReviewTokenTx'
 import useBalances from '@/hooks/useBalances'
@@ -108,13 +108,7 @@ const ReviewSpendingLimitTx = ({ params, onSubmit }: TokenTransferModalProps): R
 
         <SendFromBlock />
 
-        <Typography color={({ palette }) => palette.text.secondary} pb={1}>
-          Recipient
-        </Typography>
-
-        <Box mb={3}>
-          <EthHashInfo address={params.recipient} shortAddress={false} hasExplorer showCopyButton />
-        </Box>
+        <SendToBlock address={params.recipient} />
 
         <AdvancedParams
           params={advancedParams}

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -23,7 +23,7 @@ import InputValueHelper from '@/components/common/InputValueHelper'
 import SendFromBlock from '../../SendFromBlock'
 import SpendingLimitRow from '@/components/tx/SpendingLimitRow'
 import useSpendingLimit from '@/hooks/useSpendingLimit'
-import EthHashInfo from '@/components/common/EthHashInfo'
+import SendToBlock from '@/components/tx/SendToBlock'
 import useAddressBook from '@/hooks/useAddressBook'
 import { getSafeTokenAddress } from '@/components/common/SafeTokenWidget'
 import useChainId from '@/hooks/useChainId'
@@ -136,7 +136,7 @@ const SendAssetsForm = ({ onSubmit, formData, disableSpendingLimit = false }: Se
           <FormControl fullWidth sx={{ mb: 2, mt: 1 }}>
             {addressBook[recipient] ? (
               <Box onClick={() => setValue(SendAssetsField.recipient, '')}>
-                <EthHashInfo address={recipient} shortAddress={false} hasExplorer showCopyButton />
+                <SendToBlock address={recipient} />
               </Box>
             ) : (
               <AddressBookInput name={SendAssetsField.recipient} label="Recipient" />


### PR DESCRIPTION
## What it solves

Resolves #1242 

## How this PR fixes it

- Changes the font-size of `EthHashInfo` addresses to `inherit` (16px)
- (refactor): Extracts the recipient area from tx modals into `SendToBlock` to keep the smaller font-size of 14px for all addresses displayed inside tx modals. Also addresses some inconsistencies across different tx modals where captions had different colors and font-weights.

## How to test it

1. Open a safe
2. Go to History
3. Open a transaction
4. Observe all addresses and hashes have the same font-size
5. Open a tx modal
6. Observe that all addresses have a smaller font-size of 14px

## Screenshots
<img width="636" alt="Screenshot 2022-12-13 at 12 44 40" src="https://user-images.githubusercontent.com/5880855/207309311-d380e8f6-5102-45f6-bd6f-f49a07730b49.png">
<img width="844" alt="Screenshot 2022-12-13 at 12 46 32" src="https://user-images.githubusercontent.com/5880855/207309650-883fc647-b6a6-4ce2-9549-6dce8398e9aa.png">
