### PR TITLE
[Spam tokens] manually hide tokens 

### DIFF
--- a/src/components/address-book/AddressBookTable/index.tsx
+++ b/src/components/address-book/AddressBookTable/index.tsx
@@ -81,50 +81,52 @@ const AddressBookTable = () => {
   }, [addressBookEntries, searchQuery])
 
   const rows = filteredEntries.map(([address, name]) => ({
-    name: {
-      rawValue: name,
-      content: name,
-    },
-    address: {
-      rawValue: address,
-      content: <EthHashInfo address={address} showName={false} shortAddress={false} hasExplorer showCopyButton />,
-    },
-    actions: {
-      rawValue: '',
-      sticky: true,
-      content: (
-        <div className={tableCss.actions}>
-          <Track {...ADDRESS_BOOK_EVENTS.EDIT_ENTRY}>
-            <Tooltip title="Edit entry" placement="top">
-              <IconButton onClick={() => handleOpenModalWithValues(ModalType.ENTRY, address, name)} size="small">
-                <SvgIcon component={EditIcon} inheritViewBox color="border" fontSize="small" />
-              </IconButton>
-            </Tooltip>
-          </Track>
-
-          <Track {...ADDRESS_BOOK_EVENTS.DELETE_ENTRY}>
-            <Tooltip title="Delete entry" placement="top">
-              <IconButton onClick={() => handleOpenModalWithValues(ModalType.REMOVE, address, name)} size="small">
-                <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
-              </IconButton>
-            </Tooltip>
-          </Track>
-
-          {isGranted && (
-            <Track {...ADDRESS_BOOK_EVENTS.SEND}>
-              <Button
-                variant="contained"
-                color="primary"
-                size="small"
-                onClick={() => setSelectedAddress(address)}
-                className={css.sendButton}
-              >
-                Send
-              </Button>
+    cells: {
+      name: {
+        rawValue: name,
+        content: name,
+      },
+      address: {
+        rawValue: address,
+        content: <EthHashInfo address={address} showName={false} shortAddress={false} hasExplorer showCopyButton />,
+      },
+      actions: {
+        rawValue: '',
+        sticky: true,
+        content: (
+          <div className={tableCss.actions}>
+            <Track {...ADDRESS_BOOK_EVENTS.EDIT_ENTRY}>
+              <Tooltip title="Edit entry" placement="top">
+                <IconButton onClick={() => handleOpenModalWithValues(ModalType.ENTRY, address, name)} size="small">
+                  <SvgIcon component={EditIcon} inheritViewBox color="border" fontSize="small" />
+                </IconButton>
+              </Tooltip>
             </Track>
-          )}
-        </div>
-      ),
+
+            <Track {...ADDRESS_BOOK_EVENTS.DELETE_ENTRY}>
+              <Tooltip title="Delete entry" placement="top">
+                <IconButton onClick={() => handleOpenModalWithValues(ModalType.REMOVE, address, name)} size="small">
+                  <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            </Track>
+
+            {isGranted && (
+              <Track {...ADDRESS_BOOK_EVENTS.SEND}>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  size="small"
+                  onClick={() => setSelectedAddress(address)}
+                  className={css.sendButton}
+                >
+                  Send
+                </Button>
+              </Track>
+            )}
+          </div>
+        ),
+      },
     },
   }))
 

--- a/src/components/balances/AssetsHeader/index.tsx
+++ b/src/components/balances/AssetsHeader/index.tsx
@@ -5,7 +5,7 @@ import NavTabs from '@/components/common/NavTabs'
 import PageHeader from '@/components/common/PageHeader'
 import CurrencySelect from '@/components/balances/CurrencySelect'
 import { balancesNavItems } from '@/components/sidebar/SidebarNavigation/config'
-import { useHiddenAssets } from '@/hooks/useHiddenAssets'
+import useHiddenAssets from '@/hooks/useHiddenAssets'
 import { VisibilityOutlined, VisibilityOffOutlined } from '@mui/icons-material'
 
 import css from './styles.module.css'

--- a/src/components/balances/AssetsHeader/index.tsx
+++ b/src/components/balances/AssetsHeader/index.tsx
@@ -1,19 +1,46 @@
-import { Box } from '@mui/material'
-import type { ReactElement } from 'react'
+import { Box, ButtonBase, Typography } from '@mui/material'
+import { type ReactElement, useContext } from 'react'
 
 import NavTabs from '@/components/common/NavTabs'
 import PageHeader from '@/components/common/PageHeader'
 import CurrencySelect from '@/components/balances/CurrencySelect'
 import { balancesNavItems } from '@/components/sidebar/SidebarNavigation/config'
+import { useHiddenAssets } from '@/hooks/useHiddenAssets'
+import { VisibilityOutlined, VisibilityOffOutlined } from '@mui/icons-material'
 
-const AssetsHeader = ({ currencySelect = false }: { currencySelect?: boolean }): ReactElement => {
+import css from './styles.module.css'
+import { HiddenAssetsContext } from '../HiddenAssetsProvider'
+
+const AssetsHeader = ({
+  hiddenAssets = false,
+  currencySelect = false,
+}: {
+  hiddenAssets?: boolean
+  currencySelect?: boolean
+}): ReactElement => {
+  const currentHiddenAssets = useHiddenAssets()
+  const hiddenAssetCount = currentHiddenAssets ? Object.keys(currentHiddenAssets).length : 0
+  const { showHiddenAssets, toggleShowHiddenAssets } = useContext(HiddenAssetsContext)
+
   return (
     <PageHeader
       title="Assets"
       action={
         <Box display="flex" justifyContent="space-between" alignItems="center">
           <NavTabs tabs={balancesNavItems} />
-          {currencySelect && <CurrencySelect />}
+          <Box display="flex" flexDirection="row" alignItems="center" gap={1}>
+            {hiddenAssets && hiddenAssetCount > 0 && (
+              <ButtonBase className={css.hiddenAssetsButton} onClick={toggleShowHiddenAssets}>
+                {showHiddenAssets ? (
+                  <VisibilityOutlined color="border" fontSize="small" />
+                ) : (
+                  <VisibilityOffOutlined color="border" fontSize="small" />
+                )}{' '}
+                <Typography fontSize="small">{hiddenAssetCount}</Typography>
+              </ButtonBase>
+            )}
+            {currencySelect && <CurrencySelect />}
+          </Box>
         </Box>
       }
     />

--- a/src/components/balances/AssetsHeader/styles.module.css
+++ b/src/components/balances/AssetsHeader/styles.module.css
@@ -1,0 +1,13 @@
+.hiddenAssetsButton {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-1);
+  border: 1px solid var(--color-border-main);
+  border-radius: 6px;
+  padding: 8.5px 14px;
+}
+
+.hiddenAssetsButton:hover {
+  border: 1px solid var(--color-text-primary);
+}

--- a/src/components/balances/AssetsTable/index.tsx
+++ b/src/components/balances/AssetsTable/index.tsx
@@ -1,6 +1,7 @@
-import { useState, type ReactElement, useMemo } from 'react'
-import { Button, Tooltip, Typography, SvgIcon } from '@mui/material'
-import { type SafeBalanceResponse, TokenType } from '@safe-global/safe-gateway-typescript-sdk'
+import { useState, type ReactElement, useMemo, useContext, useCallback } from 'react'
+import { Button, Tooltip, Typography, SvgIcon, IconButton, Box } from '@mui/material'
+import type { SafeBalanceResponse, TokenInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { TokenType } from '@safe-global/safe-gateway-typescript-sdk'
 import css from './styles.module.css'
 import FiatValue from '@/components/common/FiatValue'
 import TokenAmount from '@/components/common/TokenAmount'
@@ -12,14 +13,44 @@ import useIsGranted from '@/hooks/useIsGranted'
 import Track from '@/components/common/Track'
 import { ASSETS_EVENTS } from '@/services/analytics/events/assets'
 import InfoIcon from '@/public/images/notifications/info.svg'
+import { VisibilityOffOutlined, VisibilityOutlined } from '@mui/icons-material'
+import { HiddenAssetsContext } from '../HiddenAssetsProvider'
+import { useHiddenAssets } from '@/hooks/useHiddenAssets'
 
 interface AssetsTableProps {
   items?: SafeBalanceResponse['items']
 }
 
+const isNativeToken = (tokenInfo: TokenInfo) => {
+  return tokenInfo.type === TokenType.NATIVE_TOKEN
+}
+
 const AssetsTable = ({ items }: AssetsTableProps): ReactElement => {
   const [selectedAsset, setSelectedAsset] = useState<string | undefined>()
   const isGranted = useIsGranted()
+  const { showHiddenAssets, toggleAsset, saveChanges, assetsToHide, assetsToUnhide, reset } =
+    useContext(HiddenAssetsContext)
+  const hiddenAssets = useHiddenAssets()
+
+  const visibleItems = useMemo(
+    () =>
+      showHiddenAssets
+        ? items
+        : items?.filter(
+            (item) => isNativeToken(item.tokenInfo) || typeof hiddenAssets?.[item.tokenInfo.address] === 'undefined',
+          ),
+    [hiddenAssets, items, showHiddenAssets],
+  )
+
+  // Assets are selected if they are either hidden or marked for hiding
+  const isAssetSelected = useCallback(
+    (address: string) =>
+      (hiddenAssets && typeof hiddenAssets[address] !== 'undefined' && !assetsToUnhide.includes(address)) ||
+      assetsToHide.includes(address),
+    [assetsToHide, assetsToUnhide, hiddenAssets],
+  )
+
+  const selectedAssetCount = visibleItems?.filter((item) => isAssetSelected(item.tokenInfo.address)).length || 0
 
   const shouldHideActions = !isGranted
 
@@ -51,71 +82,102 @@ const AssetsTable = ({ items }: AssetsTableProps): ReactElement => {
     [shouldHideActions],
   )
 
-  const rows = (items || []).map((item) => {
+  const rows = (visibleItems || []).map((item) => {
     const rawFiatValue = parseFloat(item.fiatBalance)
+    const isNative = isNativeToken(item.tokenInfo)
 
     return {
-      asset: {
-        rawValue: item.tokenInfo.name,
-        content: (
-          <div className={css.token}>
-            <TokenIcon logoUri={item.tokenInfo.logoUri} tokenSymbol={item.tokenInfo.symbol} />
+      selected: !isNative && isAssetSelected(item.tokenInfo.address),
+      cells: {
+        asset: {
+          rawValue: item.tokenInfo.name,
+          content: (
+            <div className={css.token}>
+              <TokenIcon logoUri={item.tokenInfo.logoUri} tokenSymbol={item.tokenInfo.symbol} />
 
-            <Typography>{item.tokenInfo.name}</Typography>
+              <Typography>{item.tokenInfo.name}</Typography>
 
-            {item.tokenInfo.type !== TokenType.NATIVE_TOKEN && <TokenExplorerLink address={item.tokenInfo.address} />}
-          </div>
-        ),
-      },
-      balance: {
-        rawValue: Number(item.balance) / 10 ** item.tokenInfo.decimals,
-        content: (
-          <TokenAmount value={item.balance} decimals={item.tokenInfo.decimals} tokenSymbol={item.tokenInfo.symbol} />
-        ),
-      },
-      value: {
-        rawValue: rawFiatValue,
-        content: (
-          <>
-            <FiatValue value={item.fiatBalance} />
-            {rawFiatValue === 0 && (
-              <Tooltip title="Value may be zero due to missing token price information" placement="top" arrow>
-                <span>
-                  <SvgIcon
-                    component={InfoIcon}
-                    inheritViewBox
-                    color="error"
-                    fontSize="small"
-                    sx={{ verticalAlign: 'middle', marginLeft: 0.5 }}
-                  />
-                </span>
-              </Tooltip>
-            )}
-          </>
-        ),
-      },
-      actions: {
-        rawValue: '',
-        sticky: true,
-        hide: shouldHideActions,
-        content: (
-          <Track {...ASSETS_EVENTS.SEND}>
-            <Button
-              variant="contained"
-              color="primary"
-              size="small"
-              onClick={() => setSelectedAsset(item.tokenInfo.address)}
-            >
-              Send
-            </Button>
-          </Track>
-        ),
+              {!isNative && <TokenExplorerLink address={item.tokenInfo.address} />}
+            </div>
+          ),
+        },
+        balance: {
+          rawValue: Number(item.balance) / 10 ** item.tokenInfo.decimals,
+          content: (
+            <TokenAmount value={item.balance} decimals={item.tokenInfo.decimals} tokenSymbol={item.tokenInfo.symbol} />
+          ),
+        },
+        value: {
+          rawValue: rawFiatValue,
+          content: (
+            <>
+              <FiatValue value={item.fiatBalance} />
+              {rawFiatValue === 0 && (
+                <Tooltip title="Value may be zero due to missing token price information" placement="top" arrow>
+                  <span>
+                    <SvgIcon
+                      component={InfoIcon}
+                      inheritViewBox
+                      color="error"
+                      fontSize="small"
+                      sx={{ verticalAlign: 'middle', marginLeft: 0.5 }}
+                    />
+                  </span>
+                </Tooltip>
+              )}
+            </>
+          ),
+        },
+        actions: {
+          rawValue: '',
+          sticky: true,
+          hide: shouldHideActions,
+          content: (
+            <Box display="flex" flexDirection="row" gap={1} alignItems="center">
+              <Track {...ASSETS_EVENTS.SEND}>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  size="small"
+                  onClick={() => setSelectedAsset(item.tokenInfo.address)}
+                >
+                  Send
+                </Button>
+              </Track>
+              {!isNative && (
+                <Track {...ASSETS_EVENTS.HIDE}>
+                  <IconButton onClick={() => toggleAsset(item.tokenInfo.address)}>
+                    {isAssetSelected(item.tokenInfo.address) ? <VisibilityOutlined /> : <VisibilityOffOutlined />}
+                  </IconButton>
+                </Track>
+              )}
+            </Box>
+          ),
+        },
       },
     }
   })
 
   return (
     <div className={css.container}>
+      {(assetsToHide.length > 0 || showHiddenAssets) && (
+        <Box display="flex" flexWrap="wrap" flexDirection="row" alignItems="center" gap={1} mb={2}>
+          <Box className={css.hideTokensHeader}>
+            <VisibilityOffOutlined />
+            <Typography>
+              {selectedAssetCount} {selectedAssetCount === 1 ? 'token' : 'tokens'} selected
+            </Typography>
+          </Box>
+          <div>
+            <Button onClick={reset} className={css.tinyButton} variant="outlined">
+              Deselect all
+            </Button>
+            <Button onClick={saveChanges} className={css.tinyButton} variant="contained">
+              Apply
+            </Button>
+          </div>
+        </Box>
+      )}
       <EnhancedTable rows={rows} headCells={headCells} />
       {selectedAsset && (
         <TokenTransferModal

--- a/src/components/balances/AssetsTable/index.tsx
+++ b/src/components/balances/AssetsTable/index.tsx
@@ -15,7 +15,7 @@ import { ASSETS_EVENTS } from '@/services/analytics/events/assets'
 import InfoIcon from '@/public/images/notifications/info.svg'
 import { VisibilityOffOutlined, VisibilityOutlined } from '@mui/icons-material'
 import { HiddenAssetsContext } from '../HiddenAssetsProvider'
-import { useHiddenAssets } from '@/hooks/useHiddenAssets'
+import useHiddenAssets from '@/hooks/useHiddenAssets'
 
 interface AssetsTableProps {
   items?: SafeBalanceResponse['items']
@@ -24,6 +24,30 @@ interface AssetsTableProps {
 const isNativeToken = (tokenInfo: TokenInfo) => {
   return tokenInfo.type === TokenType.NATIVE_TOKEN
 }
+
+const headCells = [
+  {
+    id: 'asset',
+    label: 'Asset',
+    width: '60%',
+  },
+  {
+    id: 'balance',
+    label: 'Balance',
+    width: '20%',
+  },
+  {
+    id: 'value',
+    label: 'Value',
+    width: '20%',
+  },
+  {
+    id: 'actions',
+    label: '',
+    width: '20%',
+    sticky: true,
+  },
+]
 
 const AssetsTable = ({ items }: AssetsTableProps): ReactElement => {
   const [selectedAsset, setSelectedAsset] = useState<string | undefined>()
@@ -52,35 +76,7 @@ const AssetsTable = ({ items }: AssetsTableProps): ReactElement => {
 
   const selectedAssetCount = visibleItems?.filter((item) => isAssetSelected(item.tokenInfo.address)).length || 0
 
-  const shouldHideActions = !isGranted
-
-  const headCells = useMemo(
-    () => [
-      {
-        id: 'asset',
-        label: 'Asset',
-        width: '60%',
-      },
-      {
-        id: 'balance',
-        label: 'Balance',
-        width: '20%',
-      },
-      {
-        id: 'value',
-        label: 'Value',
-        width: '20%',
-      },
-      {
-        id: 'actions',
-        label: '',
-        width: '20%',
-        hide: shouldHideActions,
-        sticky: true,
-      },
-    ],
-    [shouldHideActions],
-  )
+  const shouldHideSend = !isGranted
 
   const rows = (visibleItems || []).map((item) => {
     const rawFiatValue = parseFloat(item.fiatBalance)
@@ -131,19 +127,20 @@ const AssetsTable = ({ items }: AssetsTableProps): ReactElement => {
         actions: {
           rawValue: '',
           sticky: true,
-          hide: shouldHideActions,
           content: (
             <Box display="flex" flexDirection="row" gap={1} alignItems="center">
-              <Track {...ASSETS_EVENTS.SEND}>
-                <Button
-                  variant="contained"
-                  color="primary"
-                  size="small"
-                  onClick={() => setSelectedAsset(item.tokenInfo.address)}
-                >
-                  Send
-                </Button>
-              </Track>
+              {!shouldHideSend && (
+                <Track {...ASSETS_EVENTS.SEND}>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    size="small"
+                    onClick={() => setSelectedAsset(item.tokenInfo.address)}
+                  >
+                    Send
+                  </Button>
+                </Track>
+              )}
               {!isNative && (
                 <Track {...ASSETS_EVENTS.HIDE}>
                   <IconButton onClick={() => toggleAsset(item.tokenInfo.address)}>
@@ -170,7 +167,7 @@ const AssetsTable = ({ items }: AssetsTableProps): ReactElement => {
           </Box>
           <div>
             <Button onClick={reset} className={css.tinyButton} variant="outlined">
-              Deselect all
+              Cancel
             </Button>
             <Button onClick={saveChanges} className={css.tinyButton} variant="contained">
               Apply

--- a/src/components/balances/AssetsTable/styles.module.css
+++ b/src/components/balances/AssetsTable/styles.module.css
@@ -19,3 +19,19 @@
     display: none;
   }
 }
+
+.hideTokensHeader {
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+  gap: var(--space-1);
+  padding: 5px 16px;
+  background-color: var(--color-background-light);
+  border-radius: 6px;
+  min-width: 185px;
+}
+
+.tinyButton {
+  margin-left: var(--space-1);
+  padding: 4px 10px;
+}

--- a/src/components/balances/HiddenAssetsProvider/index.tsx
+++ b/src/components/balances/HiddenAssetsProvider/index.tsx
@@ -1,0 +1,95 @@
+import useChainId from '@/hooks/useChainId'
+import { useHiddenAssets } from '@/hooks/useHiddenAssets'
+import { useAppDispatch } from '@/store'
+import { addHiddenAssets, removeHiddenAssets } from '@/store/hiddenAssetsSlice'
+import { type ReactElement, type ReactNode, useState, useCallback } from 'react'
+import { createContext } from 'react'
+
+export const HiddenAssetsContext = createContext<{
+  showHiddenAssets: boolean
+  toggleShowHiddenAssets: () => void
+  toggleAsset: (address: string) => void
+  assetsToHide: string[]
+  assetsToUnhide: string[]
+  saveChanges: () => void
+  reset: () => void
+}>({
+  showHiddenAssets: false,
+  toggleShowHiddenAssets: () => {},
+  toggleAsset: () => {},
+  assetsToHide: [],
+  assetsToUnhide: [],
+  saveChanges: () => {},
+  reset: () => {},
+})
+
+const HiddenAssetsProvider = ({ children }: { children: ReactNode }): ReactElement => {
+  const [showHiddenAssets, setShowHiddenAssets] = useState(false)
+  const [assetsToHide, setAssetsToHide] = useState<string[]>([])
+  const [assetsToUnhide, setAssetsToUnhide] = useState<string[]>([])
+  const hiddenAssets = useHiddenAssets()
+  const dispatch = useAppDispatch()
+  const chainId = useChainId()
+
+  const toggleShowHiddenAssets = () => setShowHiddenAssets((prev) => !prev)
+
+  const toggleAsset = useCallback(
+    (address: string) => {
+      if (assetsToHide.includes(address)) {
+        assetsToHide.splice(assetsToHide.indexOf(address), 1)
+        setAssetsToHide([...assetsToHide])
+        return
+      }
+
+      if (assetsToUnhide.includes(address)) {
+        assetsToUnhide.splice(assetsToUnhide.indexOf(address), 1)
+        setAssetsToUnhide([...assetsToUnhide])
+        return
+      }
+
+      const assetIsHidden = hiddenAssets && typeof hiddenAssets[address] !== 'undefined'
+      if (!assetIsHidden) {
+        setAssetsToHide([...assetsToHide, address])
+      } else {
+        setAssetsToUnhide([...assetsToUnhide, address])
+      }
+    },
+    [assetsToHide, assetsToUnhide, hiddenAssets],
+  )
+
+  const reset = useCallback(() => {
+    setAssetsToHide([])
+    setAssetsToUnhide([])
+    setShowHiddenAssets(false)
+  }, [])
+
+  const saveChanges = useCallback(() => {
+    if (assetsToHide.length > 0) {
+      dispatch(addHiddenAssets({ chainId, assets: assetsToHide }))
+    }
+
+    if (assetsToUnhide.length > 0) {
+      dispatch(removeHiddenAssets({ chainId, assetAddresses: assetsToUnhide }))
+    }
+
+    reset()
+  }, [assetsToHide, assetsToUnhide, chainId, dispatch, reset])
+
+  return (
+    <HiddenAssetsContext.Provider
+      value={{
+        showHiddenAssets,
+        toggleShowHiddenAssets,
+        toggleAsset,
+        assetsToHide,
+        assetsToUnhide,
+        saveChanges,
+        reset,
+      }}
+    >
+      {children}
+    </HiddenAssetsContext.Provider>
+  )
+}
+
+export default HiddenAssetsProvider

--- a/src/components/balances/HiddenAssetsProvider/index.tsx
+++ b/src/components/balances/HiddenAssetsProvider/index.tsx
@@ -1,5 +1,5 @@
 import useChainId from '@/hooks/useChainId'
-import { useHiddenAssets } from '@/hooks/useHiddenAssets'
+import useHiddenAssets from '@/hooks/useHiddenAssets'
 import { useAppDispatch } from '@/store'
 import { addHiddenAssets, removeHiddenAssets } from '@/store/hiddenAssetsSlice'
 import { type ReactElement, type ReactNode, useState, useCallback } from 'react'

--- a/src/components/common/EnhancedTable/index.tsx
+++ b/src/components/common/EnhancedTable/index.tsx
@@ -17,15 +17,17 @@ import classNames from 'classnames'
 
 import css from './styles.module.css'
 
-type EnhancedRow = Record<
-  string,
-  {
-    content: ReactNode
-    rawValue: string | number
-    sticky?: boolean
-    hide?: boolean
-  }
->
+type EnhancedCell = {
+  content: ReactNode
+  rawValue: string | number
+  sticky?: boolean
+  hide?: boolean
+}
+
+type EnhancedRow = {
+  selected?: boolean
+  cells: Record<string, EnhancedCell>
+}
 
 type EnhancedHeadCell = {
   id: string
@@ -36,10 +38,10 @@ type EnhancedHeadCell = {
 }
 
 function descendingComparator(a: EnhancedRow, b: EnhancedRow, orderBy: string) {
-  if (b[orderBy].rawValue < a[orderBy].rawValue) {
+  if (b.cells[orderBy].rawValue < a.cells[orderBy].rawValue) {
     return -1
   }
-  if (b[orderBy].rawValue > a[orderBy].rawValue) {
+  if (b.cells[orderBy].rawValue > a.cells[orderBy].rawValue) {
     return 1
   }
   return 0
@@ -139,8 +141,8 @@ function EnhancedTable({ rows, headCells, variant }: EnhancedTableProps) {
           <TableBody>
             {pagedRows.length > 0 ? (
               pagedRows.map((row, index) => (
-                <TableRow tabIndex={-1} key={index}>
-                  {Object.entries(row).map(([key, cell]) => (
+                <TableRow tabIndex={-1} key={index} selected={row.selected}>
+                  {Object.entries(row.cells).map(([key, cell]) => (
                     <TableCell
                       key={key}
                       className={classNames({

--- a/src/components/settings/SpendingLimits/SpendingLimitsTable.tsx
+++ b/src/components/settings/SpendingLimits/SpendingLimitsTable.tsx
@@ -58,41 +58,43 @@ export const SpendingLimitsTable = ({ spendingLimits }: { spendingLimits: Spendi
         const formattedSpent = safeFormatUnits(spent, token?.tokenInfo.decimals)
 
         return {
-          beneficiary: {
-            rawValue: spendingLimit.beneficiary,
-            content: (
-              <EthHashInfo address={spendingLimit.beneficiary} shortAddress={false} hasExplorer showCopyButton />
-            ),
-          },
-          spent: {
-            rawValue: spendingLimit.spent,
-            content: (
-              <Box display="flex" alignItems="center" gap={1}>
-                <TokenIcon logoUri={token?.tokenInfo.logoUri} tokenSymbol={token?.tokenInfo.symbol} />
-                {`${formattedSpent} of ${formattedAmount} ${token?.tokenInfo.symbol}`}
-              </Box>
-            ),
-          },
-          resetTime: {
-            rawValue: spendingLimit.resetTimeMin,
-            content: (
-              <SpendingLimitLabel
-                label={relativeTime(spendingLimit.lastResetMin, spendingLimit.resetTimeMin)}
-                isOneTime={spendingLimit.resetTimeMin === '0'}
-              />
-            ),
-          },
-          actions: {
-            rawValue: '',
-            sticky: true,
-            hide: shouldHideactions,
-            content: (
-              <Track {...SETTINGS_EVENTS.SPENDING_LIMIT.REMOVE_LIMIT}>
-                <IconButton onClick={() => onRemove(spendingLimit)} color="error" size="small">
-                  <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
-                </IconButton>
-              </Track>
-            ),
+          cells: {
+            beneficiary: {
+              rawValue: spendingLimit.beneficiary,
+              content: (
+                <EthHashInfo address={spendingLimit.beneficiary} shortAddress={false} hasExplorer showCopyButton />
+              ),
+            },
+            spent: {
+              rawValue: spendingLimit.spent,
+              content: (
+                <Box display="flex" alignItems="center" gap={1}>
+                  <TokenIcon logoUri={token?.tokenInfo.logoUri} tokenSymbol={token?.tokenInfo.symbol} />
+                  {`${formattedSpent} of ${formattedAmount} ${token?.tokenInfo.symbol}`}
+                </Box>
+              ),
+            },
+            resetTime: {
+              rawValue: spendingLimit.resetTimeMin,
+              content: (
+                <SpendingLimitLabel
+                  label={relativeTime(spendingLimit.lastResetMin, spendingLimit.resetTimeMin)}
+                  isOneTime={spendingLimit.resetTimeMin === '0'}
+                />
+              ),
+            },
+            actions: {
+              rawValue: '',
+              sticky: true,
+              hide: shouldHideactions,
+              content: (
+                <Track {...SETTINGS_EVENTS.SPENDING_LIMIT.REMOVE_LIMIT}>
+                  <IconButton onClick={() => onRemove(spendingLimit)} color="error" size="small">
+                    <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
+                  </IconButton>
+                </Track>
+              ),
+            },
           },
         }
       }),

--- a/src/components/settings/owner/OwnerList/index.tsx
+++ b/src/components/settings/owner/OwnerList/index.tsx
@@ -26,20 +26,22 @@ export const OwnerList = ({ isGranted }: { isGranted: boolean }) => {
       const name = addressBook[address]
 
       return {
-        owner: {
-          rawValue: address,
-          content: <EthHashInfo address={address} showCopyButton shortAddress={false} showName={true} hasExplorer />,
-        },
-        actions: {
-          rawValue: '',
-          sticky: true,
-          content: (
-            <div className={tableCss.actions}>
-              {isGranted && <ReplaceOwnerDialog address={address} />}
-              <EditOwnerDialog address={address} name={name} chainId={safe.chainId} />
-              {isGranted && <RemoveOwnerDialog owner={{ address, name }} />}
-            </div>
-          ),
+        cells: {
+          owner: {
+            rawValue: address,
+            content: <EthHashInfo address={address} showCopyButton shortAddress={false} showName={true} hasExplorer />,
+          },
+          actions: {
+            rawValue: '',
+            sticky: true,
+            content: (
+              <div className={tableCss.actions}>
+                {isGranted && <ReplaceOwnerDialog address={address} />}
+                <EditOwnerDialog address={address} name={name} chainId={safe.chainId} />
+                {isGranted && <RemoveOwnerDialog owner={{ address, name }} />}
+              </div>
+            ),
+          },
         },
       }
     })

--- a/src/hooks/__tests__/useBalances.test.ts
+++ b/src/hooks/__tests__/useBalances.test.ts
@@ -1,0 +1,126 @@
+import { type SafeBalanceResponse, TokenType } from '@safe-global/safe-gateway-typescript-sdk'
+import * as store from '@/store'
+import * as hiddenAssets from '../useHiddenAssets'
+import { renderHook } from '@/tests/test-utils'
+import useBalances from '../useBalances'
+import { hexZeroPad } from 'ethers/lib/utils'
+
+describe('useBalances', () => {
+  test('empty balance', () => {
+    const balance: SafeBalanceResponse = {
+      fiatTotal: '0',
+      items: [],
+    }
+    jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
+      selector({
+        balances: { data: balance, error: undefined, loading: false },
+      } as store.RootState),
+    )
+
+    jest.spyOn(hiddenAssets, 'default').mockReturnValue({})
+
+    const { result } = renderHook(() => useBalances(false))
+
+    expect(result.current.balances.fiatTotal).toEqual('0')
+    expect(result.current.balances.items).toHaveLength(0)
+  })
+
+  test('return all balances if includeHidden true', () => {
+    const hiddenTokenAddress = hexZeroPad('0x2', 20)
+    const balance: SafeBalanceResponse = {
+      fiatTotal: '100',
+      items: [
+        {
+          balance: '40',
+          fiatBalance: '40',
+          fiatConversion: '1',
+          tokenInfo: {
+            address: hiddenTokenAddress,
+            decimals: 18,
+            logoUri: '',
+            name: 'Hidden Token',
+            symbol: 'HT',
+            type: TokenType.ERC20,
+          },
+        },
+        {
+          balance: '60',
+          fiatBalance: '60',
+          fiatConversion: '1',
+          tokenInfo: {
+            address: hiddenTokenAddress,
+            decimals: 18,
+            logoUri: '',
+            name: 'Visible Token',
+            symbol: 'VT',
+            type: TokenType.ERC20,
+          },
+        },
+      ],
+    }
+
+    jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
+      selector({
+        balances: { data: balance, error: undefined, loading: false },
+      } as store.RootState),
+    )
+
+    jest.spyOn(hiddenAssets, 'default').mockReturnValue({
+      [hiddenTokenAddress]: hiddenTokenAddress,
+    })
+
+    const { result } = renderHook(() => useBalances(true))
+
+    expect(result.current.balances.fiatTotal).toEqual('100')
+    expect(result.current.balances.items).toHaveLength(2)
+  })
+
+  test('return only visible balances if includeHidden false', () => {
+    const hiddenTokenAddress = hexZeroPad('0x2', 20)
+    const balance: SafeBalanceResponse = {
+      fiatTotal: '100',
+      items: [
+        {
+          balance: '40',
+          fiatBalance: '40',
+          fiatConversion: '1',
+          tokenInfo: {
+            address: hiddenTokenAddress,
+            decimals: 18,
+            logoUri: '',
+            name: 'Hidden Token',
+            symbol: 'HT',
+            type: TokenType.ERC20,
+          },
+        },
+        {
+          balance: '60',
+          fiatBalance: '60',
+          fiatConversion: '1',
+          tokenInfo: {
+            address: hexZeroPad('0x3', 20),
+            decimals: 18,
+            logoUri: '',
+            name: 'Visible Token',
+            symbol: 'VT',
+            type: TokenType.ERC20,
+          },
+        },
+      ],
+    }
+
+    jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
+      selector({
+        balances: { data: balance, error: undefined, loading: false },
+      } as store.RootState),
+    )
+    jest.spyOn(hiddenAssets, 'default').mockReturnValue({
+      [hiddenTokenAddress]: hiddenTokenAddress,
+    })
+
+    const { result } = renderHook(() => useBalances(false))
+
+    expect(result.current.balances.fiatTotal).toEqual('60')
+    expect(result.current.balances.items).toHaveLength(1)
+  })
+})

--- a/src/hooks/useBalances.ts
+++ b/src/hooks/useBalances.ts
@@ -3,22 +3,52 @@ import isEqual from 'lodash/isEqual'
 import { type SafeBalanceResponse } from '@safe-global/safe-gateway-typescript-sdk'
 import { useAppSelector } from '@/store'
 import { selectBalances } from '@/store/balancesSlice'
+import type { HiddenAssetsOnChain } from '@/store/hiddenAssetsSlice'
+import useHiddenAssets from './useHiddenAssets'
+import { safeFormatUnits, safeParseUnits } from '@/utils/formatters'
+import { BigNumber } from 'ethers'
 
-const useBalances = (): {
+const removeHiddenBalances = (
+  balances: SafeBalanceResponse,
+  hiddenAssets: HiddenAssetsOnChain,
+): SafeBalanceResponse => {
+  const fiatTotalVisible = safeFormatUnits(
+    balances.items
+      .reduce((acc, balanceItem) => {
+        if (typeof hiddenAssets?.[balanceItem.tokenInfo.address] !== 'undefined') {
+          return acc.sub(safeParseUnits(balanceItem.fiatBalance, 18) || 0)
+        }
+        return acc
+      }, BigNumber.from(!balances || balances.fiatTotal === '' ? 0 : safeParseUnits(balances.fiatTotal, 18)))
+      .toString(),
+    18,
+  )
+
+  const balanceItemsVisible = balances.items.filter(
+    (balanceItem) => hiddenAssets?.[balanceItem.tokenInfo.address] === undefined,
+  )
+
+  return { fiatTotal: fiatTotalVisible, items: balanceItemsVisible }
+}
+
+const useBalances = (
+  includeHidden = false,
+): {
   balances: SafeBalanceResponse
   loading: boolean
   error?: string
 } => {
   const state = useAppSelector(selectBalances, isEqual)
+  const hiddenAssets = useHiddenAssets()
   const { data, error, loading } = state
 
   return useMemo(
     () => ({
-      balances: data,
+      balances: includeHidden ? data : removeHiddenBalances(data, hiddenAssets || {}),
       error,
       loading,
     }),
-    [data, error, loading],
+    [includeHidden, data, hiddenAssets, error, loading],
   )
 }
 

--- a/src/hooks/useHiddenAssets.ts
+++ b/src/hooks/useHiddenAssets.ts
@@ -2,7 +2,9 @@ import { useAppSelector } from '@/store'
 import { selectHiddenAssetsPerChain } from '@/store/hiddenAssetsSlice'
 import useChainId from './useChainId'
 
-export const useHiddenAssets = () => {
+const useHiddenAssets = () => {
   const chainId = useChainId()
   return useAppSelector((state) => selectHiddenAssetsPerChain(state, chainId))
 }
+
+export default useHiddenAssets

--- a/src/hooks/useHiddenAssets.ts
+++ b/src/hooks/useHiddenAssets.ts
@@ -1,0 +1,8 @@
+import { useAppSelector } from '@/store'
+import { selectHiddenAssetsPerChain } from '@/store/hiddenAssetsSlice'
+import useChainId from './useChainId'
+
+export const useHiddenAssets = () => {
+  const chainId = useChainId()
+  return useAppSelector((state) => selectHiddenAssetsPerChain(state, chainId))
+}

--- a/src/pages/balances/index.tsx
+++ b/src/pages/balances/index.tsx
@@ -12,7 +12,7 @@ import NoAssetsIcon from '@/public/images/balances/no-assets.svg'
 import HiddenAssetsProvider from '@/components/balances/HiddenAssetsProvider'
 
 const Balances: NextPage = () => {
-  const { balances, loading, error } = useBalances()
+  const { balances, loading, error } = useBalances(true)
 
   useEffect(() => {
     if (!loading && balances.items.length === 0) {

--- a/src/pages/balances/index.tsx
+++ b/src/pages/balances/index.tsx
@@ -9,6 +9,7 @@ import { useEffect } from 'react'
 import { trackEvent, ASSETS_EVENTS } from '@/services/analytics'
 import PagePlaceholder from '@/components/common/PagePlaceholder'
 import NoAssetsIcon from '@/public/images/balances/no-assets.svg'
+import HiddenAssetsProvider from '@/components/balances/HiddenAssetsProvider'
 
 const Balances: NextPage = () => {
   const { balances, loading, error } = useBalances()
@@ -25,17 +26,19 @@ const Balances: NextPage = () => {
         <title>Safe – Assets</title>
       </Head>
 
-      <AssetsHeader currencySelect />
+      <HiddenAssetsProvider>
+        <AssetsHeader currencySelect hiddenAssets />
 
-      <main>
-        {loading && <CircularProgress size={20} sx={{ marginTop: 2 }} />}
+        <main>
+          {loading && <CircularProgress size={20} sx={{ marginTop: 2 }} />}
 
-        {!error ? (
-          <AssetsTable items={balances?.items} />
-        ) : (
-          <PagePlaceholder img={<NoAssetsIcon />} text="There was an error loading your assets" />
-        )}
-      </main>
+          {!error ? (
+            <AssetsTable items={balances?.items} />
+          ) : (
+            <PagePlaceholder img={<NoAssetsIcon />} text="There was an error loading your assets" />
+          )}
+        </main>
+      </HiddenAssetsProvider>
     </>
   )
 }

--- a/src/services/analytics/events/assets.ts
+++ b/src/services/analytics/events/assets.ts
@@ -21,4 +21,12 @@ export const ASSETS_EVENTS = {
     action: 'Send',
     category: ASSETS_CATEGORY,
   },
+  HIDE: {
+    action: 'Hide',
+    category: ASSETS_CATEGORY,
+  },
+  UNHIDE: {
+    action: 'Unhide',
+    category: ASSETS_CATEGORY,
+  },
 }

--- a/src/store/hiddenAssetsSlice.ts
+++ b/src/store/hiddenAssetsSlice.ts
@@ -1,0 +1,54 @@
+import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { RootState } from '.'
+
+export type HiddenAssetsOnChain = {
+  [tokenAddress: string]: string
+}
+
+export type HiddenAssetsState = {
+  [chainId: string]: HiddenAssetsOnChain
+}
+
+const initialState: HiddenAssetsState = {}
+
+export const hiddenAssetsSlice = createSlice({
+  name: 'hiddenAssets',
+  initialState,
+  reducers: {
+    addHiddenAssets: (state, action: PayloadAction<{ chainId: string; assets: string[] }>) => {
+      const { payload } = action
+      const { chainId, assets } = payload
+
+      state[chainId] ??= {}
+      assets.forEach((asset) => {
+        state[chainId][asset] = asset
+      })
+    },
+
+    removeHiddenAssets: (state, action: PayloadAction<{ chainId: string; assetAddresses: string[] }>) => {
+      const { payload } = action
+      const { chainId, assetAddresses } = payload
+
+      assetAddresses.forEach((address) => {
+        delete state[chainId]?.[address]
+
+        if (Object.keys(state[chainId]).length === 0) {
+          delete state[chainId]
+        }
+      })
+    },
+  },
+})
+
+export const { addHiddenAssets, removeHiddenAssets } = hiddenAssetsSlice.actions
+
+export const selectAllHiddenAssets = (state: RootState): HiddenAssetsState => {
+  return state[hiddenAssetsSlice.name]
+}
+
+export const selectHiddenAssetsPerChain = createSelector(
+  [selectAllHiddenAssets, (_: RootState, chainId: string) => chainId],
+  (allHiddenAssets, chainId): HiddenAssetsOnChain | undefined => {
+    return allHiddenAssets[chainId]
+  },
+)

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -24,6 +24,7 @@ import { cookiesSlice } from './cookiesSlice'
 import { popupSlice } from './popupSlice'
 import { spendingLimitSlice } from './spendingLimitsSlice'
 import { safeAppsSlice } from './safeAppsSlice'
+import { hiddenAssetsSlice } from './hiddenAssetsSlice'
 
 const rootReducer = combineReducers({
   [chainsSlice.name]: chainsSlice.reducer,
@@ -41,6 +42,7 @@ const rootReducer = combineReducers({
   [popupSlice.name]: popupSlice.reducer,
   [spendingLimitSlice.name]: spendingLimitSlice.reducer,
   [safeAppsSlice.name]: safeAppsSlice.reducer,
+  [hiddenAssetsSlice.name]: hiddenAssetsSlice.reducer,
 })
 
 const persistedSlices: (keyof PreloadedState<RootState>)[] = [
@@ -51,6 +53,7 @@ const persistedSlices: (keyof PreloadedState<RootState>)[] = [
   settingsSlice.name,
   cookiesSlice.name,
   safeAppsSlice.name,
+  hiddenAssetsSlice.name,
 ]
 
 const middleware = [persistState(persistedSlices), txHistoryMiddleware, txQueueMiddleware, addedSafesMiddleware]

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -167,6 +167,9 @@ const initTheme = (darkMode: boolean) => {
               border: '2px solid',
             },
           },
+          contained: {
+            border: '2px solid',
+          },
           sizeLarge: { fontSize: '16px' },
         },
       },
@@ -399,6 +402,9 @@ const initTheme = (darkMode: boolean) => {
             },
 
             '& .MuiTableRow-root:hover': {
+              backgroundColor: theme.palette.background.light,
+            },
+            '& .MuiTableRow-root.Mui-selected': {
               backgroundColor: theme.palette.background.light,
             },
           }),


### PR DESCRIPTION
## What it solves
Unwanted / spam tokens could not be hidden from the interface.

Resolves #1337 

## How this PR fixes it
- New button in Assets page to manually hide / unhide tokens
- new parameter for `useBalances` to get all or only not hidden tokens

## How to test it
- Hide some tokens in the Assets page of a safe
- These tokens should be hidden for all Safes on that chain
  - Not appear in assets
  - not counted in total balance
  - not appear through safe apps sdk `getBalance`
  - not show in Dashboard Overview

## Analytics changes
- New events for hiding / unhiding tokens
## Screenshots
