### PR TITLE
Feat: add a chain switch button in Safe creation

### DIFF
--- a/src/components/new-safe/create/NetworkWarning/index.tsx
+++ b/src/components/new-safe/create/NetworkWarning/index.tsx
@@ -1,5 +1,6 @@
-import { Alert, AlertTitle } from '@mui/material'
+import { Alert, AlertTitle, Box } from '@mui/material'
 import { useCurrentChain } from '@/hooks/useChains'
+import ChainSwitcher from '@/components/common/ChainSwitcher'
 
 const NetworkWarning = () => {
   const chain = useCurrentChain()
@@ -7,9 +8,12 @@ const NetworkWarning = () => {
   if (!chain) return null
 
   return (
-    <Alert severity="info" sx={{ mt: 3 }}>
+    <Alert severity="warning" sx={{ mt: 3 }}>
       <AlertTitle sx={{ fontWeight: 700 }}>Change your wallet network</AlertTitle>
       You are trying to create a Safe on {chain.chainName}. Make sure that your wallet is set to the same network.
+      <Box mt={2}>
+        <ChainSwitcher />
+      </Box>
     </Alert>
   )
 }


### PR DESCRIPTION
## What it solves

I was trying to create a Safe and was really confused why the submit button was disabled.

### Before
<img width="806" alt="Screenshot 2023-01-09 at 15 31 59" src="https://user-images.githubusercontent.com/381895/211332229-f909ad7c-f6d0-48bb-898d-6e4d736aadff.png">

### After
<img width="807" alt="Screenshot 2023-01-09 at 15 29 58" src="https://user-images.githubusercontent.com/381895/211332096-484fdcb0-1a77-4015-ae76-d51ee1d4d82f.png">
