### PR TITLE
chore: enable no-constant-condition eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,8 @@
   "rules": {
     "@next/next/no-img-element": "off",
     "unused-imports/no-unused-imports-ts": "error",
-    "@typescript-eslint/consistent-type-imports": "error"
+    "@typescript-eslint/consistent-type-imports": "error",
+    "no-constant-condition": "warn"
   },
   "ignorePatterns": ["node_modules/", ".next/", ".github/"],
   "plugins": ["unused-imports", "@typescript-eslint"]


### PR DESCRIPTION
## What it solves
Enables `no-constant-condition` eslint rule which detects constant conditions such as

```ts
if ("constant" {
  doSomething()
}
```

## How to test it
Add constant conditions in some code and see a warning appear.
