### PR TITLE
Fix: cookies-policy "self"

### DIFF
--- a/src/config/securityHeaders.ts
+++ b/src/config/securityHeaders.ts
@@ -19,9 +19,10 @@ export const ContentSecurityPolicy = `
  };
  frame-src *;
  style-src 'self' 'unsafe-inline' https://*.getbeamer.com https://*.googleapis.com;
- font-src 'self' data:; 
+ font-src 'self' data:;
  worker-src 'self' blob:;
  img-src * data:;
+ cookies-policy 'self';
 `
   .replace(/\s{2,}/g, ' ')
   .trim()


### PR DESCRIPTION
## What it solves

Beamer sets its cookies on the main domain instead of app.safe.global. This PR adds a CSP to limit cookies to the current subdomain.