### PR TITLE
fix: trigger validation upon owner removal

### DIFF
--- a/src/components/new-safe/OwnerRow/index.tsx
+++ b/src/components/new-safe/OwnerRow/index.tsx
@@ -27,7 +27,7 @@ export const OwnerRow = ({
 }) => {
   const wallet = useWallet()
   const fieldName = `${groupName}.${index}`
-  const { control, getValues, setValue } = useFormContext()
+  const { control, getValues, setValue, trigger } = useFormContext()
   const owners = useWatch({
     control,
     name: groupName,
@@ -51,6 +51,10 @@ export const OwnerRow = ({
   )
 
   const { ens, name, resolving } = useAddressResolver(owner.address)
+
+  useEffect(() => {
+    trigger()
+  }, [trigger, owners])
 
   useEffect(() => {
     if (ens) {

--- a/src/components/new-safe/OwnerRow/index.tsx
+++ b/src/components/new-safe/OwnerRow/index.tsx
@@ -27,7 +27,7 @@ export const OwnerRow = ({
 }) => {
   const wallet = useWallet()
   const fieldName = `${groupName}.${index}`
-  const { control, getValues, setValue, trigger } = useFormContext()
+  const { control, getValues, setValue } = useFormContext()
   const owners = useWatch({
     control,
     name: groupName,
@@ -43,18 +43,15 @@ export const OwnerRow = ({
 
   const validateSafeAddress = useCallback(
     async (address: string) => {
+      const owners = getValues('owners')
       if (owners.filter((owner: NamedAddress) => sameAddress(owner.address, address)).length > 1) {
         return 'Owner is already added'
       }
     },
-    [owners],
+    [getValues],
   )
 
   const { ens, name, resolving } = useAddressResolver(owner.address)
-
-  useEffect(() => {
-    trigger()
-  }, [trigger, owners])
 
   useEffect(() => {
     if (ens) {

--- a/src/components/new-safe/create/steps/Step2/index.tsx
+++ b/src/components/new-safe/create/steps/Step2/index.tsx
@@ -50,7 +50,7 @@ const CreateSafeStep2 = ({
     },
   })
 
-  const { handleSubmit, control, watch, formState, getValues, setValue } = formMethods
+  const { handleSubmit, control, watch, formState, getValues, setValue, trigger } = formMethods
 
   const threshold = watch(CreateSafeStep2Fields.threshold)
 
@@ -64,6 +64,7 @@ const CreateSafeStep2 = ({
     // Set threshold if it's greater than the number of owners
     setValue(CreateSafeStep2Fields.threshold, Math.min(threshold, ownerFields.length - 1))
     remove(index)
+    trigger()
   }
 
   const isDisabled = isWrongChain || !formState.isValid

--- a/src/components/new-safe/create/steps/Step2/index.tsx
+++ b/src/components/new-safe/create/steps/Step2/index.tsx
@@ -43,7 +43,7 @@ const CreateSafeStep2 = ({
   useSyncSafeCreationStep(setStep)
 
   const formMethods = useForm<CreateSafeStep2Form>({
-    mode: 'all',
+    mode: 'onChange',
     defaultValues: {
       [CreateSafeStep2Fields.owners]: data.owners,
       [CreateSafeStep2Fields.threshold]: data.threshold,
@@ -64,7 +64,7 @@ const CreateSafeStep2 = ({
     // Set threshold if it's greater than the number of owners
     setValue(CreateSafeStep2Fields.threshold, Math.min(threshold, ownerFields.length - 1))
     remove(index)
-    trigger()
+    trigger(CreateSafeStep2Fields.owners)
   }
 
   const isDisabled = isWrongChain || !formState.isValid


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/web-core/issues/1350

## How this PR fixes it
Triggers a form validation after an owners array change

## How to test it
In the creation flow, add a repeated owner.
Remove the repeated owner.
The form should have no errors.

## Analytics changes

## Screenshots
