### PR TITLE
[Eip-1271] normalize EIP-712 messages

### DIFF
--- a/src/services/safe-messages/__tests__/safeMsgSender.test.ts
+++ b/src/services/safe-messages/__tests__/safeMsgSender.test.ts
@@ -5,6 +5,7 @@ import type { JsonRpcSigner } from '@ethersproject/providers'
 import { dispatchSafeMsgConfirmation, dispatchSafeMsgProposal } from '@/services/safe-messages/safeMsgSender'
 import * as utils from '@/utils/safe-messages'
 import * as events from '@/services/safe-messages/safeMsgEvents'
+import { hexZeroPad } from 'ethers/lib/utils'
 
 jest.mock('@safe-global/safe-gateway-typescript-sdk', () => ({
   ...jest.requireActual('@safe-global/safe-gateway-typescript-sdk'),
@@ -60,6 +61,58 @@ describe('safeMsgSender', () => {
         requestId,
       })
     })
+
+    it('should normalize EIP712 messages', async () => {
+      const proposeSafeMessageSpy = jest.spyOn(gateway, 'proposeSafeMessage')
+      proposeSafeMessageSpy.mockImplementation(() => Promise.resolve())
+      jest.spyOn(events, 'safeMsgDispatch')
+
+      const safe = {
+        version: '1.3.0',
+        chainId: '1',
+        address: {
+          value: hexZeroPad('0x789', 20),
+        },
+      } as unknown as gateway.SafeInfo
+      const message: {
+        types: { [type: string]: { name: string; type: string }[] }
+        domain: any
+        message: any
+        primaryType?: string
+      } = {
+        types: {
+          Test: [{ name: 'test', type: 'string' }],
+        },
+        domain: {
+          chainId: '1',
+          name: 'TestDapp',
+          verifyingContract: hexZeroPad('0x1234', 20),
+        },
+        message: {
+          test: 'Hello World!',
+        },
+      }
+      const requestId = '0x123'
+      const safeAppId = 1
+      const signer = mockProvider.getSigner()
+
+      await dispatchSafeMsgProposal({ signer, safe, message, requestId, safeAppId })
+
+      // Normalize message manually
+      message.types['EIP712Domain'] = [
+        { name: 'name', type: 'string' },
+        { name: 'chainId', type: 'uint256' },
+        { name: 'verifyingContract', type: 'address' },
+      ]
+      message.primaryType = 'Test'
+
+      expect(proposeSafeMessageSpy).toHaveBeenCalledWith('1', hexZeroPad('0x789', 20), {
+        message,
+        signature: '0x456',
+        safeAppId,
+      })
+    })
+
     it('should dispatch a message proposal failure', async () => {
       const proposeSafeMessageSpy = jest.spyOn(gateway, 'proposeSafeMessage')
       proposeSafeMessageSpy.mockImplementation(() => Promise.reject(new Error('Example error')))
@@ -126,6 +179,7 @@ describe('safeMsgSender', () => {
         requestId,
       })
     })
+
     it('should dispatch a message proposal failure', async () => {
       const confirmSafeMessageSpy = jest.spyOn(gateway, 'confirmSafeMessage')
       confirmSafeMessageSpy.mockImplementation(() => Promise.reject(new Error('Example error')))

--- a/src/services/safe-messages/safeMsgSender.ts
+++ b/src/services/safe-messages/safeMsgSender.ts
@@ -1,11 +1,13 @@
 import { proposeSafeMessage, confirmSafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
 import type { SafeInfo, SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
 import type { RequestId } from '@gnosis.pm/safe-apps-sdk'
+import { isObjectEIP712TypedData } from '@gnosis.pm/safe-apps-sdk'
 import type { TypedDataDomain } from 'ethers'
 import type { JsonRpcSigner } from '@ethersproject/providers'
 
 import { safeMsgDispatch, SafeMsgEvent } from './safeMsgEvents'
 import { generateSafeMessageHash, generateSafeMessageTypedData } from '@/utils/safe-messages'
+import { normalizeTypedData } from '@/utils/web3'
 
 export const dispatchSafeMsgProposal = async ({
   signer,
@@ -30,8 +32,13 @@ export const dispatchSafeMsgProposal = async ({
       typedData.message,
     )
 
+    let normalizedMessage = message
+    if (isObjectEIP712TypedData(message)) {
+      normalizedMessage = normalizeTypedData(message)
+    }
+
     await proposeSafeMessage(safe.chainId, safe.address.value, {
-      message,
+      message: normalizedMessage,
       signature,
       safeAppId,
     })

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -7,3 +7,8 @@ export const hashTypedData = (typedData: EIP712TypedData): string => {
   const { EIP712Domain: _, ...types } = typedData.types
   return _TypedDataEncoder.hash(typedData.domain as TypedDataDomain, types, typedData.message)
 }
+
+export const normalizeTypedData = (typedData: EIP712TypedData) => {
+  const { EIP712Domain: _, ...types } = typedData.types
+  return _TypedDataEncoder.getPayload(typedData.domain as TypedDataDomain, types, typedData.message)
+}


### PR DESCRIPTION
## What it solves

Before submitting EIP 712 messages to our tx service we normalize the message.

Normalizing a message does:
- Infers the EIP712Domain type
- Infers the primaryType

Resolves #1517 

## TODOs
- [x] Add unit test for message normalization

## How this PR fixes it
Uses the `TypedDataEncoder.getPayload` function to normalize and verify a message before submitting it.

## How to test it
Sign a EIP 712 message without primaryType or without EIP712Domain type.

## Analytics changes
None