### PR TITLE
Fix: disallow editing nonce for existing txs

### DIFF
--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -93,8 +93,8 @@ const SignOrExecuteForm = ({
 
   // Estimating gas
   const isEstimating = willExecute && gasLimitLoading
-  // Nonce cannot be edited if the tx is already signed, or it's a rejection
-  const nonceReadonly = !!tx?.signatures.size || isRejection
+  // Nonce cannot be edited if the tx is already proposed, or signed, or it's a rejection
+  const nonceReadonly = !!txId || !!tx?.signatures.size || isRejection
 
   // Assert that wallet, tx and provider are defined
   const assertDependencies = (): [ConnectedWallet, SafeTransaction, Web3Provider] => {


### PR DESCRIPTION
## What it solves

Resolves #1364

## How this PR fixes it

As per @schmanu's suggestion, we check if a tx is already proposed (txId is there), and if so we don't allow editing the nonce.

## How to test it
* Create a tx either with MMI or a smart contract wallet
* Start signing it from another wallet – the nonce should **not** be editable

<img width="791" alt="Screenshot 2022-12-23 at 09 25 12" src="https://user-images.githubusercontent.com/381895/209300484-6167fd77-4320-4203-996e-42ea047c03a5.png">
