### PR TITLE
fix: message positioning

### DIFF
--- a/src/components/safe-messages/Msg/index.tsx
+++ b/src/components/safe-messages/Msg/index.tsx
@@ -23,14 +23,14 @@ const Msg = ({
   }
 
   return (
-    <>
+    <div className={css.overflow}>
+      <pre className={css.pre}>
+        <code className={!showMsg ? css.truncated : undefined}>{JSON.stringify(message, null, 2)}</code>
+      </pre>
       <Link component="button" onClick={handleToggleMsg} fontSize="medium" className={css.toggle}>
         {showMsg ? 'Hide' : 'Show all'}
       </Link>
-      <pre>
-        <code className={!showMsg ? css.truncated : undefined}>{JSON.stringify(message, null, 2)}</code>
-      </pre>
-    </>
+    </div>
   )
 }
 

--- a/src/components/safe-messages/Msg/styles.module.css
+++ b/src/components/safe-messages/Msg/styles.module.css
@@ -1,6 +1,7 @@
 .toggle {
   font-weight: 700;
   text-decoration: underline;
+  text-align: left;
 }
 
 .truncated {
@@ -9,4 +10,12 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
   max-height: 9ex;
+}
+
+.overflow {
+  overflow: auto;
+}
+
+.pre {
+  margin: 0;
 }

--- a/src/components/safe-messages/MsgDetails/index.tsx
+++ b/src/components/safe-messages/MsgDetails/index.tsx
@@ -47,13 +47,13 @@ const MsgDetails = ({ msg }: { msg: SafeMessage }): ReactElement => {
         </div>
 
         <div className={txDetailsCss.txSummary}>
-          <TxDataRow title="Message:">
-            <Msg message={msg.message} defaultExpanded />
-          </TxDataRow>
-          <TxDataRow title="SafeMessage:">{generateDataRowValue(safeMessage, 'hash')}</TxDataRow>
-          <TxDataRow title="SafeMessage hash:">{generateDataRowValue(msg.messageHash, 'hash')}</TxDataRow>
           <TxDataRow title="Created:">{formatDateTime(msg.creationTimestamp)}</TxDataRow>
           <TxDataRow title="Last modified:">{formatDateTime(msg.modifiedTimestamp)}</TxDataRow>
+          <TxDataRow title="Message hash:">{generateDataRowValue(msg.messageHash, 'hash')}</TxDataRow>
+          <TxDataRow title="SafeMessage hash:">{generateDataRowValue(safeMessage, 'hash')}</TxDataRow>
+          <TxDataRow title="SafeMessage:">
+            <Msg message={msg.message} defaultExpanded />
+          </TxDataRow>
         </div>
 
         {msg.preparedSignature && (

--- a/src/components/safe-messages/MsgDetails/index.tsx
+++ b/src/components/safe-messages/MsgDetails/index.tsx
@@ -50,8 +50,8 @@ const MsgDetails = ({ msg }: { msg: SafeMessage }): ReactElement => {
           <TxDataRow title="Created:">{formatDateTime(msg.creationTimestamp)}</TxDataRow>
           <TxDataRow title="Last modified:">{formatDateTime(msg.modifiedTimestamp)}</TxDataRow>
           <TxDataRow title="Message hash:">{generateDataRowValue(msg.messageHash, 'hash')}</TxDataRow>
-          <TxDataRow title="SafeMessage hash:">{generateDataRowValue(safeMessage, 'hash')}</TxDataRow>
-          <TxDataRow title="SafeMessage:">
+          <TxDataRow title="SafeMessage:">{generateDataRowValue(safeMessage, 'hash')}</TxDataRow>
+          <TxDataRow title="Message:">
             <Msg message={msg.message} defaultExpanded />
           </TxDataRow>
         </div>

--- a/src/components/transactions/TxDetails/styles.module.css
+++ b/src/components/transactions/TxDetails/styles.module.css
@@ -1,18 +1,12 @@
 .container {
-  display: grid;
-  grid-template-columns: 2fr 1fr;
+  display: flex;
   width: 100%;
   overflow-x: auto;
   border-top: 1px solid var(--color-border-light);
 }
 
-@media (max-width: 600px) {
-  .container {
-    grid-template-columns: 1fr;
-  }
-}
-
 .details {
+  width: 66.6%;
   display: flex;
   flex-direction: column;
   position: relative;
@@ -24,8 +18,8 @@
   top: 16px;
 }
 
-.details.noSigners {
-  grid-column: 1 / 3;
+.details .noSigners {
+  width: 100%;
 }
 
 .loading,
@@ -48,6 +42,7 @@
 
 .txSigners {
   display: flex;
+  width: 33.3%;
   flex-direction: column;
   justify-content: space-between;
   padding: var(--space-3);
@@ -64,7 +59,16 @@
 }
 
 @media (max-width: 600px) {
+  .container {
+    flex-direction: column;
+  }
+
+  .details {
+    width: 100%;
+  }
+
   .txSigners {
+    width: 100%;
     border-left: 0;
     border-top: 1px solid var(--color-border-light);
   }


### PR DESCRIPTION
## What it solves

Resolves #1393

## How this PR fixes it

The message details `display` has been altered to `flex` and the `SafeMessage` positioning has been aligned with [the design](https://www.figma.com/file/x1uuIJsOZkyv5cwNlDdVC1/EIP-1271?node-id=253%3A4454&t=62fpDRvXgYksVegG-0).

## How to test it

Open an EIP-712 message and observe the new layout, not overlapping onto the signers column.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/212296700-0d2bbcf5-28e7-4262-af00-e65b567bca9d.png)
![image](https://user-images.githubusercontent.com/20442784/212296727-552d6e60-d0b7-4be3-bda6-144f0b37be9b.png)
![image](https://user-images.githubusercontent.com/20442784/212296742-31f1d752-ad69-4954-b7da-c8c200039ca9.png)
![image](https://user-images.githubusercontent.com/20442784/212296768-a617a0df-52d3-498b-b6a4-341a15ab2f5b.png)

![image](https://user-images.githubusercontent.com/20442784/212296783-f0b24a78-e3d5-40da-8e28-48874d237050.png)
![image](https://user-images.githubusercontent.com/20442784/212296792-ac553bbf-a7e0-42bb-baf1-0d5a1a6af90f.png)

![image](https://user-images.githubusercontent.com/20442784/212298154-e5490382-0472-405f-a9d4-c67fe3bef603.png)