### PR TITLE
fix: `merge` hydration of persisted state

### DIFF
--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -1,0 +1,63 @@
+import { _hydrationReducer } from '@/store'
+
+describe('store', () => {
+  describe('hydrationReducer', () => {
+    it('should return a merged state', () => {
+      const persistedState = {
+        oldKey: 'newValue',
+      }
+
+      const initialState = {
+        oldKey: 'oldValue',
+        newKey: 'oldValue',
+      }
+
+      // @ts-expect-error demo state
+      const mergedState = _hydrationReducer(initialState, {
+        type: '@@HYDRATE',
+        payload: persistedState,
+      })
+
+      expect(mergedState).toStrictEqual({
+        oldKey: 'newValue',
+        newKey: 'oldValue',
+      })
+    })
+
+    it('should not replace the intial state', () => {
+      const persistedState = {
+        oldKey: 'newValue',
+      }
+
+      const initialState = {
+        oldKey: 'oldValue',
+        newKey: 'oldValue',
+      }
+
+      // @ts-expect-error demo state
+      const mergedState = _hydrationReducer(initialState, {
+        type: '@@HYDRATE',
+        payload: persistedState,
+      })
+
+      expect(mergedState).not.toStrictEqual({
+        oldKey: 'newValue',
+      })
+    })
+
+    it('should not mutate the intial state', () => {
+      const persistedState = {}
+
+      const initialState = {}
+
+      // @ts-expect-error demo state
+      const mergedState = _hydrationReducer(initialState, {
+        type: '@@HYDRATE',
+        payload: persistedState,
+      })
+
+      // lodash' `merge` mutates the first argument
+      expect(initialState === mergedState).toBeFalsy()
+    })
+  })
+})

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -4,12 +4,21 @@ describe('store', () => {
   describe('hydrationReducer', () => {
     it('should return a merged state', () => {
       const persistedState = {
-        oldKey: 'newValue',
+        str1: 'str1',
+        obj1: {
+          key1: true, // Persisted value
+        },
+        arr1: ['arr1', 'arr2'], // Persisted value
       }
 
       const initialState = {
-        oldKey: 'oldValue',
-        newKey: 'oldValue',
+        str1: 'str1',
+        str2: 'str2', // New property
+        obj1: {
+          key1: 'key1',
+          key2: 'key2', // New property
+        },
+        arr1: ['arr1'],
       }
 
       // @ts-expect-error demo state
@@ -19,19 +28,33 @@ describe('store', () => {
       })
 
       expect(mergedState).toStrictEqual({
-        oldKey: 'newValue',
-        newKey: 'oldValue',
+        str1: 'str1',
+        str2: 'str2',
+        obj1: {
+          key1: true,
+          key2: 'key2',
+        },
+        arr1: ['arr1', 'arr2'],
       })
     })
 
     it('should not replace the intial state', () => {
       const persistedState = {
-        oldKey: 'newValue',
+        str1: 'str1',
+        obj1: {
+          key1: true, // Persisted value
+        },
+        arr1: ['arr1', 'arr2', 'arr3'], // Persisted value
       }
 
       const initialState = {
-        oldKey: 'oldValue',
-        newKey: 'oldValue',
+        str1: 'str1',
+        str2: 'str2', // New property
+        obj1: {
+          key1: 'key1',
+          key2: 'key2', // New property
+        },
+        arr1: ['arr1'],
       }
 
       // @ts-expect-error demo state
@@ -41,14 +64,54 @@ describe('store', () => {
       })
 
       expect(mergedState).not.toStrictEqual({
-        oldKey: 'newValue',
+        str1: 'str1',
+        obj1: {
+          key1: true,
+        },
+        arr1: ['arr1', 'arr2', 'arr3'],
       })
     })
 
-    it('should not mutate the intial state', () => {
-      const persistedState = {}
+    it('should not wipe the initial state if no localStorage entry is present', () => {
+      const initialState = {
+        str1: 'str1',
+        str2: 'str2',
+        obj1: {
+          key1: 'key1',
+          key2: 'key2',
+        },
+        arr1: ['arr1'],
+      }
 
-      const initialState = {}
+      // @ts-expect-error demo state
+      const mergedState = _hydrationReducer(initialState, {
+        type: '@@HYDRATE',
+        // No localStorage entry
+        payload: undefined,
+      })
+
+      expect(mergedState).not.toBeUndefined()
+
+      expect(mergedState).toStrictEqual({
+        str1: 'str1',
+        str2: 'str2',
+        obj1: {
+          key1: 'key1',
+          key2: 'key2',
+        },
+        arr1: ['arr1'],
+      })
+    })
+
+    it('should return a new state, not mutating the initial or persisted state', () => {
+      const persistedState = {
+        str1: 'str1',
+      }
+
+      const initialState = {
+        str1: 'str1',
+        str2: 'str2',
+      }
 
       // @ts-expect-error demo state
       const mergedState = _hydrationReducer(initialState, {
@@ -56,8 +119,15 @@ describe('store', () => {
         payload: persistedState,
       })
 
-      // lodash' `merge` mutates the first argument
-      expect(initialState === mergedState).toBeFalsy()
+      expect(mergedState).toStrictEqual({
+        str1: 'str1',
+        str2: 'str2',
+      })
+
+      // @ts-expect-error demo state
+      expect(mergedState === initialState).toBeFalsy()
+      // @ts-expect-error demo state
+      expect(mergedState === persistedState).toBeFalsy()
     })
   })
 })

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -6,6 +6,7 @@ import {
   type AnyAction,
 } from '@reduxjs/toolkit'
 import { useDispatch, useSelector, type TypedUseSelectorHook } from 'react-redux'
+import merge from 'lodash/merge'
 import { IS_PRODUCTION } from '@/config/constants'
 import { createStoreHydrator, HYDRATE_ACTION } from './storeHydrator'
 import { chainsSlice } from './chainsSlice'
@@ -61,10 +62,8 @@ export const getPersistedState = () => {
 
 const hydrationReducer: typeof rootReducer = (state, action) => {
   if (action.type === HYDRATE_ACTION) {
-    return {
-      ...state,
-      ...action.payload,
-    }
+    // `merge` mutates the first argument, so we need to create a new object
+    return merge({}, state, action.payload)
   }
   return rootReducer(state, action)
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -60,7 +60,7 @@ export const getPersistedState = () => {
   return getPreloadedState(persistedSlices)
 }
 
-const hydrationReducer: typeof rootReducer = (state, action) => {
+export const _hydrationReducer: typeof rootReducer = (state, action) => {
   if (action.type === HYDRATE_ACTION) {
     // `merge` mutates the first argument, so we need to create a new object
     return merge({}, state, action.payload)
@@ -70,7 +70,7 @@ const hydrationReducer: typeof rootReducer = (state, action) => {
 
 const makeStore = (initialState?: Record<string, any>) => {
   return configureStore({
-    reducer: hydrationReducer,
+    reducer: _hydrationReducer,
     middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(middleware),
     devTools: !IS_PRODUCTION,
     preloadedState: initialState,
@@ -80,7 +80,7 @@ const makeStore = (initialState?: Record<string, any>) => {
 export const StoreHydrator = createStoreHydrator(makeStore)
 
 export type AppDispatch = ReturnType<typeof makeStore>['dispatch']
-export type RootState = ReturnType<typeof hydrationReducer>
+export type RootState = ReturnType<typeof _hydrationReducer>
 
 export type AppThunk<ReturnType = void> = ThunkAction<ReturnType, RootState, unknown, AnyAction>
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -62,7 +62,19 @@ export const getPersistedState = () => {
 
 export const _hydrationReducer: typeof rootReducer = (state, action) => {
   if (action.type === HYDRATE_ACTION) {
-    // `merge` mutates the first argument, so we need to create a new object
+    /**
+     * `merge` is required when adding new properties to slices, otherwise the new properties will be lost
+     * when the store is rehydrated. It recursively merges own/inherited enumerable string keyed properties
+     * of source objects into destination object.
+     *
+     * Source properties that resolve to `undefined` are skipped (e.g. empty persisted state) if a destination
+     * value exists (initial state). Array and plain object properties are merged recursively. Other objects
+     * and value types are overridden by assignment. Source objects are applied from left to right. Subsequent
+     * sources overwrite property assignments of previous sources.
+     *
+     * @see https://lodash.com/docs/4.17.15#merge
+     */
+
     return merge({}, state, action.payload)
   }
   return rootReducer(state, action)

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -63,14 +63,10 @@ export const getPersistedState = () => {
 export const _hydrationReducer: typeof rootReducer = (state, action) => {
   if (action.type === HYDRATE_ACTION) {
     /**
-     * `merge` is required when adding new properties to slices, otherwise the new properties will be lost
-     * when the store is rehydrated. It recursively merges own/inherited enumerable string keyed properties
-     * of source objects into destination object.
-     *
-     * Source properties that resolve to `undefined` are skipped (e.g. empty persisted state) if a destination
-     * value exists (initial state). Array and plain object properties are merged recursively. Other objects
-     * and value types are overridden by assignment. Source objects are applied from left to right. Subsequent
-     * sources overwrite property assignments of previous sources.
+     * When changing the schema of a Redux slice, previously stored data in LS might become incompatible.
+     * To avoid this, we should always migrate the data on a case-by-case basis in the corresponding slice.
+     * However, as a catch-all measure, we attempt to merge the stored data with the initial Redux state,
+     * so that any new properties added to the slice are not overwritten as undefined.
      *
      * @see https://lodash.com/docs/4.17.15#merge
      */

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -66,7 +66,7 @@ export const _hydrationReducer: typeof rootReducer = (state, action) => {
      * When changing the schema of a Redux slice, previously stored data in LS might become incompatible.
      * To avoid this, we should always migrate the data on a case-by-case basis in the corresponding slice.
      * However, as a catch-all measure, we attempt to merge the stored data with the initial Redux state,
-     * so that any new properties added to the slice are not overwritten as undefined.
+     * so that any newly added properties in the initial state are preserved, and existing properties are taken from the LS.
      *
      * @see https://lodash.com/docs/4.17.15#merge
      */

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -6,11 +6,9 @@ import type { RootState } from '@/store'
 export type SettingsState = {
   currency: string
 
-  hiddenTokens:
-    | {
-        [chainId: string]: string[]
-      }
-    | undefined /* This was added to the slice later, so hydration will set it to undefined initially */
+  hiddenTokens: {
+    [chainId: string]: string[]
+  }
 
   shortName: {
     show: boolean
@@ -56,7 +54,6 @@ export const settingsSlice = createSlice({
     },
     setHiddenTokensForChain: (state, { payload }: PayloadAction<{ chainId: string; assets: string[] }>) => {
       const { chainId, assets } = payload
-      state.hiddenTokens ??= {}
       state.hiddenTokens[chainId] = assets
     },
   },


### PR DESCRIPTION
## What it solves

Resolves #1551

## How this PR fixes it

Hydrated state is now merged with the initial state.

## How to test it

1. Run the project locally.
2. Add a new key to a slice's `initialState`.
3. Reload the app and observe the new key present in the state in Redux DevTools.