### PR TITLE
fix: Downgrade RHF version to 7.41.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react-dom": "18.2.0",
     "react-dropzone": "^14.2.3",
     "react-gtm-module": "^2.0.11",
-    "react-hook-form": "^7.41.3",
+    "react-hook-form": "7.41.1",
     "react-papaparse": "^4.0.2",
     "react-qr-reader": "2.2.1",
     "react-redux": "^8.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10864,10 +10864,10 @@ react-gtm-module@^2.0.11:
   resolved "https://registry.yarnpkg.com/react-gtm-module/-/react-gtm-module-2.0.11.tgz#14484dac8257acd93614e347c32da9c5ac524206"
   integrity sha512-8gyj4TTxeP7eEyc2QKawEuQoAZdjKvMY4pgWfycGmqGByhs17fR+zEBs0JUDq4US/l+vbTl+6zvUIx27iDo/Vw==
 
-react-hook-form@^7.41.3:
-  version "7.41.3"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.41.3.tgz#1b85e95e70cb743d41cd9230ea2df71359d00151"
-  integrity sha512-5QNTmqJtDb88WV5n41b6+AmcDMVyaJ3tccPgHAgS215w3jZ3bmJhDO27kNTr8u4YHNYXmS7p1/4/KachBAlUtw==
+react-hook-form@7.41.1:
+  version "7.41.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.41.1.tgz#0e25e231550d477c5774b7f5a4ff800485281e6a"
+  integrity sha512-IHUozfwuqE+P201KIJwotMd+UCKqzIprseR8UUjz1jRupkZeubg0xyeMLIaT192zHv7vBBu9bibpNV5cIB4E9g==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
## What it solves

The recent update to RHF >= 7.41.2 broke the form validation on the safe creation screen (and potentially other places).

## How this PR fixes it

Downgrades RHF to the last working version 7.41.1

## How to test it

1. Open the Safe
3. Create a new safe and navigate to the owner policy screen
4. Observe that the Next button is not disabled

## References

[Slack thread with more info](https://5afe.slack.com/archives/C03DAGWJCR5/p1672932360224469)
