### PR TITLE
fix: GA tracking wrong eventLabels, missing event type, overtracking wallet connect event

### DIFF
--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -66,10 +66,12 @@ const trackWalletType = (wallet: ConnectedWallet) => {
 
   getWalletConnectLabel(wallet)
     .then((wcLabel) => {
-      trackEvent({
-        ...WALLET_EVENTS.WALLET_CONNECT,
-        label: wcLabel,
-      })
+      if (wcLabel) {
+        trackEvent({
+          ...WALLET_EVENTS.WALLET_CONNECT,
+          label: wcLabel,
+        })
+      }
     })
     .catch(() => null)
 }

--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -79,6 +79,7 @@ type ActionGtmEvent = GtmEvent & {
   eventCategory: string
   eventAction: string
   eventLabel?: EventLabel
+  eventType?: EventType
 }
 
 type PageviewGtmEvent = GtmEvent & {
@@ -103,8 +104,17 @@ export const gtmTrack = (eventData: AnalyticsEvent): void => {
     eventAction: eventData.action,
   }
 
+  if (eventData.event === EventType.META) {
+    gtmEvent.eventType = EventType.META
+  } else {
+    gtmEvent.eventType = undefined
+  }
+
   if (eventData.label) {
     gtmEvent.eventLabel = eventData.label
+  } else {
+    // Otherwise, whatever was in the datalayer before will be reused
+    gtmEvent.eventLabel = undefined
   }
 
   const abTest = getAbTest()

--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -104,8 +104,8 @@ export const gtmTrack = (eventData: AnalyticsEvent): void => {
     eventAction: eventData.action,
   }
 
-  if (eventData.event === EventType.META) {
-    gtmEvent.eventType = EventType.META
+  if (eventData.event) {
+    gtmEvent.eventType = eventData.event
   } else {
     gtmEvent.eventType = undefined
   }


### PR DESCRIPTION
## What it solves

- Fixes overtracking introduced with #1496 
- Sends the meta event type as a custom dimension to GA for making it easier to filter
- Resets `eventLabel` for events that don't use it to prevent pollution

## How to test it

1. Open the Safe
2. Connect with MM
3. Observe only one meta event for connecting the wallet
4. Observe a new field `eventType` in GTM that is only set with meta events
5. Go to Assets and hide a token
6. Observe `eventLabel` with an undefined value in GTM

## Analytics changes

A new optional attribute `eventType` was added to the data layer
