### PR TITLE
fix: modal header text + smaller message font

### DIFF
--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -299,8 +299,8 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
           (signMessageModalState.isOffChain ? (
             <MsgModal
               onClose={onSafeAppsModalClose}
-              logoUri={remoteApp?.iconUrl || ''}
-              name={remoteApp?.name || ''}
+              logoUri={safeAppFromManifest?.iconUrl || ''}
+              name={safeAppFromManifest?.name || ''}
               message={signMessageModalState.message}
               safeAppId={remoteApp?.id}
               requestId={signMessageModalState.requestId}

--- a/src/components/safe-messages/Msg/index.tsx
+++ b/src/components/safe-messages/Msg/index.tsx
@@ -17,16 +17,16 @@ const Msg = ({ message }: { message: SafeMessage['message'] }): ReactElement => 
   }
 
   return (
-    <div>
-      {showMsg && (
-        <pre style={{ margin: 0 }}>
-          <code>{JSON.stringify(message, null, 2)}</code>
-        </pre>
-      )}
+    <>
       <Link component="button" onClick={handleToggleMsg} fontSize="medium" className={css.toggle}>
         {showMsg ? 'Hide' : 'Show'}
       </Link>
-    </div>
+      {showMsg && (
+        <pre>
+          <code>{JSON.stringify(message, null, 2)}</code>
+        </pre>
+      )}
+    </>
   )
 }
 

--- a/src/components/safe-messages/Msg/styles.module.css
+++ b/src/components/safe-messages/Msg/styles.module.css
@@ -1,5 +1,4 @@
 .toggle {
   font-weight: 700;
   text-decoration: underline;
-  margin-top: var(--space-1);
 }

--- a/src/components/safe-messages/MsgModal/index.tsx
+++ b/src/components/safe-messages/MsgModal/index.tsx
@@ -14,8 +14,6 @@ import { dispatchSafeMsgConfirmation, dispatchSafeMsgProposal } from '@/services
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { generateSafeMessageHash, generateSafeMessageMessage } from '@/utils/safe-messages'
 import { getDecodedMessage } from '@/components/safe-apps/utils'
-
-import txStepperCss from '@/components/tx/TxStepper/styles.module.css'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import useIsWrongChain from '@/hooks/useIsWrongChain'
 import ErrorMessage from '@/components/tx/ErrorMessage'
@@ -25,7 +23,10 @@ import useSafeMessages from '@/hooks/useSafeMessages'
 import { isSafeMessageListItem } from '@/utils/safe-message-guards'
 import { useWeb3 } from '@/hooks/wallets/web3'
 
+import txStepperCss from '@/components/tx/TxStepper/styles.module.css'
+
 const APP_LOGO_FALLBACK_IMAGE = '/images/apps/apps-icon.svg'
+const APP_NAME_FALLBACK = 'Sign message off-chain'
 
 type BaseProps = {
   onClose: () => void
@@ -47,7 +48,7 @@ type ConfirmProps = BaseProps & {
 
 const MsgModal = ({
   onClose,
-  logoUri = APP_LOGO_FALLBACK_IMAGE,
+  logoUri,
   name,
   message,
   messageHash,
@@ -128,7 +129,9 @@ const MsgModal = ({
                   width={24}
                   height={24}
                 />
-                <Typography variant="h4">{name}</Typography>
+                <Typography variant="h4" pl={1}>
+                  {name || APP_NAME_FALLBACK}
+                </Typography>
               </Box>
             </Grid>
           </Grid>
@@ -145,15 +148,22 @@ const MsgModal = ({
             This action will confirm the message and add your confirmation to the prepared signature.
           </Typography>
           <Typography fontWeight={700}>Message:</Typography>
-          <Msg message={decodedMessage} />
+          <Typography variant="body2">
+            <Msg message={decodedMessage} />
+          </Typography>
           <Typography fontWeight={700} mt={2}>
             SafeMessage:
           </Typography>
-          <EthHashInfo address={safeMessageMessage} showAvatar={false} shortAddress={false} showCopyButton />
+          <Typography variant="body2">
+            <EthHashInfo address={safeMessageMessage} showAvatar={false} shortAddress={false} showCopyButton />
+          </Typography>
+
           <Typography fontWeight={700} mt={2}>
             SafeMessage hash:
           </Typography>
-          <EthHashInfo address={safeMessageHash} showAvatar={false} shortAddress={false} showCopyButton />
+          <Typography variant="body2">
+            <EthHashInfo address={safeMessageHash} showAvatar={false} shortAddress={false} showCopyButton />
+          </Typography>
 
           {!web3 ? (
             <ErrorMessage>No wallet is connected.</ErrorMessage>


### PR DESCRIPTION
## What it solves

Resolves #1392 & #1393

## How this PR fixes it

- The signing modal now shows the Safe app icon/name from the manifest, falling back to "Sign message off-chain".
- The font size of the message, SafeMessage and hash has been reduced.

Note: the modal colour has not been adjusted as it matches the others/uses the global theme. Truncation of the message is an open question that can be later adjusted if necessary.

## How to test it

- When signing a message, observe that the copy buttons are now visible.
- When signing an EIP-712 message, observe the width now fitting within the modal.
- The signed message in the messages list should now display it under the "Message" title.

## Screenshots

### EIP-191

![image](https://user-images.githubusercontent.com/20442784/208670010-ff945681-e87d-4b76-93c2-bc13a116721e.png)

### EIP-712

![image](https://user-images.githubusercontent.com/20442784/208691742-669ede65-fcc2-48f2-9454-090b0a16650b.png)

![image](https://user-images.githubusercontent.com/20442784/208691750-e451d8f0-a57f-4ad8-b000-41a734821c23.png)

Note: the show/hide button will be at the top when compared to this screenshot

![image](https://user-images.githubusercontent.com/20442784/208670025-0600c31b-fc8b-42b5-9109-359488bdb64f.png)