### PR TITLE
fix: threshold position

### DIFF
--- a/src/components/common/SafeIcon/styles.module.css
+++ b/src/components/common/SafeIcon/styles.module.css
@@ -1,14 +1,11 @@
 .container {
   position: relative;
-  height: 40px;
-  width: 40px;
 }
 
 .threshold {
   position: absolute;
-  margin-top: -6px;
-  margin-left: -16px;
-  left: 36px;
+  top: -6px;
+  right: -6px;
   z-index: 1;
   border-radius: 100%;
   font-size: 12px;

--- a/src/components/dashboard/Overview/Overview.tsx
+++ b/src/components/dashboard/Overview/Overview.tsx
@@ -113,9 +113,7 @@ const Overview = (): ReactElement => {
         ) : (
           <Card>
             <Grid container pb={2}>
-              <Grid item xs={2}>
-                <SafeIcon address={safeAddress} threshold={safe.threshold} owners={safe.owners.length} size={48} />
-              </Grid>
+              <SafeIcon address={safeAddress} threshold={safe.threshold} owners={safe.owners.length} size={48} />
 
               <Grid item xs />
 


### PR DESCRIPTION
## What it solves

Resolves #1240

## How this PR fixes it

The `SafeIcon` `container` now matches that of the `Identicon` size and the `Threshold` is position based on the top right of it.

## How to test it

Open a Safe dashboard and observe the position matching in the sidebar and the overview widget.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/208718713-1dca9473-7485-4014-a0c6-230d3b9f6631.png)