### PR TITLE
fix: Allow editing gas fees for spending limit transactions

### DIFF
--- a/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
+++ b/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
@@ -84,11 +84,13 @@ const AdvancedParamsForm = ({ params, ...props }: AdvancedParamsFormProps) => {
         <form onSubmit={onFormSubmit}>
           <DialogContent>
             <Grid container spacing={2}>
-              <Grid item xs={12}>
-                <Typography variant="body1" fontWeight={700}>
-                  Safe transaction
-                </Typography>
-              </Grid>
+              {(params.nonce !== undefined || !!params.safeTxGas) && (
+                <Grid item xs={12}>
+                  <Typography variant="body1" fontWeight={700}>
+                    Safe transaction
+                  </Typography>
+                </Grid>
+              )}
 
               {/* Safe nonce */}
               {params.nonce !== undefined && (

--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -51,7 +51,7 @@ const GasParams = ({ params, isExecution, isEIP1559, onEdit, gasLimitError }: Ga
   }
 
   return (
-    <Accordion elevation={0} onChange={onChangeExpand} sx={nonce === undefined ? { pointerEvents: 'none' } : undefined}>
+    <Accordion elevation={0} onChange={onChangeExpand}>
       <AccordionSummary>
         {isExecution ? (
           <Typography display="flex" alignItems="center" justifyContent="space-between" width={1}>


### PR DESCRIPTION
## What it solves

Resolves #1345 

## How this PR fixes it

- Doesn't disable the gas fee accordion even if the nonce is undefined

## How to test it

1. Open the Safe
2. Create a new spending limit transaction
3. Observe that the "Estimated Fee" Accordion is clickable and opens
4. Observe being able to edit gas fee params

## Screenshots
<img width="650" alt="Screenshot 2022-12-14 at 14 58 10" src="https://user-images.githubusercontent.com/5880855/207614197-cfd76f13-6f81-479b-a1f4-444b185b2fbf.png">
