### PR TITLE
fix: button color for OnboardingTooltip

### DIFF
--- a/src/components/common/OnboardingTooltip/index.tsx
+++ b/src/components/common/OnboardingTooltip/index.tsx
@@ -39,7 +39,7 @@ export const OnboardingTooltip = ({
           <span>{text}</span>
           <Button
             size="small"
-            color={isDarkMode ? undefined : 'secondary'}
+            color={isDarkMode ? 'background' : 'secondary'}
             variant="text"
             sx={{ whiteSpace: 'nowrap' }}
             onClick={() => setWidgetHidden(true)}

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -46,6 +46,10 @@ declare module '@mui/material/Button' {
   interface ButtonPropsSizeOverrides {
     stretched: true
   }
+
+  interface ButtonPropsColorOverrides {
+    background: true
+  }
 }
 
 const initTheme = (darkMode: boolean) => {


### PR DESCRIPTION
## What it solves
In dark mode the green text button on white background is hard to read. Changed it to black.

## How to test it
Look at the tooltip for the new hide tokens in dark mode

## Screenshots
![Screenshot 2023-01-10 at 10 51 00](https://user-images.githubusercontent.com/2670790/211520236-9906b8fe-ba94-462c-b3dd-93ab45dd0397.png)

