### PR TITLE
Fix: fiat total skeleton

### DIFF
--- a/src/components/sidebar/SidebarHeader/index.tsx
+++ b/src/components/sidebar/SidebarHeader/index.tsx
@@ -1,5 +1,4 @@
-import type { ReactElement } from 'react'
-import { useEffect, useState } from 'react'
+import { type ReactElement, useMemo } from 'react'
 import Typography from '@mui/material/Typography'
 import IconButton from '@mui/material/IconButton'
 import Skeleton from '@mui/material/Skeleton'
@@ -30,16 +29,16 @@ import { useVisibleBalances } from '@/hooks/useVisibleBalances'
 
 const SafeHeader = (): ReactElement => {
   const currency = useAppSelector(selectCurrency)
-  const { balances, loading: balancesLoading } = useVisibleBalances()
+  const { balances } = useVisibleBalances()
   const { safe, safeAddress, safeLoading } = useSafeInfo()
   const { threshold, owners } = safe
   const chain = useCurrentChain()
   const settings = useAppSelector(selectSettings)
-  const [fiatTotal, setFiatTotal] = useState<string>('')
 
-  useEffect(() => {
-    setFiatTotal(balancesLoading ? '' : formatCurrency(balances.fiatTotal, currency))
-  }, [currency, balances.fiatTotal, balancesLoading])
+  const fiatTotal = useMemo(
+    () => (balances.fiatTotal ? formatCurrency(balances.fiatTotal, currency) : ''),
+    [currency, balances.fiatTotal],
+  )
 
   const addressCopyText = settings.shortName.copy && chain ? `${chain.shortName}:${safeAddress}` : safeAddress
 

--- a/src/hooks/useVisibleBalances.ts
+++ b/src/hooks/useVisibleBalances.ts
@@ -43,17 +43,17 @@ export const useVisibleBalances = (): {
   loading: boolean
   error?: string
 } => {
-  const balances = useBalances()
+  const data = useBalances()
   const hiddenTokens = useHiddenTokens()
 
   return useMemo(
     () => ({
-      ...balances,
+      ...data,
       balances: {
-        items: filterHiddenTokens(balances.balances.items, hiddenTokens),
-        fiatTotal: getVisibleFiatTotal(balances.balances, hiddenTokens),
+        items: filterHiddenTokens(data.balances.items, hiddenTokens),
+        fiatTotal: data.balances.fiatTotal ? getVisibleFiatTotal(data.balances, hiddenTokens) : '',
       },
     }),
-    [balances, hiddenTokens],
+    [data, hiddenTokens],
   )
 }


### PR DESCRIPTION
## What it solves

A small regression from the spam tokens feature. While balances are loading, we were briefly displaying 0.00 USD instead of a skeleton in the sidebar.