### PR TITLE
fix: poll for messages

### DIFF
--- a/src/hooks/loadables/useLoadSafeMessages.ts
+++ b/src/hooks/loadables/useLoadSafeMessages.ts
@@ -5,17 +5,37 @@ import type { SafeMessageListPage } from '@safe-global/safe-gateway-typescript-s
 import useAsync from '@/hooks/useAsync'
 import { logError, Errors } from '@/services/exceptions'
 import useSafeInfo from '@/hooks/useSafeInfo'
+import { POLLING_INTERVAL } from '@/config/constants'
+import useIntervalCounter from '@/hooks/useIntervalCounter'
 import type { AsyncResult } from '@/hooks/useAsync'
 
 export const useLoadSafeMessages = (): AsyncResult<SafeMessageListPage> => {
   const { safe, safeAddress, safeLoaded } = useSafeInfo()
 
-  const [data, error, loading] = useAsync<SafeMessageListPage>(() => {
-    if (!safeLoaded) {
-      return
-    }
-    return getSafeMessages(safe.chainId, safeAddress)
-  }, [safeLoaded, safe.chainId, safeAddress, safe.messagesTag])
+  // TODO: Remove manual polling when messagesTag is no longer cached on the backend
+  const [pollCount, resetPolling] = useIntervalCounter(POLLING_INTERVAL)
+
+  // Reset the counter when safe address/chainId changes
+  useEffect(() => {
+    resetPolling()
+  }, [resetPolling, safeAddress, safe.chainId])
+
+  const [data, error, loading] = useAsync<SafeMessageListPage>(
+    () => {
+      if (!safeLoaded) {
+        return
+      }
+      return getSafeMessages(safe.chainId, safeAddress)
+    },
+    [
+      safeLoaded,
+      safe.chainId,
+      safeAddress,
+      // safe.messagesTag,
+      pollCount,
+    ],
+    false,
+  )
 
   useEffect(() => {
     if (error) {

--- a/src/hooks/useSafeMessagePendingStatuses.ts
+++ b/src/hooks/useSafeMessagePendingStatuses.ts
@@ -13,12 +13,12 @@ const pendingStatuses: Record<SafeMsgEvent, boolean> = {
   [SafeMsgEvent.SIGNATURE_PREPARED]: false,
 }
 
+const entries = Object.entries(pendingStatuses) as [keyof typeof pendingStatuses, boolean][]
+
 const useSafeMessagePendingStatuses = () => {
   const dispatch = useAppDispatch()
 
   useEffect(() => {
-    const entries = Object.entries(pendingStatuses) as [keyof typeof pendingStatuses, boolean][]
-
     const unsubFns = entries.map(([event, isPending]) =>
       safeMsgSubscribe(event, ({ messageHash }) => {
         if (!isPending) {


### PR DESCRIPTION
## What it solves

Resolves #1394

## How this PR fixes it

Safe messages are always polled for on the `POLLING_INTERVAL`.

## How to test it

1. Open a 2+/n Safe and sign a message with owner 1.
2. Reload the Safe and switch to owner 2.
3. Confirm the message and observe that the pending status clears on next poll.