### PR TITLE
Add increment for failing estimations in Gnosis Chain

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,7 +24,7 @@ jobs:
           # branch should not be protected
           branch: 'main'
           # user names of users allowed to contribute without CLA
-          allowlist: lukasschor,mikheevm,rmeissner,germartinez,Uxio0,dasanra,francovenica,tschubotz,luarx,gnosis-info,bot*,DaniSomoza,iamacook,yagopv,usame-algan,schmanu,DiogoSoaress,JagoFigueroa
+          allowlist: lukasschor,rmeissner,germartinez,Uxio0,dasanra,francovenica,tschubotz,luarx,DaniSomoza,iamacook,yagopv,usame-algan,schmanu,DiogoSoaress,JagoFigueroa,bot*
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           # enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/src/hooks/useGasLimit.ts
+++ b/src/hooks/useGasLimit.ts
@@ -71,8 +71,8 @@ const useGasLimit = (
         type: operationType,
       })
       .then((gasLimit) => {
-        // Due to a bug in Nethermind estimation we need to increment 30% the gasLimit
-        // when the safeTxGas is defined and not 0.
+        // Due to a bug in Nethermind estimation, we need to increment the gasLimit by 30%
+        // when the safeTxGas is defined and not 0. Currently Nethermind is used only for Gnosis Chain.
         const safeTxGas = safeTx?.data?.safeTxGas
         if (currentChainId === chains.gno && safeTxGas && safeTxGas !== 0) {
           return gasLimit.mul(130).div(100)

--- a/src/hooks/useGasLimit.ts
+++ b/src/hooks/useGasLimit.ts
@@ -7,13 +7,12 @@ import { OperationType } from '@safe-global/safe-core-sdk-types'
 import useAsync from '@/hooks/useAsync'
 import useChainId from '@/hooks/useChainId'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
+import chains from '@/config/chains'
 import useSafeAddress from './useSafeAddress'
 import useWallet from './wallets/useWallet'
 import { useSafeSDK } from './coreSDK/safeCoreSDK'
 import useIsSafeOwner from './useIsSafeOwner'
 import { Errors, logError } from '@/services/exceptions'
-
-const GNOSIS_CHAIN_ID = '100'
 
 const getEncodedSafeTx = (safeSDK: Safe, safeTx: SafeTransaction, from?: string): string => {
   const EXEC_TX_METHOD = 'execTransaction'
@@ -75,7 +74,7 @@ const useGasLimit = (
         // Due to a bug in Nethermind estimation we need to increment 30% the gasLimit
         // when the safeTxGas is defined and not 0.
         const safeTxGas = safeTx?.data?.safeTxGas
-        if (safeTxGas && safeTxGas !== 0 && currentChainId === GNOSIS_CHAIN_ID) {
+        if (currentChainId === chains.gno && safeTxGas && safeTxGas !== 0) {
           return gasLimit.mul(130).div(100)
         }
 


### PR DESCRIPTION
## What it solves
Resolves gas limit is not high enough for transactions in Gnosis Chain when the safeTxGas is set.
Due to a problem on Nethermind it's returning a lower gas estimation for those transactions having a `safeTxGas` set. 
`safeTxGas`is used as a mechanism so developers can suggest a gasLimit of the inner transaction. So whenever an app suggests a gasLimit it's set as safeTxGas.

## How this PR fixes it
Add an increment of 30% to the estimated `gasLimit`.
The fix is not ideal, but there is no other way to workaround this until a proper fix is added to Nethermind. Fix will be applied only specifically for Gnosis Chain and when the `safeTxGas` is set to a different value than 0.

## How to test it
Use `CowSwap` with latest version of WalletConnect Safe app and try to execute an `approve`
In this PR it should have enough gas limit, not the same case as production web app.

## Analytics changes

## Screenshots
