### PR TITLE
fix: move message below link

### DIFF
--- a/src/components/safe-messages/Msg/index.tsx
+++ b/src/components/safe-messages/Msg/index.tsx
@@ -24,14 +24,12 @@ const Msg = ({
 
   return (
     <>
-      <div>
-        <pre>
-          <code className={!showMsg ? css.truncated : undefined}>{JSON.stringify(message, null, 2)}</code>
-        </pre>
-        <Link component="button" onClick={handleToggleMsg} fontSize="medium" className={css.toggle}>
-          {showMsg ? 'Hide' : 'Show all'}
-        </Link>
-      </div>
+      <Link component="button" onClick={handleToggleMsg} fontSize="medium" className={css.toggle}>
+        {showMsg ? 'Hide' : 'Show all'}
+      </Link>
+      <pre>
+        <code className={!showMsg ? css.truncated : undefined}>{JSON.stringify(message, null, 2)}</code>
+      </pre>
     </>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves #1393

## How this PR fixes it

Extensive messages are now shown below the link that shows/hides them.

## How to test it

- Sign an EIP-712 message and observe that the show/hide link is above it, as well as no overflowing outside of the modal.
- Observe that no overflow appears in the message details in the transaction list.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/210799287-63357fb3-1545-45e4-888f-8d095ed18550.png)

![image](https://user-images.githubusercontent.com/20442784/210799341-bbdebaa5-22f0-44d8-a290-7a877677c802.png)

![image](https://user-images.githubusercontent.com/20442784/210799356-75ef7cca-42b6-474f-8d03-0deef7fe44a4.png)