### PR TITLE
fix: show input loading state when "Add Safe" from the sidebar

### DIFF
--- a/src/components/common/AddressInput/index.tsx
+++ b/src/components/common/AddressInput/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react'
-import { useEffect, useCallback, useRef, useMemo } from 'react'
+import { useEffect, useCallback, useRef, useMemo, useState } from 'react'
 import { InputAdornment, TextField, type TextFieldProps, CircularProgress, Grid } from '@mui/material'
 import { useFormContext, useWatch, type Validate, get } from 'react-hook-form'
 import { FEATURES } from '@safe-global/safe-gateway-typescript-sdk'
@@ -25,6 +25,7 @@ const AddressInput = ({ name, validate, required = true, deps, ...props }: Addre
   const rawValueRef = useRef<string>('')
   const watchedValue = useWatch({ name, control })
   const currentShortName = currentChain?.shortName || ''
+  const [localLoading, setLocalLoading] = useState<boolean>(false)
 
   // Fetch an ENS resolution for the current address
   const isDomainLookupEnabled = !!currentChain && hasFeature(currentChain, FEATURES.DOMAIN_LOOKUP)
@@ -54,6 +55,10 @@ const AddressInput = ({ name, validate, required = true, deps, ...props }: Addre
     }
   }, [address, currentShortName, setAddressValue])
 
+  useEffect(() => {
+    setLocalLoading(false)
+  }, [isValidating])
+
   return (
     <Grid container alignItems="center" gap={1}>
       <Grid item flexGrow={1}>
@@ -72,7 +77,7 @@ const AddressInput = ({ name, validate, required = true, deps, ...props }: Addre
               <InputAdornment position="end">{currentShortName}:</InputAdornment>
             ),
 
-            endAdornment: (resolving || isValidating) && (
+            endAdornment: (resolving || isValidating || localLoading) && (
               <InputAdornment position="end">
                 <CircularProgress size={20} />
               </InputAdornment>
@@ -89,6 +94,7 @@ const AddressInput = ({ name, validate, required = true, deps, ...props }: Addre
             required,
 
             setValueAs: (value: string): string => {
+              setLocalLoading(true)
               rawValueRef.current = value
               // This also checksums the address
               return parsePrefixedAddress(value).address


### PR DESCRIPTION
## What it solves

Resolves #1520 

## How this PR fixes it
Creates a local isValidating instead of using the `isValidating` returned by the `useFormContext`.

## How to test it
See https://github.com/safe-global/web-core/issues/1520

## Screenshots
https://user-images.githubusercontent.com/32431609/211860699-491ad7ad-7d9b-4d3e-99ee-81ffb4eeb5df.mov

