### PR TITLE
fix: check for compatibility handler

### DIFF
--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -121,12 +121,17 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
       }
     },
     onSetSafeSettings: (safeSettings: SafeSettings) => {
+      const isEIP1271Supported = supportsEIP1271(safe)
       const newSettings: SafeSettings = {
         ...settings,
-        offChainSigning: supportsEIP1271(safe) && !!safeSettings.offChainSigning,
+        offChainSigning: isEIP1271Supported && !!safeSettings.offChainSigning,
       }
 
       setSettings(newSettings)
+
+      !isEIP1271Supported &&
+        safeSettings.offChainSigning &&
+        console.warn('The connected Safe does not support off-chain signing.')
 
       return newSettings
     },

--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -129,9 +129,9 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
 
       setSettings(newSettings)
 
-      !isEIP1271Supported &&
-        safeSettings.offChainSigning &&
+      if (!isEIP1271Supported && safeSettings.offChainSigning) {
         console.warn('The connected Safe does not support off-chain signing.')
+      }
 
       return newSettings
     },

--- a/src/utils/__tests__/safe-messages.test.ts
+++ b/src/utils/__tests__/safe-messages.test.ts
@@ -1,7 +1,8 @@
 import { ethers } from 'ethers'
 import type { SafeInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 
-import { generateSafeMessageTypedData } from '../safe-messages'
+import { generateSafeMessageTypedData, supportsEIP1271 } from '../safe-messages'
+import { hexZeroPad } from 'ethers/lib/utils'
 
 const MOCK_ADDRESS = ethers.utils.hexZeroPad('0x123', 20)
 
@@ -120,6 +121,56 @@ describe('safe-messages', () => {
           message: '0x37abd8589f35b81d0ed965127e85b3de86f17c06f3736cfbb5f8e67767a8dd45',
         },
       })
+    })
+  })
+
+  describe('supportsEIP1271', () => {
+    it('false for 1.3.0 Safes without fallback handler', () => {
+      expect(
+        supportsEIP1271({
+          chainId: '5',
+          version: '1.3.0',
+          fallbackHandler: null,
+        } as any),
+      ).toBeFalsy()
+    })
+
+    it('false for 1.3.0 Safes with invalid fallback handler', () => {
+      expect(
+        supportsEIP1271({
+          chainId: '5',
+          version: '0.0.1',
+          fallbackHandler: { value: 'this is not an address' },
+        } as any),
+      ).toBeFalsy()
+    })
+
+    it('true for 1.3.0 Safes with fallback handler', () => {
+      expect(
+        supportsEIP1271({
+          chainId: '5',
+          version: '1.3.0',
+          fallbackHandler: { value: hexZeroPad('0x2222', 20) },
+        } as any),
+      ).toBeTruthy()
+    })
+
+    it('true for 1.1.0 Safes', () => {
+      expect(
+        supportsEIP1271({
+          chainId: '5',
+          version: '1.0.0',
+        } as any),
+      ).toBeTruthy()
+    })
+
+    it('false for 0.0.1 Safes', () => {
+      expect(
+        supportsEIP1271({
+          chainId: '5',
+          version: '0.0.1',
+        } as any),
+      ).toBeFalsy()
     })
   })
 })

--- a/src/utils/__tests__/validation.test.ts
+++ b/src/utils/__tests__/validation.test.ts
@@ -5,17 +5,22 @@ import {
   validateAmount,
   validatePrefixedAddress,
   validateDecimalLength,
+  isValidAddress,
 } from '@/utils/validation'
 
 describe('validation', () => {
   describe('Ethereum address validation', () => {
     it('should return undefined if the address is valid', () => {
       expect(validateAddress('0x1234567890123456789012345678901234567890')).toBeUndefined()
+      expect(isValidAddress('0x1234567890123456789012345678901234567890')).toBeTruthy()
     })
 
     it('should return an error if the address is invalid', () => {
       expect(validateAddress('0x1234567890123456789012345678901234567890x')).toBe('Invalid address format')
+      expect(isValidAddress('0x1234567890123456789012345678901234567890x')).toBeFalsy()
+
       expect(validateAddress('0x8Ba1f109551bD432803012645Ac136ddd64DBA72')).toBe('Invalid address checksum')
+      expect(isValidAddress('0x8Ba1f109551bD432803012645Ac136ddd64DBA72')).toBeFalsy()
     })
   })
 

--- a/src/utils/safe-messages.ts
+++ b/src/utils/safe-messages.ts
@@ -3,7 +3,7 @@ import { gte } from 'semver'
 import type { SafeInfo, SafeMessage, EIP712TypedData } from '@safe-global/safe-gateway-typescript-sdk'
 
 import { hashTypedData } from '@/utils/web3'
-import { validateAddress } from './validation'
+import { isValidAddress } from './validation'
 
 export const generateSafeMessageMessage = (message: SafeMessage['message']): string => {
   return typeof message === 'string' ? hashMessage(message) : hashTypedData(message)
@@ -48,7 +48,7 @@ export const supportsEIP1271 = ({ version, fallbackHandler }: SafeInfo): boolean
   const isHandledByFallbackHandler = gte(version, EIP1271_FALLBACK_HANDLER_SUPPORTED_SAFE_VERSION)
   if (isHandledByFallbackHandler) {
     // We only check if any fallback Handler is set as we expect / assume that users who overwrite the fallback handler by a custom one know what they are doing
-    return fallbackHandler !== null && validateAddress(fallbackHandler.value) === undefined
+    return fallbackHandler !== null && isValidAddress(fallbackHandler.value)
   }
 
   return gte(version, EIP1271_SUPPORTED_SAFE_VERSION)

--- a/src/utils/safe-messages.ts
+++ b/src/utils/safe-messages.ts
@@ -3,7 +3,7 @@ import { gte } from 'semver'
 import type { SafeInfo, SafeMessage, EIP712TypedData } from '@safe-global/safe-gateway-typescript-sdk'
 
 import { hashTypedData } from '@/utils/web3'
-import { getCompatibilityFallbackHandlerDeployment } from '@gnosis.pm/safe-deployments'
+import { validateAddress } from './validation'
 
 export const generateSafeMessageMessage = (message: SafeMessage['message']): string => {
   return typeof message === 'string' ? hashMessage(message) : hashTypedData(message)
@@ -36,7 +36,7 @@ export const generateSafeMessageHash = (safe: SafeInfo, message: SafeMessage['me
   return hashTypedData(typedData)
 }
 
-export const supportsEIP1271 = ({ chainId, version, fallbackHandler }: SafeInfo): boolean => {
+export const supportsEIP1271 = ({ version, fallbackHandler }: SafeInfo): boolean => {
   const EIP1271_SUPPORTED_SAFE_VERSION = '1.0.0'
   // From v1.3.0, EIP-1271 support was moved to the CompatibilityFallbackHandler
   const EIP1271_FALLBACK_HANDLER_SUPPORTED_SAFE_VERSION = '1.3.0'
@@ -47,8 +47,8 @@ export const supportsEIP1271 = ({ chainId, version, fallbackHandler }: SafeInfo)
 
   const isHandledByFallbackHandler = gte(version, EIP1271_FALLBACK_HANDLER_SUPPORTED_SAFE_VERSION)
   if (isHandledByFallbackHandler) {
-    const fallbackHandlerDeployment = getCompatibilityFallbackHandlerDeployment({ network: chainId, version })
-    return !!fallbackHandler.value && fallbackHandler.value === fallbackHandlerDeployment?.networkAddresses[chainId]
+    // We only check if any fallback Handler is set as we expect / assume that users who overwrite the fallback handler by a custom one know what they are doing
+    return fallbackHandler !== null && validateAddress(fallbackHandler.value) === undefined
   }
 
   return gte(version, EIP1271_SUPPORTED_SAFE_VERSION)

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -14,6 +14,8 @@ export const validateAddress = (address: string) => {
   }
 }
 
+export const isValidAddress = (address: string): boolean => validateAddress(address) === undefined
+
 const chainIds = Object.values(chains)
 export const validateChainId = (chainId: string) => {
   if (!chainIds.includes(chainId)) {


### PR DESCRIPTION
## What it solves
Does not run into an error if the compatibility handler is not set.

Resolves #1413 

## How this PR fixes it
- Handles the case when the fallback handler is `null`
- Adds jest test for the supportsEip1271 function

## How to test it
- Connect using our test dapp with this PR deployment using the patched wallet connect version
- Using a safe without compatiblity fallback handler
- Observe warning in log when pressing "enable off-chain signing"
