### PR TITLE
[EIP-1271] support Safe's < 1.3.0

### DIFF
--- a/src/components/safe-messages/MsgModal/index.test.tsx
+++ b/src/components/safe-messages/MsgModal/index.test.tsx
@@ -26,6 +26,7 @@ describe('MsgModal', () => {
 
     jest.spyOn(useSafeInfoHook, 'default').mockImplementation(() => ({
       safe: {
+        version: '1.3.0',
         address: {
           value: hexZeroPad('0x1', 20),
         },
@@ -213,6 +214,7 @@ describe('MsgModal', () => {
     expect(proposalSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         safe: {
+          version: '1.3.0',
           address: {
             value: hexZeroPad('0x1', 20),
           },
@@ -270,6 +272,7 @@ describe('MsgModal', () => {
     expect(confirmationSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         safe: {
+          version: '1.3.0',
           address: {
             value: hexZeroPad('0x1', 20),
           },

--- a/src/services/safe-messages/__tests__/safeMsgSender.test.ts
+++ b/src/services/safe-messages/__tests__/safeMsgSender.test.ts
@@ -36,6 +36,7 @@ describe('safeMsgSender', () => {
       const safeMsgDispatchSpy = jest.spyOn(events, 'safeMsgDispatch')
 
       const safe = {
+        version: '1.3.0',
         chainId: 1,
         address: {
           value: '0x789',
@@ -66,6 +67,7 @@ describe('safeMsgSender', () => {
       const safeMsgDispatchSpy = jest.spyOn(events, 'safeMsgDispatch')
 
       const safe = {
+        version: '1.3.0',
         chainId: 1,
         address: {
           value: '0x789',
@@ -103,6 +105,7 @@ describe('safeMsgSender', () => {
       const safeMsgDispatchSpy = jest.spyOn(events, 'safeMsgDispatch')
 
       const safe = {
+        version: '1.3.0',
         chainId: 1,
         address: {
           value: '0x789',
@@ -130,6 +133,7 @@ describe('safeMsgSender', () => {
       const safeMsgDispatchSpy = jest.spyOn(events, 'safeMsgDispatch')
 
       const safe = {
+        version: '1.3.0',
         chainId: 1,
         address: {
           value: '0x789',

--- a/src/utils/__tests__/safe-messages.test.ts
+++ b/src/utils/__tests__/safe-messages.test.ts
@@ -8,8 +8,9 @@ const MOCK_ADDRESS = ethers.utils.hexZeroPad('0x123', 20)
 
 describe('safe-messages', () => {
   describe('createSafeMessage', () => {
-    it('should generate the correct types for a EIP-191 message', () => {
+    it('should generate the correct types for a EIP-191 message for >= 1.3.0 Safes', () => {
       const safe = {
+        version: '1.3.0',
         address: {
           value: MOCK_ADDRESS,
         },
@@ -34,8 +35,35 @@ describe('safe-messages', () => {
       })
     })
 
-    it('should generate the correct types for an EIP-712 message', () => {
+    it('should generate the correct types for a EIP-191 message for < 1.3.0 Safes', () => {
       const safe = {
+        version: '1.1.1',
+        address: {
+          value: MOCK_ADDRESS,
+        },
+        chainId: 1,
+      } as unknown as SafeInfo
+
+      const message = 'Hello world!'
+
+      const safeMessage = generateSafeMessageTypedData(safe, message)
+
+      expect(safeMessage).toEqual({
+        domain: {
+          verifyingContract: MOCK_ADDRESS,
+        },
+        types: {
+          SafeMessage: [{ name: 'message', type: 'bytes' }],
+        },
+        message: {
+          message: '0xaa05af77f274774b8bdc7b61d98bc40da523dc2821fdea555f4d6aa413199bcc',
+        },
+      })
+    })
+
+    it('should generate the correct types for an EIP-712 message for >=1.3.0 Safes', () => {
+      const safe = {
+        version: '1.3.0',
         address: {
           value: MOCK_ADDRESS,
         },
@@ -112,6 +140,95 @@ describe('safe-messages', () => {
       expect(safeMessage).toEqual({
         domain: {
           chainId: 1,
+          verifyingContract: MOCK_ADDRESS,
+        },
+        types: {
+          SafeMessage: [{ name: 'message', type: 'bytes' }],
+        },
+        message: {
+          message: '0x37abd8589f35b81d0ed965127e85b3de86f17c06f3736cfbb5f8e67767a8dd45',
+        },
+      })
+    })
+
+    it('should generate the correct types for an EIP-712 message for <1.3.0 Safes', () => {
+      const safe = {
+        version: '1.1.1',
+        address: {
+          value: MOCK_ADDRESS,
+        },
+        chainId: 1,
+      } as unknown as SafeInfo
+
+      const message = {
+        domain: {
+          chainId: 5,
+          name: 'Ether Mail',
+          verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+          version: '1',
+        },
+        message: {
+          contents: 'Hello, Bob!',
+          from: {
+            name: 'Cow',
+            wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+          },
+          to: {
+            name: 'Bob',
+            wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+          },
+        },
+        primaryType: 'Mail',
+        types: {
+          EIP712Domain: [
+            {
+              name: 'name',
+              type: 'string',
+            },
+            {
+              name: 'version',
+              type: 'string',
+            },
+            {
+              name: 'chainId',
+              type: 'uint256',
+            },
+            {
+              name: 'verifyingContract',
+              type: 'address',
+            },
+          ],
+          Mail: [
+            {
+              name: 'from',
+              type: 'Person',
+            },
+            {
+              name: 'to',
+              type: 'Person',
+            },
+            {
+              name: 'contents',
+              type: 'string',
+            },
+          ],
+          Person: [
+            {
+              name: 'name',
+              type: 'string',
+            },
+            {
+              name: 'wallet',
+              type: 'address',
+            },
+          ],
+        },
+      }
+
+      const safeMessage = generateSafeMessageTypedData(safe, message)
+
+      expect(safeMessage).toEqual({
+        domain: {
           verifyingContract: MOCK_ADDRESS,
         },
         types: {

--- a/src/utils/__tests__/safe-messages.test.ts
+++ b/src/utils/__tests__/safe-messages.test.ts
@@ -72,7 +72,7 @@ describe('safe-messages', () => {
 
       const message = {
         domain: {
-          chainId: 5,
+          chainId: 1,
           name: 'Ether Mail',
           verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
           version: '1',
@@ -146,7 +146,7 @@ describe('safe-messages', () => {
           SafeMessage: [{ name: 'message', type: 'bytes' }],
         },
         message: {
-          message: '0x37abd8589f35b81d0ed965127e85b3de86f17c06f3736cfbb5f8e67767a8dd45',
+          message: '0xbe609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2',
         },
       })
     })
@@ -162,7 +162,7 @@ describe('safe-messages', () => {
 
       const message = {
         domain: {
-          chainId: 5,
+          chainId: 1,
           name: 'Ether Mail',
           verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
           version: '1',
@@ -235,7 +235,7 @@ describe('safe-messages', () => {
           SafeMessage: [{ name: 'message', type: 'bytes' }],
         },
         message: {
-          message: '0x37abd8589f35b81d0ed965127e85b3de86f17c06f3736cfbb5f8e67767a8dd45',
+          message: '0xbe609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2',
         },
       })
     })

--- a/src/utils/safe-messages.ts
+++ b/src/utils/safe-messages.ts
@@ -7,9 +7,11 @@ import { isValidAddress } from './validation'
 
 /*
  * From v1.3.0, EIP-1271 support was moved to the CompatibilityFallbackHandler.
- * Also 1.3.0 introduces the chainId in the domain part of the safeMessageTypedData
+ * Also 1.3.0 introduces the chainId in the domain part of the SafeMessage
  */
 const EIP1271_FALLBACK_HANDLER_SUPPORTED_SAFE_VERSION = '1.3.0'
+
+const EIP1271_SUPPORTED_SAFE_VERSION = '1.0.0'
 
 export const generateSafeMessageMessage = (message: SafeMessage['message']): string => {
   return typeof message === 'string' ? hashMessage(message) : hashTypedData(message)
@@ -53,9 +55,6 @@ export const generateSafeMessageHash = (safe: SafeInfo, message: SafeMessage['me
 }
 
 export const supportsEIP1271 = ({ version, fallbackHandler }: SafeInfo): boolean => {
-  const EIP1271_SUPPORTED_SAFE_VERSION = '1.0.0'
-  const EIP1271_FALLBACK_HANDLER_SUPPORTED_SAFE_VERSION = '1.3.0'
-
   if (!version) {
     return false
   }


### PR DESCRIPTION
## What it solves
For Safes `<1.3.0` a wrong Safe message hash is computed when signing off-chain messages.

Resolves #1432 

## How this PR fixes it
- Does not add the `chainId` into the `domain` part of the Safe message's typed data if Safe version < 1.3.0

## How to test it
- Testing is blocked by the tx service also computing a wrong Safe message hash when creating off-chain messages.
