### PR TITLE
fix: wait until successful SDK call to set pending state

### DIFF
--- a/src/services/tx/tx-sender/dispatch.ts
+++ b/src/services/tx/tx-sender/dispatch.ts
@@ -86,12 +86,11 @@ export const dispatchOnChainSigning = async (safeTx: SafeTransaction, provider: 
   const safeTxHash = await sdkUnchecked.getTransactionHash(safeTx)
   const eventParams = { txId }
 
-  txDispatch(TxEvent.ONCHAIN_SIGNATURE_REQUESTED, eventParams)
-
   try {
     // With the unchecked signer, the contract call resolves once the tx
     // has been submitted in the wallet not when it has been executed
     await sdkUnchecked.approveTransactionHash(safeTxHash)
+    txDispatch(TxEvent.ONCHAIN_SIGNATURE_REQUESTED, eventParams)
   } catch (err) {
     txDispatch(TxEvent.FAILED, { ...eventParams, error: err as Error })
     throw err

--- a/src/services/tx/tx-sender/dispatch.ts
+++ b/src/services/tx/tx-sender/dispatch.ts
@@ -115,12 +115,11 @@ export const dispatchTxExecution = async (
   const sdkUnchecked = await getUncheckedSafeSDK(provider)
   const eventParams = txId ? { txId } : { groupKey: await sdkUnchecked.getTransactionHash(safeTx) }
 
-  txDispatch(TxEvent.EXECUTING, eventParams)
-
   // Execute the tx
   let result: TransactionResult | undefined
   try {
     result = await sdkUnchecked.executeTransaction(safeTx, txOptions)
+    txDispatch(TxEvent.EXECUTING, eventParams)
   } catch (error) {
     txDispatch(TxEvent.FAILED, { ...eventParams, error: error as Error })
     throw error

--- a/src/services/tx/tx-sender/dispatch.ts
+++ b/src/services/tx/tx-sender/dispatch.ts
@@ -158,14 +158,13 @@ export const dispatchBatchExecution = async (
 ) => {
   const groupKey = multiSendTxData
 
-  txs.forEach(({ txId }) => {
-    txDispatch(TxEvent.EXECUTING, { txId, groupKey })
-  })
-
   let result: TransactionResult | undefined
 
   try {
     result = await multiSendContract.contract.connect(provider.getSigner()).multiSend(multiSendTxData)
+    txs.forEach(({ txId }) => {
+      txDispatch(TxEvent.EXECUTING, { txId, groupKey })
+    })
   } catch (err) {
     txs.forEach(({ txId }) => {
       txDispatch(TxEvent.FAILED, { txId, error: err as Error, groupKey })
@@ -228,8 +227,6 @@ export const dispatchSpendingLimitTxExecution = async (
 
   const id = JSON.stringify(txParams)
 
-  txDispatch(TxEvent.EXECUTING, { groupKey: id })
-
   let result: ContractTransaction | undefined
   try {
     result = await contract.executeAllowanceTransfer(
@@ -243,6 +240,7 @@ export const dispatchSpendingLimitTxExecution = async (
       txParams.signature,
       txOptions,
     )
+    txDispatch(TxEvent.EXECUTING, { groupKey: id })
   } catch (error) {
     txDispatch(TxEvent.FAILED, { groupKey: id, error: error as Error })
     throw error

--- a/src/services/tx/tx-sender/index.test.ts
+++ b/src/services/tx/tx-sender/index.test.ts
@@ -317,26 +317,6 @@ describe('txSender', () => {
       await expect(dispatchTxExecution(safeTx, mockProvider, {}, txId)).rejects.toThrow('error')
 
       expect(mockSafeSDK.executeTransaction).toHaveBeenCalled()
-      expect(txEvents.txDispatch).toHaveBeenCalledWith('EXECUTING', { txId })
-      expect(txEvents.txDispatch).toHaveBeenCalledWith('FAILED', { txId, error: new Error('error') })
-    })
-
-    it('should fail executing a tx', async () => {
-      jest.spyOn(mockSafeSDK, 'executeTransaction').mockImplementationOnce(() => Promise.reject(new Error('error')))
-
-      const txId = 'tx_id_123'
-
-      const safeTx = await createTx({
-        to: '0x123',
-        value: '1',
-        data: '0x0',
-        nonce: 1,
-      })
-
-      await expect(dispatchTxExecution(safeTx, mockProvider, {}, txId)).rejects.toThrow('error')
-
-      expect(mockSafeSDK.executeTransaction).toHaveBeenCalled()
-      expect(txEvents.txDispatch).toHaveBeenCalledWith('EXECUTING', { txId })
       expect(txEvents.txDispatch).toHaveBeenCalledWith('FAILED', { txId, error: new Error('error') })
     })
 


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/web-core/issues/1489

## How this PR fixes it
Waits for a successful SDK interaction to dispatch the tx PENDING state

## How to test it
1. Open a fully signed tx
2. Press Execute
3. Do not approve or reject in the wallet
4. Refresh the page
5. There is no "Submitting" transaction yet

## Analytics changes
N/A

## Screenshots
https://user-images.githubusercontent.com/32431609/212056935-3965af77-002d-48cc-95cd-1eea1adea614.mov

