### PR TITLE
Fix: div in p warning

### DIFF
--- a/src/components/common/Notifications/index.tsx
+++ b/src/components/common/Notifications/index.tsx
@@ -29,7 +29,7 @@ export const NotificationLink = ({
   const isExternal = typeof link.href === 'string' ? !isRelativeUrl(link.href) : link.href.host || link.href.hostname
 
   return (
-    <Track {...OVERVIEW_EVENTS.NOTIFICATION_INTERACTION} label={link.title}>
+    <Track {...OVERVIEW_EVENTS.NOTIFICATION_INTERACTION} label={link.title} as="span">
       <NextLink href={link.href} passHref>
         <Link
           className={css.link}

--- a/src/components/notification-center/NotificationCenterItem/index.tsx
+++ b/src/components/notification-center/NotificationCenterItem/index.tsx
@@ -39,10 +39,10 @@ const NotificationCenterItem = ({
   const requiresAction = !isRead && !!link
 
   const secondaryText = (
-    <div className={css.secondaryText}>
+    <span className={css.secondaryText}>
       <span>{formatTimeInWords(timestamp)}</span>
       <NotificationLink link={link} onClick={handleClose} />
-    </div>
+    </span>
   )
 
   return (


### PR DESCRIPTION
## What it solves

The `div inside p` warning strikes again.