### PR TITLE
fix: adjust message display style

### DIFF
--- a/src/components/safe-messages/Msg/index.tsx
+++ b/src/components/safe-messages/Msg/index.tsx
@@ -1,36 +1,25 @@
-import { Link } from '@mui/material'
-import { useState } from 'react'
+import { TextField } from '@mui/material'
 import type { ReactElement } from 'react'
 import type { SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
 
 import css from './styles.module.css'
 
-const Msg = ({
-  message,
-  defaultExpanded = false,
-}: {
-  message: SafeMessage['message']
-  defaultExpanded?: boolean
-}): ReactElement => {
-  const [showMsg, setShowMsg] = useState(defaultExpanded)
+const Msg = ({ message }: { message: SafeMessage['message'] }): ReactElement => {
+  const isTextMessage = typeof message === 'string'
 
-  const handleToggleMsg = () => {
-    setShowMsg((prev) => !prev)
-  }
-
-  if (typeof message === 'string') {
-    return <>{message}</>
-  }
+  const readableData = isTextMessage ? message : JSON.stringify(message, null, 2)
 
   return (
-    <div className={css.overflow}>
-      <pre className={css.pre}>
-        <code className={!showMsg ? css.truncated : undefined}>{JSON.stringify(message, null, 2)}</code>
-      </pre>
-      <Link component="button" onClick={handleToggleMsg} fontSize="medium" className={css.toggle}>
-        {showMsg ? 'Hide' : 'Show all'}
-      </Link>
-    </div>
+    <TextField
+      rows={isTextMessage ? 2 : 16}
+      multiline
+      disabled
+      fullWidth
+      className={css.msg}
+      inputProps={{
+        value: readableData,
+      }}
+    />
   )
 }
 

--- a/src/components/safe-messages/Msg/styles.module.css
+++ b/src/components/safe-messages/Msg/styles.module.css
@@ -1,21 +1,6 @@
-.toggle {
-  font-weight: 700;
-  text-decoration: underline;
-  text-align: left;
-}
-
-.truncated {
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  max-height: 9ex;
-}
-
-.overflow {
-  overflow: auto;
-}
-
-.pre {
-  margin: 0;
+.msg :global .MuiInputBase-input {
+  white-space: pre;
+  font-family: monospace;
+  font-size: 0.85rem;
+  -webkit-text-fill-color: var(--color-text-primary);
 }

--- a/src/components/safe-messages/MsgDetails/index.tsx
+++ b/src/components/safe-messages/MsgDetails/index.tsx
@@ -51,9 +51,10 @@ const MsgDetails = ({ msg }: { msg: SafeMessage }): ReactElement => {
           <TxDataRow title="Last modified:">{formatDateTime(msg.modifiedTimestamp)}</TxDataRow>
           <TxDataRow title="Message hash:">{generateDataRowValue(msg.messageHash, 'hash')}</TxDataRow>
           <TxDataRow title="SafeMessage:">{generateDataRowValue(safeMessage, 'hash')}</TxDataRow>
-          <TxDataRow title="Message:">
-            <Msg message={msg.message} defaultExpanded />
-          </TxDataRow>
+          <Typography fontWeight={700} mb={1}>
+            Message:
+          </Typography>
+          <Msg message={msg.message} />
         </div>
 
         {msg.preparedSignature && (

--- a/src/components/safe-messages/MsgModal/index.tsx
+++ b/src/components/safe-messages/MsgModal/index.tsx
@@ -147,7 +147,9 @@ const MsgModal = ({
           <Typography variant="body1" textAlign="center" mb={2}>
             This action will confirm the message and add your confirmation to the prepared signature.
           </Typography>
-          <Typography fontWeight={700}>Message:</Typography>
+          <Typography fontWeight={700} mb={1}>
+            Message:
+          </Typography>
           <Typography variant="body2">
             <Msg message={decodedMessage} />
           </Typography>


### PR DESCRIPTION
## What it solves

Resolves #1393

## How this PR fixes it

The message is now display inside a `textarea` according to [the design](1393).

## How to test it

Open the messages list and observe the new formatting of the messages, as well as in the signing modal.

## Analytics changes

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/213217320-6c584981-060e-4986-af4a-f17e8bfe39ed.png)

![image](https://user-images.githubusercontent.com/20442784/213217060-c05b0ca2-3f94-4832-8c41-500e978efe7c.png)

![image](https://user-images.githubusercontent.com/20442784/213217258-c9d6f31d-80bc-4309-bd8a-ac447c690368.png)

![image](https://user-images.githubusercontent.com/20442784/213217287-4bc04de0-2e70-4474-863d-c2ccd70b5891.png)