### PR TITLE
fix: don't show unread badge if showing all

### DIFF
--- a/src/components/notification-center/NotificationCenter/index.tsx
+++ b/src/components/notification-center/NotificationCenter/index.tsx
@@ -137,7 +137,7 @@ const NotificationCenter = (): ReactElement => {
             <div className={css.popoverFooter}>
               <IconButton onClick={() => setShowAll((prev) => !prev)} disableRipple className={css.expandButton}>
                 <UnreadBadge
-                  invisible={unreadCount <= NOTIFICATION_CENTER_LIMIT}
+                  invisible={showAll || unreadCount <= NOTIFICATION_CENTER_LIMIT}
                   anchorOrigin={{
                     vertical: 'top',
                     horizontal: 'left',


### PR DESCRIPTION
## What it solves

Resolves #1487

## How this PR fixes it

The unread badge is hidden if showing all notifications (when there are more unread notifications than the notification limit).

## How to test it

1. Queue >4 notifcations, without reading them.
2. Open the notification centre and observe an unread badge on the expand button.
3. Expand the list and no longer observe an unread badge.
4. Hiding again (without having read the later notifications) should display the unread badge again.

## Screenshots

![unread badge](https://user-images.githubusercontent.com/20442784/210802251-7e8df82f-bc6b-4f30-a4bc-9500f4719e23.gif)