### PR TITLE
fix: Sidebar hover and selected color

### DIFF
--- a/src/components/sidebar/SidebarList/styles.module.css
+++ b/src/components/sidebar/SidebarList/styles.module.css
@@ -20,10 +20,18 @@
   color: var(--color-text-primary);
 }
 
-.list :global .MuiListItemButton-root:hover,
+[data-theme='dark'] .list :global .Mui-selected {
+  background-color: var(--color-border-light);
+}
+
+.list :global .MuiListItemButton-root:hover {
+  border-radius: 6px;
+  background-color: var(--color-background-light);
+}
+
 .list :global .Mui-selected {
   border-radius: 6px;
-  background-color: var(--color-secondary-background);
+  background-color: var(--color-background-main);
 }
 
 .listItemButton :global .beamer_icon.active {


### PR DESCRIPTION
## What it solves

Resolves #1264 

## How this PR fixes it

- Uses the correct palette colors for hover/selected state in the sidebar

## How to test it

1. Open the Safe
2. Hover and select sidebar items in light and dark mode
3. Observe it is the same color as in the design

## Screenshots
<img width="251" alt="Screenshot 2022-12-23 at 10 18 07" src="https://user-images.githubusercontent.com/5880855/209308554-a2cdf965-9999-4c45-9eb2-b3f7e9210d92.png">
<img width="274" alt="Screenshot 2022-12-23 at 10 18 15" src="https://user-images.githubusercontent.com/5880855/209308582-d26e05ff-74b7-4d31-a964-6e2b00eab9d3.png">
