### PR TITLE
fix: expire/clear pairing session after 24h

### DIFF
--- a/src/services/pairing/__tests__/utils.test.ts
+++ b/src/services/pairing/__tests__/utils.test.ts
@@ -74,7 +74,7 @@ describe('Pairing utils', () => {
 
       window.localStorage.setItem('SAFE_v2__pairingConnector', JSON.stringify(session))
 
-      jest.spyOn(Date, 'now').mockImplementation(() => session.handshakeId + 1)
+      jest.spyOn(Date, 'now').mockImplementation(() => +session.handshakeId.toString().slice(0, -3) + 1)
 
       expect(hasValidPairingSession()).toBe(true)
     })
@@ -87,7 +87,7 @@ describe('Pairing utils', () => {
       window.localStorage.setItem('SAFE_v2__pairingConnector', JSON.stringify(session))
 
       const sessionTimestamp = session.handshakeId.toString().slice(0, -3)
-      const expirationDate = addDays(new Date(sessionTimestamp), 1)
+      const expirationDate = addDays(new Date(+sessionTimestamp), 1)
 
       jest.spyOn(Date, 'now').mockImplementation(() => expirationDate.getTime() + 1)
 

--- a/src/services/pairing/__tests__/utils.test.ts
+++ b/src/services/pairing/__tests__/utils.test.ts
@@ -1,7 +1,7 @@
 import { addDays } from 'date-fns'
 import type { IWalletConnectSession } from '@walletconnect/types'
 
-import { formatPairingUri, isPairingSupported, hasValidPairingSession, _hasPairingSessionExpired } from '../utils'
+import { formatPairingUri, isPairingSupported, hasValidPairingSession, _isPairingSessionExpired } from '../utils'
 
 describe('Pairing utils', () => {
   describe('formatPairingUri', () => {
@@ -40,13 +40,13 @@ describe('Pairing utils', () => {
     })
   })
 
-  describe('hasPairingSessionExpired', () => {
+  describe('isPairingSessionExpired', () => {
     it('should return true if the session is older than 24h', () => {
       const session: Pick<IWalletConnectSession, 'handshakeId'> = {
         handshakeId: 1000000000000123,
       }
 
-      expect(_hasPairingSessionExpired(session as IWalletConnectSession)).toBe(true)
+      expect(_isPairingSessionExpired(session as IWalletConnectSession)).toBe(true)
     })
 
     it('should return false if the session is within the last 24h', () => {
@@ -54,7 +54,7 @@ describe('Pairing utils', () => {
         handshakeId: +`${Date.now()}123`,
       }
 
-      expect(_hasPairingSessionExpired(session as IWalletConnectSession)).toBe(false)
+      expect(_isPairingSessionExpired(session as IWalletConnectSession)).toBe(false)
     })
   })
 

--- a/src/services/pairing/connector.ts
+++ b/src/services/pairing/connector.ts
@@ -5,13 +5,8 @@ import packageJson from '../../../package.json'
 import { IS_PRODUCTION } from '@/config/constants'
 import ExternalStore from '@/services/ExternalStore'
 import PairingIcon from '@/public/images/safe-logo-green.png'
-import local from '../local-storage/local'
 
 export const PAIRING_MODULE_STORAGE_ID = 'pairingConnector'
-
-export const hasStoredPairingSession = (): boolean => {
-  return Boolean(local.getItem(PAIRING_MODULE_STORAGE_ID))
-}
 
 export const getClientMeta = () => {
   const host = location.origin

--- a/src/services/pairing/utils.ts
+++ b/src/services/pairing/utils.ts
@@ -1,4 +1,4 @@
-import { addDays, isBefore } from 'date-fns'
+import { addDays, isAfter } from 'date-fns'
 import type { IWalletConnectSession } from '@walletconnect/types'
 import type WalletConnect from '@walletconnect/client'
 
@@ -39,7 +39,7 @@ export const _hasPairingSessionExpired = (session: IWalletConnectSession): boole
   // The session is valid for 24h (mobile clears it on their end)
   const expirationDate = addDays(new Date(+sessionTimestamp), 1)
 
-  return isBefore(expirationDate, Date.now())
+  return isAfter(Date.now(), expirationDate)
 }
 
 export const hasValidPairingSession = (): boolean => {
@@ -49,11 +49,11 @@ export const hasValidPairingSession = (): boolean => {
     return false
   }
 
-  const isValid = _hasPairingSessionExpired(cachedSession)
+  const hasExpired = _hasPairingSessionExpired(cachedSession)
 
-  if (!isValid) {
+  if (hasExpired) {
     local.removeItem(PAIRING_MODULE_STORAGE_ID)
   }
 
-  return isValid
+  return !hasExpired
 }

--- a/src/services/pairing/utils.ts
+++ b/src/services/pairing/utils.ts
@@ -33,7 +33,7 @@ export const isPairingSupported = (disabledWallets?: string[]) => {
   return !!disabledWallets?.length && !disabledWallets.includes(CGW_NAMES[WALLET_KEYS.PAIRING] as string)
 }
 
-export const _hasPairingSessionExpired = (session: IWalletConnectSession): boolean => {
+export const _isPairingSessionExpired = (session: IWalletConnectSession): boolean => {
   // WC appends 3 digits to the timestamp. NOTE: This may change in WC v2
   const sessionTimestamp = session.handshakeId.toString().slice(0, -3)
   // The session is valid for 24h (mobile clears it on their end)
@@ -49,11 +49,11 @@ export const hasValidPairingSession = (): boolean => {
     return false
   }
 
-  const hasExpired = _hasPairingSessionExpired(cachedSession)
+  const isExpired = _isPairingSessionExpired(cachedSession)
 
-  if (hasExpired) {
+  if (isExpired) {
     local.removeItem(PAIRING_MODULE_STORAGE_ID)
   }
 
-  return !hasExpired
+  return !isExpired
 }

--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -1,5 +1,5 @@
 import { ProviderLabel } from '@web3-onboard/injected-wallets'
-import { hasStoredPairingSession } from '@/services/pairing/connector'
+import { hasValidPairingSession } from '@/services/pairing/utils'
 import { PAIRING_MODULE_LABEL } from '@/services/pairing/module'
 import { E2E_WALLET_NAME } from '@/tests/e2e-wallet'
 import type { EthersError } from '@/utils/ethers-utils'
@@ -38,8 +38,8 @@ export const isWalletUnlocked = async (walletName: string): Promise<boolean> => 
   }
 
   // Our own Safe mobile pairing module
-  if (walletName === WalletNames.SAFE_MOBILE_PAIRING && hasStoredPairingSession()) {
-    return hasStoredPairingSession()
+  if (walletName === WalletNames.SAFE_MOBILE_PAIRING && hasValidPairingSession()) {
+    return hasValidPairingSession()
   }
 
   if (walletName === E2E_WALLET_NAME) {


### PR DESCRIPTION
## What it solves

Resolves #701

## How this PR fixes it

Previously cached pairing sessions (if last connected >24h) are no longer automatically connected to/are cleared.

## How to test it

Connect to the Safe UI via pairing. Increase system time by 24h (+1m) and observe that reconnection does not automatically happen. The `SAFE_v2__pairingConnector` `localStorage` item should also no longer be present.

When returning to the Safe UI within a 24h window, the pairing session should connect as before.