### PR TITLE
fix: Max amount button when sending tokens

### DIFF
--- a/cypress/e2e/create_tx.cy.js
+++ b/cypress/e2e/create_tx.cy.js
@@ -34,8 +34,8 @@ describe('Queue a transaction on 1/N', () => {
     cy.get('input[name="tokenAddress"]').prev().click()
     cy.get('ul[role="listbox"]').contains('Görli Ether').click()
 
-    // Insert amount
-    cy.get('input[name="amount"]').type(`${sendValue}`)
+    // Insert max amount
+    cy.contains('Max').click()
 
     cy.contains('Next').click()
   })

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -116,10 +116,10 @@ const SendAssetsForm = ({ onSubmit, formData, disableSpendingLimit = false }: Se
   const spendingLimitAmount = spendingLimit ? BigNumber.from(spendingLimit.amount).sub(spendingLimit.spent) : undefined
 
   const onMaxAmountClick = () => {
-    if (!selectedToken || !spendingLimitAmount) return
+    if (!selectedToken) return
 
     const amount =
-      spendingLimit && isSpendingLimitType && spendingLimitAmount.lte(selectedToken.balance)
+      isSpendingLimitType && spendingLimitAmount && spendingLimitAmount.lte(selectedToken.balance)
         ? spendingLimitAmount.toString()
         : selectedToken.balance
 


### PR DESCRIPTION
## What it solves

Resolves #1441 

## How this PR fixes it

- Removes the spending limit check from the early return statement

## How to test it

1. Open a safe
2. Create a new transaction
3. Select a token that doesn't have a spending limit
4. Press "Max"
5. Observe the max amount in the input field
6. Select a token that has a spending limit
7. Press "Max"
8. Observe the max spending limit amount in the input field
