### PR TITLE
Update safe-core-sdk to v3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@mui/material": "^5.9.3",
     "@mui/x-date-pickers": "^5.0.0-beta.6",
     "@reduxjs/toolkit": "^1.8.2",
-    "@safe-global/safe-core-sdk": "^3.2.0",
+    "@safe-global/safe-core-sdk": "^3.2.1",
     "@safe-global/safe-ethers-lib": "^1.7.0",
     "@safe-global/safe-gateway-typescript-sdk": "^3.5.4",
     "@sentry/react": "^7.8.1",


### PR DESCRIPTION
## What it solves
Updates `safe-core-sdk` version to `v3.2.1`.
This fixes this issue: https://github.com/safe-global/web-core/issues/1343
