### PR TITLE
fix(safe-apps-e2e): Add timeout for avoid flakiness when transaction modal is showed

### DIFF
--- a/cypress/e2e/safe-apps/tx_modal.cy.js
+++ b/cypress/e2e/safe-apps/tx_modal.cy.js
@@ -19,7 +19,7 @@ describe('The transaction modal', () => {
   })
 
   describe('When sending a transaction from an app', () => {
-    it('should show the transaction popup', () => {
+    it('should show the transaction popup', { defaultCommandTimeout: 12000 }, () => {
       cy.findByRole('dialog').within(() => {
         cy.findByText(/sending from/i)
 


### PR DESCRIPTION
## What it solves

Flakiness in transaction modal e2e test
