### PR TITLE
fix: show overwrite alert after loading the import file

### DIFF
--- a/src/components/settings/ImportAllDialog/index.tsx
+++ b/src/components/settings/ImportAllDialog/index.tsx
@@ -146,11 +146,13 @@ const ImportAllDialog = ({ handleClose }: { handleClose: () => void }): ReactEle
         <div className={css.horizontalDivider} />
 
         <Typography>Only JSON files exported from a Safe can be imported.</Typography>
-        <Alert severity="warning" sx={{ mt: 3 }}>
-          <AlertTitle sx={{ fontWeight: 700 }}>Overwrite your current data?</AlertTitle>
-          This action will overwrite your currently added Safes and address book entries with those from the imported
-          file.
-        </Alert>
+        {jsonData && (
+          <Alert severity="warning" sx={{ mt: 3 }}>
+            <AlertTitle sx={{ fontWeight: 700 }}>Overwrite your current data?</AlertTitle>
+            This action will overwrite your currently added Safes and address book entries with those from the imported
+            file.
+          </Alert>
+        )}
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>


### PR DESCRIPTION
## What it solves

Resolves #1356 

## How this PR fixes it
Displays the alert after `.json` is load

## How to test it
Open the "Data import" dialog.
You should see the Alert only after selecting the .json you want to import

## Screenshots
<img width="640" alt="Screenshot 2022-12-13 at 14 08 24" src="https://user-images.githubusercontent.com/32431609/207326734-545fa814-9c06-4659-81ba-ec096263c6a8.png">

