### PR TITLE
fix: Replacement modal button alignment on mobile

### DIFF
--- a/src/components/tx/modals/NewTxModal/ReplacementModal.tsx
+++ b/src/components/tx/modals/NewTxModal/ReplacementModal.tsx
@@ -10,7 +10,6 @@ import {
   DialogActions,
   Grid,
 } from '@mui/material'
-import type { SystemProps } from '@mui/system/Box'
 
 import ModalDialog from '@/components/common/ModalDialog'
 import InfoIcon from '@/public/images/notifications/info.svg'
@@ -49,11 +48,6 @@ const btnWidth = {
     xs: 240,
     sm: '100%',
   },
-}
-
-const flexDirection: SystemProps['flexDirection'] = {
-  xs: 'column',
-  sm: 'row',
 }
 
 const ReplacementModal = ({
@@ -98,22 +92,13 @@ const ReplacementModal = ({
         </Stepper>
       </DialogContent>
       <DialogActions className={css.container}>
-        <Grid container alignItems="center" justifyContent="center" flexDirection={flexDirection}>
+        <Grid container alignItems="center" justifyContent="center" flexDirection="row">
           <Grid item xs={12}>
             <Typography variant="body2" textAlign="center" fontWeight={700} mb={3}>
               Select how you would like to replace this transaction
             </Typography>
           </Grid>
-          <Grid
-            item
-            container
-            justifyContent="center"
-            alignItems="center"
-            gap={1}
-            xs={12}
-            sm
-            flexDirection={flexDirection}
-          >
+          <Grid item container justifyContent="center" alignItems="center" gap={1} xs={12} sm flexDirection="row">
             <SendTokensButton onClick={onTokenModalOpen} sx={btnWidth} />
             <SendNFTsButton onClick={onNFTModalOpen} sx={btnWidth} />
           </Grid>
@@ -132,7 +117,8 @@ const ReplacementModal = ({
               sm: 'flex-start',
             }}
             alignItems="center"
-            flexDirection={flexDirection}
+            textAlign="center"
+            flexDirection="row"
           >
             <Tooltip
               arrow

--- a/src/components/tx/modals/NewTxModal/styles.module.css
+++ b/src/components/tx/modals/NewTxModal/styles.module.css
@@ -75,4 +75,8 @@
     left: 0;
     width: calc(100% - 50px);
   }
+
+  .or {
+    padding: var(--space-1) var(--space-2);
+  }
 }


### PR DESCRIPTION
## What it solves

Resolves #1357 

## How this PR fixes it

- Aligns the replacement modal buttons on smaller screens to fit the viewport

## How to test it

1. Open the Safe
2. Replace an existing transaction
3. Observe that the buttons are aligned
4. Reduce the screen width
5. Observe that all buttons are still visible

## Screenshots
<img width="380" alt="Screenshot 2022-12-13 at 14 11 09" src="https://user-images.githubusercontent.com/5880855/207327579-79a410f7-0e9d-4852-9507-96703bda3482.png">
