### PR TITLE
feat(safe-apps): Open drawer in dashboard

### DIFF
--- a/src/components/dashboard/SafeAppsDashboardSection/SafeAppsDashboardSection.tsx
+++ b/src/components/dashboard/SafeAppsDashboardSection/SafeAppsDashboardSection.tsx
@@ -6,12 +6,16 @@ import Button from '@mui/material/Button'
 
 import { WidgetContainer } from '../styled'
 import { useSafeApps } from '@/hooks/safe-apps/useSafeApps'
-import { AppCard, AppCardContainer } from '@/components/safe-apps/AppCard'
+import useSafeAppPreviewDrawer from '@/hooks/safe-apps/useSafeAppPreviewDrawer'
+import { AppCardContainer } from '@/components/safe-apps/AppCard'
+import SafeAppPreviewDrawer from '@/components/new-safe-apps/SafeAppPreviewDrawer/SafeAppPreviewDrawer'
+import SafeAppCard from '@/components/new-safe-apps/SafeAppCard/SafeAppCard'
 import { AppRoutes } from '@/config/routes'
 import ExploreSafeAppsIcon from '@/public/images/apps/explore.svg'
 
 const SafeAppsDashboardSection = () => {
   const { rankedSafeApps, togglePin, pinnedSafeAppIds } = useSafeApps()
+  const { isPreviewDrawerOpen, previewDrawerApp, openPreviewDrawer, closePreviewDrawer } = useSafeAppPreviewDrawer()
 
   return (
     <WidgetContainer>
@@ -22,7 +26,12 @@ const SafeAppsDashboardSection = () => {
       <Grid container spacing={3}>
         {rankedSafeApps.map((rankedSafeApp) => (
           <Grid key={rankedSafeApp.id} item xs={12} sm={6} md={4} xl={4}>
-            <AppCard safeApp={rankedSafeApp} onPin={togglePin} pinned={pinnedSafeAppIds.has(rankedSafeApp.id)} />
+            <SafeAppCard
+              safeApp={rankedSafeApp}
+              onBookmarkSafeApp={togglePin}
+              isBookmarked={pinnedSafeAppIds.has(rankedSafeApp.id)}
+              onClickSafeApp={() => openPreviewDrawer(rankedSafeApp)}
+            />
           </Grid>
         ))}
 
@@ -30,6 +39,14 @@ const SafeAppsDashboardSection = () => {
           <ExploreSafeAppsCard />
         </Grid>
       </Grid>
+
+      <SafeAppPreviewDrawer
+        isOpen={isPreviewDrawerOpen}
+        safeApp={previewDrawerApp}
+        isBookmarked={previewDrawerApp && pinnedSafeAppIds.has(previewDrawerApp.id)}
+        onClose={closePreviewDrawer}
+        onBookmark={togglePin}
+      />
     </WidgetContainer>
   )
 }

--- a/src/components/new-safe-apps/SafeAppCard/SafeAppCard.tsx
+++ b/src/components/new-safe-apps/SafeAppCard/SafeAppCard.tsx
@@ -24,7 +24,7 @@ export const LIST_VIEW_MODE: SafeAppsViewMode = 'list-view'
 
 type SafeAppCardProps = {
   safeApp: SafeAppData
-  onClickSafeApp?: (event: SyntheticEvent) => void
+  onClickSafeApp?: () => void
   viewMode?: SafeAppsViewMode
   isBookmarked?: boolean
   onBookmarkSafeApp?: (safeAppId: number) => void
@@ -45,6 +45,11 @@ const SafeAppCard = ({
 
   const isListViewMode = viewMode === LIST_VIEW_MODE
 
+  const handleClickSafeApp = (e: SyntheticEvent) => {
+    e.preventDefault()
+    onClickSafeApp?.()
+  }
+
   if (isListViewMode) {
     return (
       <SafeAppCardListView
@@ -53,7 +58,7 @@ const SafeAppCard = ({
         isBookmarked={isBookmarked}
         onBookmarkSafeApp={onBookmarkSafeApp}
         removeCustomApp={removeCustomApp}
-        onClickSafeApp={onClickSafeApp}
+        onClickSafeApp={handleClickSafeApp}
       />
     )
   }
@@ -66,7 +71,7 @@ const SafeAppCard = ({
       isBookmarked={isBookmarked}
       onBookmarkSafeApp={onBookmarkSafeApp}
       removeCustomApp={removeCustomApp}
-      onClickSafeApp={onClickSafeApp}
+      onClickSafeApp={handleClickSafeApp}
     />
   )
 }

--- a/src/components/new-safe-apps/SafeAppList/SafeAppList.tsx
+++ b/src/components/new-safe-apps/SafeAppList/SafeAppList.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import Grid from '@mui/material/Grid'
-import type { SyntheticEvent } from 'react'
 import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
 
 import SafeAppsFilters from '@/components/new-safe-apps/SafeAppsFilters/SafeAppsFilters'
@@ -31,25 +30,10 @@ const SafeAppList = ({
   removeCustomApp,
 }: SafeAppListProps) => {
   const [safeAppsViewMode, setSafeAppsViewMode] = useState<SafeAppsViewMode>(GRID_VIEW_MODE)
-  const {
-    safeApp: selectedSafeApp,
-    setSafeApp: setSelectedSafeApp,
-    isOpen: isAppPreviewDrawerOpen,
-    setIsOpen: setIsAppPreviewDrawerOpen,
-  } = useSafeAppPreviewDrawer()
+  const { isPreviewDrawerOpen, previewDrawerApp, openPreviewDrawer, closePreviewDrawer } = useSafeAppPreviewDrawer()
 
   const { filteredApps, query, setQuery, setSelectedCategories, setOptimizedWithBatchFilter, selectedCategories } =
     useSafeAppsFilters(safeAppsList)
-
-  const onClickSafeApp = (safeApp: SafeAppData) => (event: SyntheticEvent) => {
-    const isCustomApp = safeApp.id < 1
-
-    if (!isCustomApp) {
-      event.preventDefault()
-      setSelectedSafeApp(safeApp)
-      setIsAppPreviewDrawerOpen(true)
-    }
-  }
 
   const showZeroResultsPlaceholder = query && filteredApps.length === 0
 
@@ -91,7 +75,7 @@ const SafeAppList = ({
                   isBookmarked={bookmarkedSafeAppsId?.has(safeApp.id)}
                   onBookmarkSafeApp={onBookmarkSafeApp}
                   removeCustomApp={removeCustomApp}
-                  onClickSafeApp={onClickSafeApp(safeApp)}
+                  onClickSafeApp={() => openPreviewDrawer(safeApp)}
                 />
               </Grid>
             )
@@ -109,7 +93,7 @@ const SafeAppList = ({
                   isBookmarked={bookmarkedSafeAppsId?.has(safeApp.id)}
                   onBookmarkSafeApp={onBookmarkSafeApp}
                   removeCustomApp={removeCustomApp}
-                  onClickSafeApp={onClickSafeApp(safeApp)}
+                  onClickSafeApp={() => openPreviewDrawer(safeApp)}
                 />
               </Grid>
             )
@@ -122,10 +106,10 @@ const SafeAppList = ({
 
       {/* Safe App Preview Drawer */}
       <SafeAppPreviewDrawer
-        isOpen={isAppPreviewDrawerOpen}
-        safeApp={selectedSafeApp}
-        isBookmarked={selectedSafeApp && bookmarkedSafeAppsId?.has(selectedSafeApp.id)}
-        onClose={() => setIsAppPreviewDrawerOpen(false)}
+        isOpen={isPreviewDrawerOpen}
+        safeApp={previewDrawerApp}
+        isBookmarked={previewDrawerApp && bookmarkedSafeAppsId?.has(previewDrawerApp.id)}
+        onClose={closePreviewDrawer}
         onBookmark={onBookmarkSafeApp}
       />
     </>

--- a/src/components/new-safe-apps/SafeAppList/SafeAppList.tsx
+++ b/src/components/new-safe-apps/SafeAppList/SafeAppList.tsx
@@ -11,6 +11,7 @@ import SafeAppPreviewDrawer from '@/components/new-safe-apps/SafeAppPreviewDrawe
 import SafeAppsListHeader from '@/components/new-safe-apps/SafeAppsListHeader/SafeAppsListHeader'
 import SafeAppsZeroResultsPlaceholder from '@/components/new-safe-apps/SafeAppsZeroResultsPlaceholder/SafeAppsZeroResultsPlaceholder'
 import useSafeAppsFilters from '@/hooks/safe-apps/useSafeAppsFilters'
+import useSafeAppPreviewDrawer from '@/hooks/safe-apps/useSafeAppPreviewDrawer'
 
 type SafeAppListProps = {
   safeAppsList: SafeAppData[]
@@ -30,17 +31,24 @@ const SafeAppList = ({
   removeCustomApp,
 }: SafeAppListProps) => {
   const [safeAppsViewMode, setSafeAppsViewMode] = useState<SafeAppsViewMode>(GRID_VIEW_MODE)
-  const [selectedSafeApp, setSelectedSafeApp] = useState<SafeAppData>()
-  const [isAppPreviewDrawerOpen, setIsAppPreviewDrawerOpen] = useState<boolean>(false)
+  const {
+    safeApp: selectedSafeApp,
+    setSafeApp: setSelectedSafeApp,
+    isOpen: isAppPreviewDrawerOpen,
+    setIsOpen: setIsAppPreviewDrawerOpen,
+  } = useSafeAppPreviewDrawer()
 
   const { filteredApps, query, setQuery, setSelectedCategories, setOptimizedWithBatchFilter, selectedCategories } =
     useSafeAppsFilters(safeAppsList)
 
   const onClickSafeApp = (safeApp: SafeAppData) => (event: SyntheticEvent) => {
-    event.preventDefault()
+    const isCustomApp = safeApp.id < 1
 
-    setSelectedSafeApp(safeApp)
-    setIsAppPreviewDrawerOpen(true)
+    if (!isCustomApp) {
+      event.preventDefault()
+      setSelectedSafeApp(safeApp)
+      setIsAppPreviewDrawerOpen(true)
+    }
   }
 
   const showZeroResultsPlaceholder = query && filteredApps.length === 0

--- a/src/hooks/safe-apps/useSafeAppPreviewDrawer.ts
+++ b/src/hooks/safe-apps/useSafeAppPreviewDrawer.ts
@@ -2,17 +2,30 @@ import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
 import { useState } from 'react'
 
 type ReturnType = {
-  safeApp: SafeAppData | undefined
-  isOpen: boolean
-  setIsOpen: (isOpen: boolean) => void
-  setSafeApp: (safeApp: SafeAppData) => void
+  isPreviewDrawerOpen: boolean
+  previewDrawerApp: SafeAppData | undefined
+  openPreviewDrawer: (safeApp: SafeAppData) => void
+  closePreviewDrawer: () => void
 }
 
 const useSafeAppPreviewDrawer = (): ReturnType => {
-  const [safeApp, setSafeApp] = useState<SafeAppData>()
-  const [isOpen, setIsOpen] = useState<boolean>(false)
+  const [previewDrawerApp, setPreviewDrawerApp] = useState<SafeAppData>()
+  const [isPreviewDrawerOpen, setIsPreviewDrawerOpen] = useState<boolean>(false)
 
-  return { safeApp, isOpen, setIsOpen, setSafeApp }
+  const openPreviewDrawer = (safeApp: SafeAppData) => {
+    const isCustomApp = previewDrawerApp && previewDrawerApp.id < 1
+
+    if (!isCustomApp) {
+      setPreviewDrawerApp(safeApp)
+      setIsPreviewDrawerOpen(true)
+    }
+  }
+
+  const closePreviewDrawer = () => {
+    setIsPreviewDrawerOpen(false)
+  }
+
+  return { isPreviewDrawerOpen, previewDrawerApp, openPreviewDrawer, closePreviewDrawer }
 }
 
 export default useSafeAppPreviewDrawer

--- a/src/hooks/safe-apps/useSafeAppPreviewDrawer.ts
+++ b/src/hooks/safe-apps/useSafeAppPreviewDrawer.ts
@@ -1,0 +1,18 @@
+import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
+import { useState } from 'react'
+
+type ReturnType = {
+  safeApp: SafeAppData | undefined
+  isOpen: boolean
+  setIsOpen: (isOpen: boolean) => void
+  setSafeApp: (safeApp: SafeAppData) => void
+}
+
+const useSafeAppPreviewDrawer = (): ReturnType => {
+  const [safeApp, setSafeApp] = useState<SafeAppData>()
+  const [isOpen, setIsOpen] = useState<boolean>(false)
+
+  return { safeApp, isOpen, setIsOpen, setSafeApp }
+}
+
+export default useSafeAppPreviewDrawer

--- a/src/hooks/safe-apps/useSafeAppPreviewDrawer.ts
+++ b/src/hooks/safe-apps/useSafeAppPreviewDrawer.ts
@@ -1,5 +1,5 @@
 import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 type ReturnType = {
   isPreviewDrawerOpen: boolean
@@ -12,18 +12,21 @@ const useSafeAppPreviewDrawer = (): ReturnType => {
   const [previewDrawerApp, setPreviewDrawerApp] = useState<SafeAppData>()
   const [isPreviewDrawerOpen, setIsPreviewDrawerOpen] = useState<boolean>(false)
 
-  const openPreviewDrawer = (safeApp: SafeAppData) => {
-    const isCustomApp = previewDrawerApp && previewDrawerApp.id < 1
+  const openPreviewDrawer = useCallback(
+    (safeApp: SafeAppData) => {
+      const isCustomApp = previewDrawerApp && previewDrawerApp.id < 1
 
-    if (!isCustomApp) {
-      setPreviewDrawerApp(safeApp)
-      setIsPreviewDrawerOpen(true)
-    }
-  }
+      if (!isCustomApp) {
+        setPreviewDrawerApp(safeApp)
+        setIsPreviewDrawerOpen(true)
+      }
+    },
+    [previewDrawerApp],
+  )
 
-  const closePreviewDrawer = () => {
+  const closePreviewDrawer = useCallback(() => {
     setIsPreviewDrawerOpen(false)
-  }
+  }, [])
 
   return { isPreviewDrawerOpen, previewDrawerApp, openPreviewDrawer, closePreviewDrawer }
 }

--- a/src/hooks/safe-apps/useSafeAppPreviewDrawer.ts
+++ b/src/hooks/safe-apps/useSafeAppPreviewDrawer.ts
@@ -1,5 +1,5 @@
-import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
 import { useCallback, useState } from 'react'
+import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
 
 type ReturnType = {
   isPreviewDrawerOpen: boolean


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/web-core/issues/1414

- [x] Show drawer in Dashboard when clicking a Safe App
- [x] Show drawer for general app list and bookmarked apps
- [x] Don't show for Custom apps
- [x] Add custom hook for managing the drawer
- [x] Use new `SafeAppCard` component in Dashboard