### PR TITLE
fix: NFT selection in SendNFTForm

### DIFF
--- a/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
+++ b/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
@@ -26,13 +26,11 @@ import InfiniteScroll from '@/components/common/InfiniteScroll'
 
 enum Field {
   recipient = 'recipient',
-  tokenAddress = 'tokenAddress',
   tokenId = 'tokenId',
 }
 
 type FormData = {
   [Field.recipient]: string
-  [Field.tokenAddress]: string
   [Field.tokenId]: string
 }
 
@@ -72,8 +70,7 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
   const formMethods = useForm<FormData>({
     defaultValues: {
       [Field.recipient]: params?.recipient || '',
-      [Field.tokenAddress]: params?.token?.address || '',
-      [Field.tokenId]: params?.token?.id || '',
+      [Field.tokenId]: params?.token ? `${params.token.address};${params.token.id}` : '',
     },
   })
   const {
@@ -86,7 +83,8 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
   const recipient = watch(Field.recipient)
 
   const onFormSubmit = (data: FormData) => {
-    const token = combinedNfts.find((item) => item.id === data.tokenId)
+    const [selectedTokenAddress, selectedTokenId] = data.tokenId.split(';')
+    const token = combinedNfts.find((item) => item.id === selectedTokenId && item.address === selectedTokenAddress)
     if (!token) return
     onSubmit({
       recipient: data.recipient,
@@ -133,7 +131,7 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
                   error={!!errors.tokenId}
                 >
                   {combinedNfts.map((item) => (
-                    <MenuItem key={item.address + item.id} value={item.id}>
+                    <MenuItem key={item.address + item.id} value={`${item.address};${item.id}`}>
                       <NftMenuItem
                         image={item.imageUri || item.logoUri}
                         name={`${item.tokenName || item.tokenSymbol || ''} #${item.id}`}

--- a/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
+++ b/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
@@ -39,6 +39,16 @@ export type SendNftFormProps = {
   params?: NftTransferParams
 }
 
+const toNftValue = (nft: SafeCollectibleResponse): string => `${nft.address};${nft.id}`
+
+const parseNftValue = (value: string): { address: string; id: string } => {
+  const splitValue = value.split(';')
+  return {
+    address: splitValue[0],
+    id: splitValue[1],
+  }
+}
+
 const NftMenuItem = ({ image, name, description }: { image: string; name: string; description?: string }) => (
   <Grid container spacing={1} alignItems="center" wrap="nowrap" sx={{ maxWidth: '530px' }}>
     <Grid item>
@@ -70,7 +80,7 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
   const formMethods = useForm<FormData>({
     defaultValues: {
       [Field.recipient]: params?.recipient || '',
-      [Field.tokenId]: params?.token ? `${params.token.address};${params.token.id}` : '',
+      [Field.tokenId]: params?.token ? toNftValue(params.token) : '',
     },
   })
   const {
@@ -83,7 +93,7 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
   const recipient = watch(Field.recipient)
 
   const onFormSubmit = (data: FormData) => {
-    const [selectedTokenAddress, selectedTokenId] = data.tokenId.split(';')
+    const { address: selectedTokenAddress, id: selectedTokenId } = parseNftValue(data.tokenId)
     const token = combinedNfts.find((item) => item.id === selectedTokenId && item.address === selectedTokenAddress)
     if (!token) return
     onSubmit({
@@ -131,7 +141,7 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
                   error={!!errors.tokenId}
                 >
                   {combinedNfts.map((item) => (
-                    <MenuItem key={item.address + item.id} value={`${item.address};${item.id}`}>
+                    <MenuItem key={item.address + item.id} value={toNftValue(item)}>
                       <NftMenuItem
                         image={item.imageUri || item.logoUri}
                         name={`${item.tokenName || item.tokenSymbol || ''} #${item.id}`}


### PR DESCRIPTION
## What it solves
NFTs were only identified by their ID in the SendNFTForm's Select component.

Resolves #1560 

## How this PR fixes it
NFTs are identified by their tokenAddress + id

## How to test it
In a Safe with multiple NFTs with the same id:
1. NFT modal
- open "Send NFT" modal
- Try to select the NFTs with same id and observe that always the correct one is selected

2. Send NFTs from assets
- Go to assets / nfts
- send NFTs with duplicate ids and observe that always the correct one is selected

## Analytics changes
None
