### PR TITLE
fix: compute copyright dates range in footer

### DIFF
--- a/src/components/common/Footer/index.tsx
+++ b/src/components/common/Footer/index.tsx
@@ -28,7 +28,7 @@ const Footer = (): ReactElement | null => {
     <footer className={css.container}>
       <ul>
         <li>
-          <Typography variant="caption">&copy;2022 Safe Ecosystem Foundation</Typography>
+          <Typography variant="caption">&copy;2022–{new Date().getFullYear()} Safe Ecosystem Foundation</Typography>
         </li>
         <li>
           <ExternalLink noIcon href="https://safe.global/terms">


### PR DESCRIPTION
## What it solves
Calculates the year displayed in the footer instead of hardcoding it.

## How to test it
Open a page with the footer (p.e, `Settings`)
Observe the year in the footer is different than in production

## Screenshots
<img width="845" alt="Screenshot 2023-01-03 at 09 24 20" src="https://user-images.githubusercontent.com/32431609/210331013-ed630c56-bddd-4bf5-9804-2deadba2d262.png">


