### PR TITLE
fix: Use custom safeTxGas for simulations

### DIFF
--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -238,7 +238,7 @@ const SignOrExecuteForm = ({
 
         <TxSimulation
           gasLimit={advancedParams.gasLimit?.toNumber()}
-          transactions={safeTx}
+          transactions={tx}
           canExecute={canExecute}
           disabled={submitDisabled}
         />


### PR DESCRIPTION
## What it solves

Resolves #1294 

## How this PR fixes it

- Uses the updated `tx` object for simulations

## How to test it

1. Open a 1.1.1 safe
2. Create a new transaction
3. Simulate
4. Observe that Tenderly receives the initially estimated safeTxGas
5. Change the safeTxGas
6. Simulate
7. Observe that Tenderly receives the custom safeTxGas

