### PR TITLE
Fix: psa banner fixed on top

### DIFF
--- a/src/components/common/Header/styles.module.css
+++ b/src/components/common/Header/styles.module.css
@@ -1,4 +1,5 @@
 .container {
+  height: var(--header-inner-height);
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
@@ -7,7 +8,6 @@
   border-radius: 0 !important;
   background-color: var(--color-background-paper);
   border-bottom: 1px solid var(--color-border-light);
-  min-height: 52px;
 }
 
 .element {

--- a/src/components/common/Header/styles.module.css
+++ b/src/components/common/Header/styles.module.css
@@ -1,5 +1,4 @@
 .container {
-  height: var(--header-height);
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
@@ -8,6 +7,7 @@
   border-radius: 0 !important;
   background-color: var(--color-background-paper);
   border-bottom: 1px solid var(--color-border-light);
+  min-height: 52px;
 }
 
 .element {

--- a/src/components/common/PageHeader/styles.module.css
+++ b/src/components/common/PageHeader/styles.module.css
@@ -1,14 +1,13 @@
 .container {
   padding: var(--space-4) var(--space-3) 0;
-  box-sizing: content-box;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   background-color: var(--color-background-main);
   z-index: 1;
-  width: calc(100% - var(--space-6));
+  width: 100%;
   position: sticky !important;
-  top: -12px;
+  top: calc(var(--header-height) - 76px);
 }
 
 .title {

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -6,6 +6,7 @@ import css from './styles.module.css'
 import SafeLoadingError from '../SafeLoadingError'
 import Footer from '../Footer'
 import SideDrawer from './SideDrawer'
+import PsaBanner from '../PsaBanner'
 
 const PageLayout = ({ children }: { children: ReactElement }): ReactElement => {
   const [isSidebarOpen, setSidebarOpen] = useState<boolean>(true)
@@ -17,6 +18,7 @@ const PageLayout = ({ children }: { children: ReactElement }): ReactElement => {
   return (
     <>
       <header className={css.header}>
+        <PsaBanner />
         <Header onMenuToggle={toggleSidebar} />
       </header>
 

--- a/src/components/common/PageLayout/styles.module.css
+++ b/src/components/common/PageLayout/styles.module.css
@@ -4,7 +4,6 @@
   top: 0;
   width: 100%;
   z-index: 1201;
-  height: var(--header-height);
 }
 
 .main {

--- a/src/components/common/PageLayout/styles.module.css
+++ b/src/components/common/PageLayout/styles.module.css
@@ -4,6 +4,7 @@
   top: 0;
   width: 100%;
   z-index: 1201;
+  height: var(--header-height);
 }
 
 .main {

--- a/src/components/common/PsaBanner/index.module.css
+++ b/src/components/common/PsaBanner/index.module.css
@@ -16,7 +16,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 52px;
+  min-height: var(--header-inner-height);
 }
 
 .content {

--- a/src/components/common/PsaBanner/index.module.css
+++ b/src/components/common/PsaBanner/index.module.css
@@ -1,9 +1,4 @@
 .banner {
-  position: fixed;
-  z-index: 10000;
-  top: 0;
-  left: 0;
-  right: 0;
   background-color: var(--color-info-dark);
   color: var(--color-text-light);
   padding: 0 var(--space-3);
@@ -21,7 +16,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: var(--header-height);
+  min-height: 52px;
 }
 
 .content {

--- a/src/components/common/PsaBanner/index.module.css
+++ b/src/components/common/PsaBanner/index.module.css
@@ -41,6 +41,6 @@
 
 @media (max-width: 600px) {
   .banner {
-    padding: var(--space-1) var(--space-3);
+    padding: var(--space-1) var(--space-2);
   }
 }

--- a/src/components/common/PsaBanner/index.tsx
+++ b/src/components/common/PsaBanner/index.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement, ReactNode } from 'react'
+import { useEffect } from 'react'
 import { isEmpty } from 'lodash'
 import type { FEATURES } from '@safe-global/safe-gateway-typescript-sdk'
 import { IconButton } from '@mui/material'
@@ -49,6 +50,12 @@ const PsaBanner = (): ReactElement | null => {
   const onClose = () => {
     setClosed(true)
   }
+
+  useEffect(() => {
+    const className = 'psaBanner'
+    document.documentElement.classList?.toggle(className, showBanner)
+    return () => document.documentElement.classList?.remove(className)
+  }, [showBanner])
 
   return showBanner ? (
     <div className={styles.banner}>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -33,7 +33,6 @@ import createEmotionCache from '@/utils/createEmotionCache'
 import MetaTags from '@/components/common/MetaTags'
 import useABTesting from '@/services/tracking/useABTesting'
 import { AbTest } from '@/services/tracking/abTesting'
-import PsaBanner from '@/components/common/PsaBanner'
 
 const GATEWAY_URL = IS_PRODUCTION || cgwDebugStorage.get() ? GATEWAY_URL_PRODUCTION : GATEWAY_URL_STAGING
 
@@ -89,8 +88,6 @@ const WebCoreApp = ({ Component, pageProps, emotionCache = clientSideEmotionCach
           <CssBaseline />
 
           <InitApp />
-
-          <PsaBanner />
 
           <PageLayout>
             <Component {...pageProps} />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -41,16 +41,20 @@ button {
 }
 
 :root {
-  --header-height: 52px;
+  --header-inner-height: 52px;
+}
+
+:root {
+  --header-height: var(--header-inner-height);
 }
 
 .psaBanner:root {
-  --header-height: 104px;
+  --header-height: calc(var(--header-inner-height) * 2);
 }
 
 @media (max-width: 600px) {
   .psaBanner:root {
-    --header-height: 120px;
+    --header-height: calc(var(--header-inner-height) * 2 + 16px);
   }
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -52,6 +52,7 @@ button {
   --header-height: calc(var(--header-inner-height) * 2);
 }
 
+/* On mobile, the banner text is two lines + padding */
 @media (max-width: 600px) {
   .psaBanner:root {
     --header-height: calc(var(--header-inner-height) * 2 + 16px);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -44,6 +44,16 @@ button {
   --header-height: 52px;
 }
 
+.psaBanner:root {
+  --header-height: 104px;
+}
+
+@media (max-width: 600px) {
+  .psaBanner:root {
+    --header-height: 120px;
+  }
+}
+
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
   -webkit-appearance: none;


### PR DESCRIPTION
## What it solves

Resolves #1202

## How this PR fixes it
The banner is now statically positioned on top of the header. When it's opened, the global header-height variable is set to 104px. When it's closed, it's set back to 52px.

<img width="1137" alt="Screenshot 2022-12-19 at 16 05 03" src="https://user-images.githubusercontent.com/381895/208455978-d0641734-359f-4abf-9ae5-a34e4e4924ad.png">
