### PR TITLE
fix: make message expandable

### DIFF
--- a/src/components/safe-messages/Msg/index.tsx
+++ b/src/components/safe-messages/Msg/index.tsx
@@ -4,16 +4,15 @@ import type { ReactElement } from 'react'
 import type { SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
 
 import css from './styles.module.css'
-import classNames from 'classnames'
 
 const Msg = ({
   message,
-  showInitially = false,
+  defaultExpanded = false,
 }: {
   message: SafeMessage['message']
-  showInitially?: boolean
+  defaultExpanded?: boolean
 }): ReactElement => {
-  const [showMsg, setShowMsg] = useState(showInitially)
+  const [showMsg, setShowMsg] = useState(defaultExpanded)
 
   const handleToggleMsg = () => {
     setShowMsg((prev) => !prev)
@@ -27,7 +26,7 @@ const Msg = ({
     <>
       <div>
         <pre>
-          <code className={classNames({ [css.truncated]: !showMsg })}>{JSON.stringify(message, null, 2)}</code>
+          <code className={!showMsg ? css.truncated : undefined}>{JSON.stringify(message, null, 2)}</code>
         </pre>
         <Link component="button" onClick={handleToggleMsg} fontSize="medium" className={css.toggle}>
           {showMsg ? 'Hide' : 'Show all'}

--- a/src/components/safe-messages/Msg/index.tsx
+++ b/src/components/safe-messages/Msg/index.tsx
@@ -4,9 +4,16 @@ import type { ReactElement } from 'react'
 import type { SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
 
 import css from './styles.module.css'
+import classNames from 'classnames'
 
-const Msg = ({ message }: { message: SafeMessage['message'] }): ReactElement => {
-  const [showMsg, setShowMsg] = useState(true)
+const Msg = ({
+  message,
+  showInitially = false,
+}: {
+  message: SafeMessage['message']
+  showInitially?: boolean
+}): ReactElement => {
+  const [showMsg, setShowMsg] = useState(showInitially)
 
   const handleToggleMsg = () => {
     setShowMsg((prev) => !prev)
@@ -18,14 +25,14 @@ const Msg = ({ message }: { message: SafeMessage['message'] }): ReactElement => 
 
   return (
     <>
-      <Link component="button" onClick={handleToggleMsg} fontSize="medium" className={css.toggle}>
-        {showMsg ? 'Hide' : 'Show'}
-      </Link>
-      {showMsg && (
+      <div>
         <pre>
-          <code>{JSON.stringify(message, null, 2)}</code>
+          <code className={classNames({ [css.truncated]: !showMsg })}>{JSON.stringify(message, null, 2)}</code>
         </pre>
-      )}
+        <Link component="button" onClick={handleToggleMsg} fontSize="medium" className={css.toggle}>
+          {showMsg ? 'Hide' : 'Show all'}
+        </Link>
+      </div>
     </>
   )
 }

--- a/src/components/safe-messages/Msg/styles.module.css
+++ b/src/components/safe-messages/Msg/styles.module.css
@@ -2,3 +2,10 @@
   font-weight: 700;
   text-decoration: underline;
 }
+
+.truncated {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/src/components/safe-messages/Msg/styles.module.css
+++ b/src/components/safe-messages/Msg/styles.module.css
@@ -8,4 +8,5 @@
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  max-height: 9ex;
 }

--- a/src/components/safe-messages/MsgDetails/index.tsx
+++ b/src/components/safe-messages/MsgDetails/index.tsx
@@ -48,7 +48,7 @@ const MsgDetails = ({ msg }: { msg: SafeMessage }): ReactElement => {
 
         <div className={txDetailsCss.txSummary}>
           <TxDataRow title="Message:">
-            <Msg message={msg.message} showInitially />
+            <Msg message={msg.message} defaultExpanded />
           </TxDataRow>
           <TxDataRow title="SafeMessage:">{generateDataRowValue(safeMessage, 'hash')}</TxDataRow>
           <TxDataRow title="SafeMessage hash:">{generateDataRowValue(msg.messageHash, 'hash')}</TxDataRow>

--- a/src/components/safe-messages/MsgDetails/index.tsx
+++ b/src/components/safe-messages/MsgDetails/index.tsx
@@ -48,7 +48,7 @@ const MsgDetails = ({ msg }: { msg: SafeMessage }): ReactElement => {
 
         <div className={txDetailsCss.txSummary}>
           <TxDataRow title="Message:">
-            <Msg message={msg.message} />
+            <Msg message={msg.message} showInitially />
           </TxDataRow>
           <TxDataRow title="SafeMessage:">{generateDataRowValue(safeMessage, 'hash')}</TxDataRow>
           <TxDataRow title="SafeMessage hash:">{generateDataRowValue(msg.messageHash, 'hash')}</TxDataRow>


### PR DESCRIPTION
## What it solves
Changes the Msg component according to the designs
Resolves #1438 

## How this PR fixes it
- Instead of completely hiding the message it shows the first 3 lines
- in the sign message modal the message is initially truncated
- Show all / hide button is below the message

## How to test it
- Off-chain sign a typed data message
- Look at a typed data message in the messages list

## Analytics changes
None

## Screenshots
<img width="1231" alt="Screenshot 2022-12-27 at 14 37 48" src="https://user-images.githubusercontent.com/2670790/209674706-8bd85f58-b943-46ae-b34b-957fb6cd5d9b.png">
