### PR TITLE
[Eip-1271] fix sign tx label

### DIFF
--- a/src/components/transactions/SignTxButton/index.tsx
+++ b/src/components/transactions/SignTxButton/index.tsx
@@ -37,7 +37,7 @@ const SignTxButton = ({
     <>
       <Track {...TX_LIST_EVENTS.CONFIRM}>
         {compact ? (
-          <Tooltip title="Sign" arrow placement="top">
+          <Tooltip title="Confirm" arrow placement="top">
             <span>
               <IconButton onClick={onClick} color="primary" disabled={isDisabled} size="small">
                 <CheckIcon fontSize="small" />
@@ -46,7 +46,7 @@ const SignTxButton = ({
           </Tooltip>
         ) : (
           <Button onClick={onClick} variant="contained" disabled={isDisabled} size="stretched">
-            Sign
+            Confirm
           </Button>
         )}
       </Track>


### PR DESCRIPTION
## What it solves
The label for the SignTxButton was accidentally changed.

Resolves #1435 

## How this PR fixes it
Changes the label / tooltip to "Confirm"

## How to test it
- Queue a tx and observe the Confirm button

## Analytics changes
None