### PR TITLE
fix: overwritten state of hidden tokens

### DIFF
--- a/src/store/__tests__/settingsSlice.test.ts
+++ b/src/store/__tests__/settingsSlice.test.ts
@@ -1,0 +1,26 @@
+import { hexZeroPad } from 'ethers/lib/utils'
+import { setHiddenTokensForChain, settingsSlice } from '../settingsSlice'
+
+describe('settingsSlice', () => {
+  it('handle hiddenTokens', () => {
+    const token1 = hexZeroPad('0x1', 20)
+    const token2 = hexZeroPad('0x2', 20)
+    const token3 = hexZeroPad('0x3', 20)
+
+    let state = settingsSlice.reducer(undefined, setHiddenTokensForChain({ chainId: '1', assets: [token1] }))
+    expect(state.hiddenTokens).toEqual({
+      ['1']: [token1],
+    })
+
+    state = settingsSlice.reducer(state, setHiddenTokensForChain({ chainId: '1', assets: [token1, token2] }))
+    expect(state.hiddenTokens).toEqual({
+      ['1']: [token1, token2],
+    })
+
+    state = settingsSlice.reducer(state, setHiddenTokensForChain({ chainId: '5', assets: [token3] }))
+    expect(state.hiddenTokens).toEqual({
+      ['1']: [token1, token2],
+      ['5']: [token3],
+    })
+  })
+})

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -56,8 +56,8 @@ export const settingsSlice = createSlice({
     },
     setHiddenTokensForChain: (state, { payload }: PayloadAction<{ chainId: string; assets: string[] }>) => {
       const { chainId, assets } = payload
-      state.hiddenTokens = {}
-      state.hiddenTokens[chainId] ??= assets
+      state.hiddenTokens ??= {}
+      state.hiddenTokens[chainId] = assets
     },
   },
 })


### PR DESCRIPTION
## What it solves

Resolves #1513 

## How this PR fixes it
Does not overwrite hidden tokens on other chains when the state is modified.

## How to test it
1. Hide tokens on mainnet
2. Hide tokens on goerli
3. go back to the Safe in mainnet and witness the tokens to still be hidden
