### PR TITLE
Bug: Custom app warning flash

### DIFF
--- a/src/components/safe-apps/SafeAppsInfoModal/useSafeAppsInfoModal.ts
+++ b/src/components/safe-apps/SafeAppsInfoModal/useSafeAppsInfoModal.ts
@@ -15,6 +15,7 @@ type useSafeAppsInfoModal = {
   permissions: AllowedFeatures[]
   addPermissions: (origin: string, permissions: BrowserPermission[]) => void
   getPermissions: (origin: string) => BrowserPermission[]
+  remoteSafeAppsLoading: boolean
 }
 
 type ModalInfoProps = {
@@ -30,6 +31,7 @@ const useSafeAppsInfoModal = ({
   permissions,
   addPermissions,
   getPermissions,
+  remoteSafeAppsLoading,
 }: useSafeAppsInfoModal): {
   isModalVisible: boolean
   isFirstTimeAccessingApp: boolean
@@ -90,7 +92,7 @@ const useSafeAppsInfoModal = ({
     const shouldShowLegalDisclaimer = !modalInfo[chainId] || modalInfo[chainId].consentsAccepted === false
     const shouldShowAllowedFeatures = !isPermissionsReviewCompleted
     const shouldShowUnknownAppWarning =
-      !isSafeAppInDefaultList && isFirstTimeAccessingApp && !isDisclaimerReadingCompleted
+      !remoteSafeAppsLoading && !isSafeAppInDefaultList && isFirstTimeAccessingApp && !isDisclaimerReadingCompleted
 
     return isComponentReady && (shouldShowLegalDisclaimer || shouldShowUnknownAppWarning || shouldShowAllowedFeatures)
   }, [
@@ -99,6 +101,7 @@ const useSafeAppsInfoModal = ({
     isFirstTimeAccessingApp,
     isSafeAppInDefaultList,
     isDisclaimerReadingCompleted,
+    remoteSafeAppsLoading,
     modalInfo,
   ])
 

--- a/src/hooks/safe-apps/useSafeApps.ts
+++ b/src/hooks/safe-apps/useSafeApps.ts
@@ -23,19 +23,19 @@ type ReturnType = {
 }
 
 const useSafeApps = (): ReturnType => {
-  const [remoteSafeApps = [], remoteSafeAppsError, remoteSafeAppsLoading] = useRemoteSafeApps()
+  const [remoteSafeApps, remoteSafeAppsError, remoteSafeAppsLoading] = useRemoteSafeApps()
   const { customSafeApps, loading: customSafeAppsLoading, updateCustomSafeApps } = useCustomSafeApps()
   const { pinnedSafeAppIds, updatePinnedSafeApps } = usePinnedSafeApps()
   const { removePermissions: removeSafePermissions } = useSafePermissions()
   const { removePermissions: removeBrowserPermissions } = useBrowserPermissions()
 
   const allSafeApps = useMemo(
-    () => remoteSafeApps.concat(customSafeApps).sort((a, b) => a.name.localeCompare(b.name)),
+    () => (remoteSafeApps || []).concat(customSafeApps).sort((a, b) => a.name.localeCompare(b.name)),
     [remoteSafeApps, customSafeApps],
   )
 
   const pinnedSafeApps = useMemo(
-    () => remoteSafeApps.filter((app) => pinnedSafeAppIds.has(app.id)),
+    () => remoteSafeApps?.filter((app) => pinnedSafeAppIds.has(app.id)) || [],
     [remoteSafeApps, pinnedSafeAppIds],
   )
 
@@ -78,17 +78,20 @@ const useSafeApps = (): ReturnType => {
 
   return {
     allSafeApps,
-    remoteSafeApps,
+    rankedSafeApps,
+
+    remoteSafeApps: remoteSafeApps || [],
+    remoteSafeAppsLoading: remoteSafeAppsLoading || !(remoteSafeApps || remoteSafeAppsError),
+    remoteSafeAppsError,
+
     pinnedSafeApps,
     pinnedSafeAppIds,
+    togglePin,
+
     customSafeApps,
-    rankedSafeApps,
-    remoteSafeAppsLoading,
     customSafeAppsLoading,
-    remoteSafeAppsError,
     addCustomApp,
     removeCustomApp,
-    togglePin,
   }
 }
 

--- a/src/pages/apps.tsx
+++ b/src/pages/apps.tsx
@@ -19,7 +19,7 @@ const Apps: NextPage = () => {
   const router = useRouter()
   const chainId = useChainId()
   const [appUrl, routerReady] = useSafeAppUrl()
-  const { remoteSafeApps } = useSafeApps()
+  const { remoteSafeApps, remoteSafeAppsLoading } = useSafeApps()
   const { isLoading, safeApp } = useSafeAppFromManifest(appUrl || '', chainId)
   const { addPermissions, getPermissions, getAllowedFeaturesList } = useBrowserPermissions()
   const origin = getOrigin(appUrl)
@@ -37,6 +37,7 @@ const Apps: NextPage = () => {
     permissions: safeApp?.safeAppsPermissions || [],
     addPermissions,
     getPermissions,
+    remoteSafeAppsLoading,
   })
 
   if (!routerReady || isLoading) {

--- a/src/pages/apps.tsx
+++ b/src/pages/apps.tsx
@@ -37,7 +37,7 @@ const Apps: NextPage = () => {
     permissions: safeApp?.safeAppsPermissions || [],
     addPermissions,
     getPermissions,
-    remoteSafeAppsLoading: remoteSafeAppsLoading || remoteSafeApps.length === 0,
+    remoteSafeAppsLoading,
   })
 
   if (!routerReady || isLoading) {

--- a/src/pages/apps.tsx
+++ b/src/pages/apps.tsx
@@ -37,7 +37,7 @@ const Apps: NextPage = () => {
     permissions: safeApp?.safeAppsPermissions || [],
     addPermissions,
     getPermissions,
-    remoteSafeAppsLoading,
+    remoteSafeAppsLoading: remoteSafeAppsLoading || remoteSafeApps.length === 0,
   })
 
   if (!routerReady || isLoading) {


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/web-core/issues/1326 and https://github.com/safe-global/safe-react-apps/issues/619

## How this PR fixes it

By checking that the remote app list was loaded before checking if the app exists there

## How to test it

Refresh a non-custom app and confirm the warning isn't there

