### PR TITLE
fix: Show sidebar on mobile when pressing the burger menu icon

### DIFF
--- a/src/components/common/PageLayout/SideDrawer.tsx
+++ b/src/components/common/PageLayout/SideDrawer.tsx
@@ -27,7 +27,15 @@ const SideDrawer = ({ isOpen, onToggle }: SideDrawerProps): ReactElement => {
   const showSidebarToggle = isSafeAppRoute(pathname, query) && !isSmallScreen
 
   useEffect(() => {
-    const closeSidebar = isSmallScreen || isSafeAppRoute(pathname, query)
+    const hideSidebar = [
+      AppRoutes.share.safeApp,
+      AppRoutes.newSafe.create,
+      AppRoutes.newSafe.load,
+      AppRoutes.welcome,
+      AppRoutes.index,
+    ].includes(pathname)
+
+    const closeSidebar = isSmallScreen || isSafeAppRoute(pathname, query) || hideSidebar
     onToggle(!closeSidebar)
   }, [isSmallScreen, onToggle, pathname, query])
 

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -7,24 +7,13 @@ import SafeLoadingError from '../SafeLoadingError'
 import Footer from '../Footer'
 import SideDrawer from './SideDrawer'
 import PsaBanner from '../PsaBanner'
-import { useRouter } from 'next/router'
-import { AppRoutes } from '@/config/routes'
 
 const PageLayout = ({ children }: { children: ReactElement }): ReactElement => {
   const [isSidebarOpen, setSidebarOpen] = useState<boolean>(true)
-  const router = useRouter()
 
   const toggleSidebar = () => {
     setSidebarOpen((prev) => !prev)
   }
-
-  const hideSidebar = [
-    AppRoutes.share.safeApp,
-    AppRoutes.newSafe.create,
-    AppRoutes.newSafe.load,
-    AppRoutes.welcome,
-    AppRoutes.index,
-  ].includes(router.pathname)
 
   return (
     <>
@@ -33,9 +22,9 @@ const PageLayout = ({ children }: { children: ReactElement }): ReactElement => {
         <Header onMenuToggle={toggleSidebar} />
       </header>
 
-      {!hideSidebar && <SideDrawer isOpen={isSidebarOpen} onToggle={setSidebarOpen} />}
+      <SideDrawer isOpen={isSidebarOpen} onToggle={setSidebarOpen} />
 
-      <div className={classnames(css.main, (!isSidebarOpen || hideSidebar) && css.mainNoSidebar)}>
+      <div className={classnames(css.main, !isSidebarOpen && css.mainNoSidebar)}>
         <div className={css.content}>
           <SafeLoadingError>{children}</SafeLoadingError>
         </div>


### PR DESCRIPTION
## What it solves

Fixes a regression introduced in #1471 

## How this PR fixes it

- Keeps the sidebar mounted but hidden

## How to test it

1. Open the welcome/create safe/load safe page on mobile
2. Press the Burger menu icon
3. Observe the sidebar opening
