### PR TITLE
fix: Use eth_signTypedData with WC

### DIFF
--- a/src/hooks/wallets/wallets.test.ts
+++ b/src/hooks/wallets/wallets.test.ts
@@ -43,7 +43,7 @@ describe('shouldUseEthSignMethod', () => {
     expect(result).toBe(true)
   })
 
-  it('returns true for WalletConnect', () => {
+  it('returns false for WalletConnect', () => {
     const mockWallet: ConnectedWallet = {
       address: ZERO_ADDRESS,
       chainId: '4',
@@ -53,7 +53,7 @@ describe('shouldUseEthSignMethod', () => {
 
     const result = shouldUseEthSignMethod(mockWallet)
 
-    expect(result).toBe(true)
+    expect(result).toBe(false)
   })
 
   it('returns false for MetaMask', () => {

--- a/src/hooks/wallets/wallets.ts
+++ b/src/hooks/wallets/wallets.ts
@@ -78,10 +78,6 @@ export const isHardwareWallet = (wallet: ConnectedWallet): boolean => {
   )
 }
 
-export const isWalletConnect = (wallet: ConnectedWallet): boolean => {
-  return wallet.label.toUpperCase() === WALLET_KEYS.WALLETCONNECT
-}
-
 export const isSafeMobileWallet = (wallet: ConnectedWallet): boolean => {
   return wallet.label === PAIRING_MODULE_LABEL
 }
@@ -99,5 +95,5 @@ export const isSmartContractWallet = async (wallet: ConnectedWallet) => {
 }
 
 export const shouldUseEthSignMethod = (wallet: ConnectedWallet): boolean => {
-  return isHardwareWallet(wallet) || isSafeMobileWallet(wallet) || isWalletConnect(wallet)
+  return isHardwareWallet(wallet) || isSafeMobileWallet(wallet)
 }


### PR DESCRIPTION
## What it solves

Resolves #1362 

## How this PR fixes it

Reverts changes done in #613 because of https://github.com/safe-global/web-core/issues/1362#issuecomment-1348525567

## How to test it

1. Open a safe
2. Connect via MM mobile app
3. Create and sign a transaction
4. Observe a MM popup showing signed data in a readable format

## Screenshots

![IMG_5320](https://user-images.githubusercontent.com/5880855/209107771-ae3da104-1172-4464-8fe8-dd983f1b3655.jpg)
