### PR TITLE
fix: change custom tx fallback icon

### DIFF
--- a/src/hooks/useTransactionType.ts
+++ b/src/hooks/useTransactionType.ts
@@ -65,7 +65,7 @@ export const getTransactionType = (tx: TransactionSummary, addressBook: AddressB
     case TransactionInfoType.CUSTOM: {
       if (isModuleExecutionInfo(tx.executionInfo)) {
         return {
-          icon: toAddress?.logoUri || '/images/transactions/settings.svg',
+          icon: toAddress?.logoUri || '/images/transactions/custom.svg',
           text: toAddress?.name || 'Contract interaction',
         }
       }


### PR DESCRIPTION
## What it solves

Resolves #1354 

## How this PR fixes it
change custom tx fallback icon

## How to test it
Open `eth:0x0DA0C3e52C977Ed3cBc641fF02DD271c3ED55aFe/transactions/tx?id=module_0x0DA0C3e52C977Ed3cBc641fF02DD271c3ED55aFe_0xe14278097fc7d0f462d2913d36185505ee09f8476ac899620c409eb0afaa812a_0xa65aaf534f1a4620` on production and observe the type be "Contract interaction".

## Screenshots
<img width="710" alt="Screenshot 2022-12-13 at 13 21 52" src="https://user-images.githubusercontent.com/32431609/207317119-6c37194a-9753-4479-a0b7-656f17ad2760.png">
