### PR TITLE
fix: accordion mounting

### DIFF
--- a/src/components/safe-apps/AppFrame/TransactionQueueBar/index.tsx
+++ b/src/components/safe-apps/AppFrame/TransactionQueueBar/index.tsx
@@ -49,7 +49,7 @@ const TransactionQueueBar = ({
                 enter: 0,
                 exit: 500,
               },
-              unmountOnExit: true,
+              unmountOnExit: false,
               mountOnEnter: true,
             }}
             sx={{

--- a/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
+++ b/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
@@ -30,8 +30,8 @@ export const ExpandableTransactionItem = ({
     <Accordion
       disableGutters
       TransitionProps={{
-        mountOnEnter: false,
-        unmountOnExit: true,
+        mountOnEnter: true,
+        unmountOnExit: false,
       }}
       elevation={0}
       defaultExpanded={!!txDetails}


### PR DESCRIPTION
## What it solves

Resolves #1303

## How this PR fixes it

The `Accordion`s now only mount on enter, not unmounting when closing.

## How to test it

Open/close the transaction accordions/Safe Apps queue bar and observe that there is only one network request. Subsequent opens/closes are then smooth.

## Screenshots

![accordions](https://user-images.githubusercontent.com/20442784/207580717-924f286e-85f3-42e6-bc6c-26bdd64ea940.gif)