### PR TITLE
feat: set fallback handler

### DIFF
--- a/src/components/settings/FallbackHandlerVersion/SetFallbackHandlerDialog.tsx
+++ b/src/components/settings/FallbackHandlerVersion/SetFallbackHandlerDialog.tsx
@@ -1,0 +1,76 @@
+import { Box, Button, Typography } from '@mui/material'
+import { useState } from 'react'
+
+import TxModal from '@/components/tx/TxModal'
+
+import useTxSender from '@/hooks/useTxSender'
+import useAsync from '@/hooks/useAsync'
+
+import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
+import type { TxStepperProps } from '@/components/tx/TxStepper/useTxStepper'
+import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import { createSetFallbackHandlerTx } from '@/services/tx/safeUpdateParams'
+
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { useCurrentChain } from '@/hooks/useChains'
+import ExternalLink from '@/components/common/ExternalLink'
+
+const SetFallbackHandlerSteps: TxStepperProps['steps'] = [
+  {
+    label: 'Set fallback handler',
+    render: (_, onSubmit) => <ReviewSetFallbackHandlerStep onSubmit={onSubmit} />,
+  },
+]
+
+const SetFallbackHandlerDialog = () => {
+  const [open, setOpen] = useState(false)
+
+  const handleClose = () => setOpen(false)
+
+  return (
+    <Box paddingTop={2}>
+      <div>
+        <Button onClick={() => setOpen(true)} variant="contained">
+          Set fallback handler
+        </Button>
+      </div>
+      {open && <TxModal onClose={handleClose} steps={SetFallbackHandlerSteps} />}
+    </Box>
+  )
+}
+
+const ReviewSetFallbackHandlerStep = ({ onSubmit }: { onSubmit: (txId?: string) => void }) => {
+  const { safe, safeLoaded } = useSafeInfo()
+  const chain = useCurrentChain()
+  const { createTx } = useTxSender()
+
+  const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
+    if (!chain || !safeLoaded) return
+
+    const tx = createSetFallbackHandlerTx(safe, chain)
+
+    return createTx(tx)
+  }, [chain, safe, safeLoaded, createTx])
+
+  return (
+    <SignOrExecuteForm safeTx={safeTx} onSubmit={onSubmit} error={safeTxError}>
+      <Typography mb={2}>
+        This transaction will set your fallback handler to the recommended one for your contract version.
+      </Typography>
+
+      <Typography mb={2}>
+        Through fallback handlers additional functionality can be given to your Safe.{' '}
+        <ExternalLink href="https://help.safe.global/en/articles/4738352-what-is-a-fallback-handler-and-how-does-it-relate-to-the-gnosis-safe">
+          Learn more
+        </ExternalLink>
+      </Typography>
+
+      <Typography mb={2}>
+        You will need to confirm this update just like any other transaction. This means other owners will have to
+        confirm the update in case more than one confirmation is required for this Safe.
+      </Typography>
+    </SignOrExecuteForm>
+  )
+}
+
+export default SetFallbackHandlerDialog

--- a/src/components/settings/FallbackHandlerVersion/__tests__/FallbackHandlerVersion.test.tsx
+++ b/src/components/settings/FallbackHandlerVersion/__tests__/FallbackHandlerVersion.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react'
+import { FallbackHandlerVersion } from '..'
+
+const renderFallbackHandler = () => render(<FallbackHandlerVersion isGranted={true} />)
+
+describe('FallbackHandlerVersion', () => {
+  it('should not render anything for unsupported safe versions', () => {
+    // TODO
+  })
+
+  it('should show set fallback handler button for empty fallback handlers', () => {
+    //TODO
+  })
+
+  it('should show name of fallback handler if known', () => {
+    // TODO
+  })
+})

--- a/src/components/settings/FallbackHandlerVersion/index.tsx
+++ b/src/components/settings/FallbackHandlerVersion/index.tsx
@@ -1,0 +1,40 @@
+import { Typography } from '@mui/material'
+
+import { sameAddress } from '@/utils/addresses'
+
+import useSafeInfo from '@/hooks/useSafeInfo'
+
+import UpdateSafeDialog from './SetFallbackHandlerDialog'
+import PrefixedEthHashInfo from '@/components/common/EthHashInfo'
+import { getFallbackHandlerContractDeployment } from '@/services/contracts/safeContracts'
+
+export const FallbackHandlerVersion = ({ isGranted }: { isGranted: boolean }) => {
+  const { safe } = useSafeInfo()
+
+  const fallbackHandlerAddress = safe.fallbackHandler?.value
+
+  const preferredFallbackHandlerContractInstance = safe.version
+    ? getFallbackHandlerContractDeployment(safe.chainId, safe.version)
+    : undefined
+  const preferredFallbackHandlerAddress = preferredFallbackHandlerContractInstance?.networkAddresses[safe.chainId]
+  const shouldUpdate =
+    preferredFallbackHandlerAddress && !sameAddress(fallbackHandlerAddress, preferredFallbackHandlerAddress)
+
+  const fallbackHandlerName =
+    safe.fallbackHandler?.name ?? !shouldUpdate ? preferredFallbackHandlerContractInstance?.contractName : 'Unknown'
+
+  return (
+    <div>
+      <Typography variant="h4" fontWeight={700} marginBottom={1}>
+        Fallback handler
+      </Typography>
+      {fallbackHandlerAddress ? (
+        <PrefixedEthHashInfo avatarSize={32} address={fallbackHandlerAddress} name={fallbackHandlerName} hasExplorer />
+      ) : (
+        <Typography>No fallback handler set</Typography>
+      )}
+
+      {shouldUpdate && isGranted && <UpdateSafeDialog />}
+    </div>
+  )
+}

--- a/src/pages/settings/setup.tsx
+++ b/src/pages/settings/setup.tsx
@@ -8,6 +8,7 @@ import { RequiredConfirmation } from '@/components/settings/RequiredConfirmation
 import useSafeInfo from '@/hooks/useSafeInfo'
 import SettingsHeader from '@/components/settings/SettingsHeader'
 import useIsGranted from '@/hooks/useIsGranted'
+import { FallbackHandlerVersion } from '@/components/settings/FallbackHandlerVersion'
 
 const Setup: NextPage = () => {
   const { safe } = useSafeInfo()
@@ -51,8 +52,11 @@ const Setup: NextPage = () => {
               </Typography>
             </Grid>
 
-            <Grid item xs>
+            <Grid item lg={4} xs={12}>
               <ContractVersion isGranted={isGranted} />
+            </Grid>
+            <Grid item lg={4} xs={12}>
+              <FallbackHandlerVersion isGranted={isGranted} />
             </Grid>
           </Grid>
         </Paper>

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -159,15 +159,14 @@ export const getProxyFactoryContractInstance = (chainId: string, safeVersion: st
 }
 
 // Fallback handler
-
-const getFallbackHandlerContractDeployment = (chainId: string) => {
+export const getFallbackHandlerContractDeployment = (chainId: string, version = LATEST_SAFE_VERSION) => {
   return (
     getFallbackHandlerDeployment({
-      version: LATEST_SAFE_VERSION,
+      version,
       network: chainId,
     }) ||
     getFallbackHandlerDeployment({
-      version: LATEST_SAFE_VERSION,
+      version,
     })
   )
 }

--- a/src/services/tx/safeUpdateParams.ts
+++ b/src/services/tx/safeUpdateParams.ts
@@ -44,3 +44,18 @@ export const createUpdateSafeTxs = (safe: SafeInfo, chain: ChainInfo): MetaTrans
 
   return txs
 }
+
+export const createSetFallbackHandlerTx = (safe: SafeInfo, chain: ChainInfo): MetaTransactionData => {
+  assertValidSafeVersion(safe.version)
+
+  const fallbackHandlerAddress = getFallbackHandlerContractInstance(chain.chainId).getAddress()
+  const safeContractInstance = getGnosisSafeContractInstance(chain, safe.version)
+  const changeFallbackHandlerCallData = safeContractInstance.encode('setFallbackHandler', [fallbackHandlerAddress])
+
+  return {
+    to: safe.address.value,
+    value: '0',
+    data: changeFallbackHandlerCallData,
+    operation: OperationType.Call,
+  }
+}


### PR DESCRIPTION
## What it solves
- Shows the fallback handler address in Settings / Setup page
- If no fallback handler is set, offers a new dialog to set the recommended fallback handler.

Resolves #1318 

## How to test it
- Open settings page and see the current fallback handler contract address
- Remove the fallback handler from a Safe and try the new "Set fallback handler" button / dialog.

## Analytics changes
tbd

## Screenshots
tbd
