### PR TITLE
fix: async validation loader in AddressInput

### DIFF
--- a/src/components/common/AddressInput/index.test.tsx
+++ b/src/components/common/AddressInput/index.test.tsx
@@ -124,6 +124,31 @@ describe('AddressInput tests', () => {
     await waitFor(() => expect(utils.getByLabelText(`${TEST_ADDRESS_B} is wrong`, { exact: false })).toBeDefined())
   })
 
+  it('should show a spinner when validation is in progress', async () => {
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+    const { input, utils } = setup('', async (val) => {
+      await sleep(2000)
+      return `${val} is wrong`
+    })
+
+    act(() => {
+      fireEvent.change(input, { target: { value: `gor:${TEST_ADDRESS_A}` } })
+      jest.advanceTimersByTime(1000)
+    })
+
+    await waitFor(() => {
+      expect(utils.getByRole('progressbar')).toBeDefined()
+      expect(utils.queryByLabelText(`${TEST_ADDRESS_A} is wrong`, { exact: false })).toBeNull()
+    })
+
+    act(() => {
+      jest.advanceTimersByTime(1000)
+    })
+
+    await waitFor(() => expect(utils.getByLabelText(`${TEST_ADDRESS_A} is wrong`, { exact: false })).toBeDefined())
+  })
+
   it('should resolve ENS names', async () => {
     const { input } = setup('')
 

--- a/src/components/common/AddressInput/index.tsx
+++ b/src/components/common/AddressInput/index.tsx
@@ -72,13 +72,11 @@ const AddressInput = ({ name, validate, required = true, deps, ...props }: Addre
               <InputAdornment position="end">{currentShortName}:</InputAdornment>
             ),
 
-            endAdornment:
-              resolving ||
-              (isValidating && (
-                <InputAdornment position="end">
-                  <CircularProgress size={20} />
-                </InputAdornment>
-              )),
+            endAdornment: (resolving || isValidating) && (
+              <InputAdornment position="end">
+                <CircularProgress size={20} />
+              </InputAdornment>
+            ),
           }}
           InputLabelProps={{
             ...(props.InputLabelProps || {}),

--- a/src/components/common/AddressInput/index.tsx
+++ b/src/components/common/AddressInput/index.tsx
@@ -18,7 +18,7 @@ const AddressInput = ({ name, validate, required = true, deps, ...props }: Addre
     register,
     setValue,
     control,
-    formState: { errors },
+    formState: { errors, isValidating },
     trigger,
   } = useFormContext()
   const currentChain = useCurrentChain()
@@ -72,11 +72,13 @@ const AddressInput = ({ name, validate, required = true, deps, ...props }: Addre
               <InputAdornment position="end">{currentShortName}:</InputAdornment>
             ),
 
-            endAdornment: resolving && (
-              <InputAdornment position="end">
-                <CircularProgress size={20} />
-              </InputAdornment>
-            ),
+            endAdornment:
+              resolving ||
+              (isValidating && (
+                <InputAdornment position="end">
+                  <CircularProgress size={20} />
+                </InputAdornment>
+              )),
           }}
           InputLabelProps={{
             ...(props.InputLabelProps || {}),


### PR DESCRIPTION
## What it solves
Fixes async validation for AddressInput

Resolves #1203 

## How this PR fixes it
Shows a loading spinner while the form is validating.

## How to test it
- Find a address input with slow validation or add a way of throttling the validation (Slow resolving promise, network throttling)
