### PR TITLE
Fix: disconnect wallet if SDK fails to init

### DIFF
--- a/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -5,7 +5,7 @@ import css from '@/components/common/ConnectWallet/styles.module.css'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
-import useOnboard, { closeAccountSelectionModal, connectWallet } from '@/hooks/wallets/useOnboard'
+import useOnboard, { switchWallet } from '@/hooks/wallets/useOnboard'
 import { useAppSelector } from '@/store'
 import { selectChainById } from '@/store/chainsSlice'
 import Identicon from '@/components/common/Identicon'
@@ -23,8 +23,7 @@ const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
   const handleSwitchWallet = () => {
     if (onboard) {
       handleClose()
-      connectWallet(onboard)
-      closeAccountSelectionModal()
+      switchWallet(onboard)
     }
   }
 

--- a/src/hooks/coreSDK/__tests__/useInitSafeCoreSDK.test.ts
+++ b/src/hooks/coreSDK/__tests__/useInitSafeCoreSDK.test.ts
@@ -3,8 +3,9 @@ import { useInitSafeCoreSDK } from '@/hooks/coreSDK/useInitSafeCoreSDK'
 import * as useSafeInfo from '@/hooks/useSafeInfo'
 import * as coreSDK from '@/hooks/coreSDK/safeCoreSDK'
 import * as useWallet from '@/hooks/wallets/useWallet'
+import * as useOnboard from '@/hooks/wallets/useOnboard'
 import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
-import type { EIP1193Provider } from '@web3-onboard/core'
+import type { EIP1193Provider, OnboardAPI } from '@web3-onboard/core'
 import { act } from '@testing-library/react'
 import type Safe from '@safe-global/safe-core-sdk'
 
@@ -30,11 +31,16 @@ describe('useInitSafeCoreSDK hook', () => {
     provider: null as unknown as EIP1193Provider,
   }
 
+  const mockOnboard = {
+    disconnectWallet: jest.fn(),
+  } as unknown as OnboardAPI
+
   beforeEach(() => {
     jest.clearAllMocks()
 
     jest.spyOn(useSafeInfo, 'default').mockReturnValue(mockSafeInfo)
     jest.spyOn(useWallet, 'default').mockReturnValue(mockWallet)
+    jest.spyOn(useOnboard, 'default').mockReturnValue(mockOnboard)
   })
 
   it('initializes a Core SDK instance', async () => {

--- a/src/hooks/coreSDK/useInitSafeCoreSDK.ts
+++ b/src/hooks/coreSDK/useInitSafeCoreSDK.ts
@@ -34,7 +34,7 @@ export const useInitSafeCoreSDK = () => {
         trackError(ErrorCodes._105, (e as Error).message)
 
         // Disconnect the wallet
-        onboard?.disconnectWallet({ label: wallet.label })
+        onboard.disconnectWallet({ label: wallet.label })
       })
   }, [onboard, wallet, safe.chainId, safe.address.value, safe.version, safeLoaded, dispatch])
 }

--- a/src/hooks/coreSDK/useInitSafeCoreSDK.ts
+++ b/src/hooks/coreSDK/useInitSafeCoreSDK.ts
@@ -6,14 +6,16 @@ import { trackError } from '@/services/exceptions'
 import ErrorCodes from '@/services/exceptions/ErrorCodes'
 import { useAppDispatch } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
+import useOnboard from '@/hooks/wallets/useOnboard'
 
 export const useInitSafeCoreSDK = () => {
   const wallet = useWallet()
+  const onboard = useOnboard()
   const { safe, safeLoaded } = useSafeInfo()
   const dispatch = useAppDispatch()
 
   useEffect(() => {
-    if (!safeLoaded || !wallet?.provider || safe.chainId !== wallet.chainId || !safe.version) {
+    if (!onboard || !wallet?.provider || !safeLoaded || safe.chainId !== wallet.chainId || !safe.version) {
       // If we don't reset the SDK, a previous Safe could remain in the store
       setSafeSDK(undefined)
       return
@@ -24,12 +26,15 @@ export const useInitSafeCoreSDK = () => {
       .catch((e) => {
         dispatch(
           showNotification({
-            message: `The Safe SDK could not be initialized.`,
+            message: `The Safe SDK could not be initialized. Please try connecting the wallet again.`,
             groupKey: 'core-sdk-init-error',
             variant: 'error',
           }),
         )
         trackError(ErrorCodes._105, (e as Error).message)
+
+        // Disconnect the wallet
+        onboard?.disconnectWallet({ label: wallet.label })
       })
-  }, [wallet?.provider, wallet?.chainId, safe.chainId, safe.address.value, safe.version, safeLoaded, dispatch])
+  }, [onboard, wallet, safe.chainId, safe.address.value, safe.version, safeLoaded, dispatch])
 }

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -107,7 +107,7 @@ export const connectWallet = async (onboard: OnboardAPI, options?: Parameters<On
 
 // A workaround for an onboard "feature" that shows a defunct account select popup
 // See https://github.com/blocknative/web3-onboard/issues/888
-export const closeAccountSelectionModal = () => {
+const closeAccountSelectionModal = () => {
   const maxTries = 100
   const modalText = 'Please switch the active account'
   let tries = 0
@@ -125,6 +125,11 @@ export const closeAccountSelectionModal = () => {
     tries += 1
     if (tries >= maxTries) clearInterval(timer)
   }, 100)
+}
+
+export const switchWallet = (onboard: OnboardAPI) => {
+  connectWallet(onboard)
+  closeAccountSelectionModal()
 }
 
 // Disable/enable wallets according to chain and cache the last used wallet

--- a/src/hooks/wallets/useWallet.ts
+++ b/src/hooks/wallets/useWallet.ts
@@ -3,16 +3,20 @@ import useOnboard, { type ConnectedWallet, getConnectedWallet } from './useOnboa
 
 const useWallet = (): ConnectedWallet | null => {
   const onboard = useOnboard()
-  const onboardWallets = onboard?.state.get().wallets || []
-  const [wallet, setWallet] = useState<ConnectedWallet | null>(getConnectedWallet(onboardWallets))
+  const [wallet, setWallet] = useState<ConnectedWallet | null>(null)
 
   useEffect(() => {
     if (!onboard) return
 
-    const walletSubscription = onboard.state.select('wallets').subscribe((wallets) => {
-      const newWallet = getConnectedWallet(wallets)
-      setWallet(newWallet)
-    })
+    const onWallet = () => {
+      const onboardWallets = onboard?.state.get().wallets || []
+      const currWallet = getConnectedWallet(onboardWallets)
+      setWallet(currWallet)
+    }
+
+    onWallet()
+
+    const walletSubscription = onboard.state.select('wallets').subscribe(onWallet)
 
     return () => {
       walletSubscription.unsubscribe()

--- a/src/hooks/wallets/useWallet.ts
+++ b/src/hooks/wallets/useWallet.ts
@@ -3,13 +3,15 @@ import useOnboard, { type ConnectedWallet, getConnectedWallet } from './useOnboa
 
 const useWallet = (): ConnectedWallet | null => {
   const onboard = useOnboard()
-  const [wallet, setWallet] = useState<ConnectedWallet | null>(null)
+  const onboardWallets = onboard?.state.get().wallets || []
+  const [wallet, setWallet] = useState<ConnectedWallet | null>(getConnectedWallet(onboardWallets))
 
   useEffect(() => {
     if (!onboard) return
 
     const walletSubscription = onboard.state.select('wallets').subscribe((wallets) => {
-      setWallet(getConnectedWallet(wallets))
+      const newWallet = getConnectedWallet(wallets)
+      setWallet(newWallet)
     })
 
     return () => {

--- a/src/hooks/wallets/useWallet.ts
+++ b/src/hooks/wallets/useWallet.ts
@@ -8,15 +8,9 @@ const useWallet = (): ConnectedWallet | null => {
   useEffect(() => {
     if (!onboard) return
 
-    const onWallet = () => {
-      const onboardWallets = onboard?.state.get().wallets || []
-      const currWallet = getConnectedWallet(onboardWallets)
-      setWallet(currWallet)
-    }
-
-    onWallet()
-
-    const walletSubscription = onboard.state.select('wallets').subscribe(onWallet)
+    const walletSubscription = onboard.state.select('wallets').subscribe((wallets) => {
+      setWallet(getConnectedWallet(wallets))
+    })
 
     return () => {
       walletSubscription.unsubscribe()


### PR DESCRIPTION
## What it solves

Resolves #1519

The root cause was that if you dismiss the HW account selection popup, the account is seemingly still connected but the Core SDK fails to init.
And the second part of the problem was that the SDK wouldn't even re-init when that popup is dismissed because the provider object doesn't refresh in that case.

## How this PR fixes it
I fixed the problem by
 1. making the entire wallet object a dependency of the SDK hook (as opposed to just the provider)
 2. the wallet will be disconnected if the SDK fails to init.

## How to test it
* Connect to Ledger
* Attempt to connect to Ledger again, but dismiss the account selection modal w/o selecting an account
* Attempt to execute a tx or a batch