### PR TITLE
Fix infinite loading at error boundary screen

### DIFF
--- a/src/components/common/ErrorBoundary/index.tsx
+++ b/src/components/common/ErrorBoundary/index.tsx
@@ -1,4 +1,4 @@
-import { Typography, Link as MuiLink, SvgIcon } from '@mui/material'
+import { Typography, Link as MuiLink } from '@mui/material'
 import Link from 'next/link'
 import type { FallbackRender } from '@sentry/react'
 
@@ -20,7 +20,7 @@ const ErrorBoundary: FallbackRender = ({ error, componentStack }) => {
           please try again.
         </Typography>
 
-        <CircularIcon icon={<SvgIcon component={WarningIcon} inheritViewBox />} badgeColor="warning" />
+        <CircularIcon icon={WarningIcon} badgeColor="warning" />
 
         {IS_PRODUCTION ? (
           <Typography color="text.primary">
@@ -31,11 +31,11 @@ const ErrorBoundary: FallbackRender = ({ error, componentStack }) => {
           </Typography>
         ) : (
           <>
-            <Typography color="error">{error.toString()}</Typography>
+            {/* Error may be undefined despite what the type says */}
+            <Typography color="error">{error?.toString()}</Typography>
             <Typography color="error">{componentStack}</Typography>
           </>
         )}
-
         <Typography mt={2}>
           <Link href={AppRoutes.welcome} passHref target="_blank" rel="noopener noreferrer" color="primary">
             <MuiLink>Go Home</MuiLink>


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-react-apps/issues/631

## How this PR fixes it

I noticed that there was one more error on development thrown by the SvgIcon component. After debugging I noticed that we pass the JSX markup to the `CircularIcon` component instead of the function itself

## How to test it

1. Visit production:
https://app.safe.global/gor:0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C/apps?appUrl=appUrl%3Djavascript%3AstartHack%28%29

2. Copy pathname from the link above and use it with the preview deployment:
https://bug_xss_infite_loading--webcore.review-web-core.5afe.dev/gor:0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C/apps?appUrl=appUrl%3Djavascript%3AstartHack%28%29


## Screenshots
<img width="2560" alt="Screenshot 2022-12-22 at 17 23 32" src="https://user-images.githubusercontent.com/16622558/209180110-f609ea7c-3abe-46c9-85e2-b3d680a51903.png">