### PR TITLE
fix: adjust error colour

### DIFF
--- a/src/styles/onboard.css
+++ b/src/styles/onboard.css
@@ -22,7 +22,7 @@
   --onboard-success-600: var(--color-secondary-light);
   --onboard-success-700: var(--color-success-dark);
 
-  --onboard-danger-500: var(--color-error-light);
+  --onboard-danger-500: var(--color-error-main);
   --onboard-danger-600: var(--color-error-main);
   --onboard-danger-700: var(--color-error-dark);
 


### PR DESCRIPTION
## What it solves

Resolves #1352

## How this PR fixes it

The `onboard-danger-500` CSS variable has been altered to `--color-error-main`.

## How to test it

Scan for a Ledger account but cancel it. Observe the more visible error text.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/210788972-c5df8194-dfad-440c-8f58-8d4a35a75167.png)

![image](https://user-images.githubusercontent.com/20442784/210788987-11f68864-72e3-4e54-8d58-dfb75cef0e43.png)