### PR TITLE
Fix asset table rerender

### DIFF
--- a/src/components/balances/AssetsTable/index.tsx
+++ b/src/components/balances/AssetsTable/index.tsx
@@ -81,6 +81,7 @@ const AssetsTable = ({
     const isSelected = isAssetSelected(item.tokenInfo.address)
 
     return {
+      key: item.tokenInfo.address,
       selected: isSelected,
       collapsed: item.tokenInfo.address === hidingAsset,
       cells: {

--- a/src/components/common/EnhancedTable/index.tsx
+++ b/src/components/common/EnhancedTable/index.tsx
@@ -28,6 +28,7 @@ type EnhancedCell = {
 type EnhancedRow = {
   selected?: boolean
   collapsed?: boolean
+  key?: string
   cells: Record<string, EnhancedCell>
 }
 
@@ -145,7 +146,7 @@ function EnhancedTable({ rows, headCells, variant }: EnhancedTableProps) {
               pagedRows.map((row, index) => (
                 <TableRow
                   tabIndex={-1}
-                  key={index}
+                  key={row.key ?? index}
                   selected={row.selected}
                   className={row.collapsed ? css.collapsedRow : undefined}
                 >


### PR DESCRIPTION
**Note: I based this branch off `spam-tokens-manually-hide` as  the EnhancedTable is refactored there in a way necessary to fix this!**

## What it solves
Render problems when sorting assets.

Resolves #1482 

## How this PR fixes it
- Adds a meaningful key to each asset row instead of the index.

## How to test it
- Sort the assets and witness the logos to be updated.

## Analytics changes
None

