### PR TITLE
Fix: hide Switch wallet button

### DIFF
--- a/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -100,9 +100,12 @@ const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
 
           <ChainSwitcher fullWidth />
 
-          <Button variant="contained" size="small" onClick={handleSwitchWallet} fullWidth>
-            Switch wallet
-          </Button>
+          {/* FIXME: onboard/SDK initialization when switching wallets */}
+          {false && (
+            <Button variant="contained" size="small" onClick={handleSwitchWallet} fullWidth>
+              Switch wallet
+            </Button>
+          )}
 
           <Button onClick={handleDisconnect} variant="danger" size="small" fullWidth disableElevation>
             Disconnect


### PR DESCRIPTION
## What it solves

There seems to be a problem with SDK init, so I'm commenting out the Switch button until it's fixed.