### PR TITLE
Chore: replace non-alpha chars with _ in PR deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,8 +83,9 @@ jobs:
       # Extract branch name
       - name: Extract branch name
         shell: bash
-        ## Cut off "refs/heads/" and only allow alphanumeric characters, e.g. "refs/heads/features/hello-1.2.0" -> "features-hello120"
-        run: echo "##[set-output name=branch;]$(echo $GITHUB_HEAD_REF | sed 's/refs\/heads\///' | sed 's/[^a-zA-Z0-9]//g')"
+        ## Cut off "refs/heads/" and only allow alphanumeric characters,
+        ## e.g. "refs/heads/features/hello-1.2.0" -> "features_hello_1_2_0"
+        run: echo "##[set-output name=branch;]$(echo $GITHUB_HEAD_REF | sed 's/refs\/heads\///' | sed 's/[^a-z0-9]+/_/ig')"
         id: extract_branch
 
       # Deploy to S3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,7 @@ jobs:
         shell: bash
         ## Cut off "refs/heads/" and only allow alphanumeric characters,
         ## e.g. "refs/heads/features/hello-1.2.0" -> "features_hello_1_2_0"
-        run: echo "##[set-output name=branch;]$(echo $GITHUB_HEAD_REF | sed 's/refs\/heads\///' | sed 's/[^a-z0-9]+/_/ig')"
+        run: echo "##[set-output name=branch;]$(echo $GITHUB_HEAD_REF | sed 's/refs\/heads\///' | sed 's/[^a-z0-9]/_/ig')"
         id: extract_branch
 
       # Deploy to S3


### PR DESCRIPTION
## What it solves

A small tweak of the branch name sanitizer. Replace non-alphanumeric symbols with underscores instead of nothing.

<img width="791" alt="Screenshot 2022-12-14 at 12 33 25" src="https://user-images.githubusercontent.com/381895/207584558-4950a1d1-38b8-4e41-a7b9-c53aeae12346.png">
