### PR TITLE
Fix: close connect popup on button click

### DIFF
--- a/src/components/common/ConnectWallet/WalletDetails.tsx
+++ b/src/components/common/ConnectWallet/WalletDetails.tsx
@@ -6,7 +6,12 @@ import type { ConnectedWallet } from '@/services/onboard'
 import useConnectWallet from '@/components/common/ConnectWallet/useConnectWallet'
 
 const WalletDetails = ({ onConnect }: { onConnect?: (wallet?: ConnectedWallet) => void }): ReactElement => {
-  const handleConnect = useConnectWallet(onConnect)
+  const connectWallet = useConnectWallet()
+
+  const handleConnect = () => {
+    onConnect?.()
+    connectWallet()
+  }
 
   return (
     <>

--- a/src/components/common/ConnectWallet/WalletDetails.tsx
+++ b/src/components/common/ConnectWallet/WalletDetails.tsx
@@ -2,10 +2,9 @@ import { Button, Typography } from '@mui/material'
 import type { ReactElement } from 'react'
 
 import KeyholeIcon from '@/components/common/icons/KeyholeIcon'
-import type { ConnectedWallet } from '@/services/onboard'
 import useConnectWallet from '@/components/common/ConnectWallet/useConnectWallet'
 
-const WalletDetails = ({ onConnect }: { onConnect?: (wallet?: ConnectedWallet) => void }): ReactElement => {
+const WalletDetails = ({ onConnect }: { onConnect?: () => void }): ReactElement => {
   const connectWallet = useConnectWallet()
 
   const handleConnect = () => {

--- a/src/components/common/ConnectWallet/useConnectWallet.ts
+++ b/src/components/common/ConnectWallet/useConnectWallet.ts
@@ -1,25 +1,20 @@
 import useOnboard, { connectWallet } from '@/hooks/wallets/useOnboard'
 import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
-import { CodedException } from '@/services/exceptions'
-import type { ConnectedWallet } from '@/services/onboard'
+import { useMemo } from 'react'
 
-const useConnectWallet = (onConnect?: (wallet?: ConnectedWallet) => void) => {
+const useConnectWallet = (): (() => void) => {
   const onboard = useOnboard()
 
-  const handleConnect = async () => {
-    if (!onboard) return
+  return useMemo(() => {
+    if (!onboard) {
+      return () => {}
+    }
 
-    // We `trackEvent` instead of using `<Track>` as it impedes styling
-    trackEvent(OVERVIEW_EVENTS.OPEN_ONBOARD)
-
-    const result = await connectWallet(onboard)
-
-    if (result instanceof CodedException) return
-
-    onConnect?.(result)
-  }
-
-  return handleConnect
+    return () => {
+      trackEvent(OVERVIEW_EVENTS.OPEN_ONBOARD)
+      connectWallet(onboard)
+    }
+  }, [onboard])
 }
 
 export default useConnectWallet

--- a/src/styles/onboard.css
+++ b/src/styles/onboard.css
@@ -84,6 +84,11 @@
   color: #162d45;
 }
 
+#walletconnect-wrapper .walletconnect-modal__footer {
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
 /* Keystone modal */
 #kv_sdk_container + .ReactModalPortal > div {
   z-index: 1301 !important;


### PR DESCRIPTION
## What it solves

Resolves #1367

## How this PR fixes it

The popover was still open after clicking on Connect, covering the WC popup and blocking input clicks.