### PR TITLE
fix: prevent scrollbars on Safe App icons

### DIFF
--- a/src/components/safe-apps/SafeAppIcon/index.tsx
+++ b/src/components/safe-apps/SafeAppIcon/index.tsx
@@ -4,7 +4,7 @@ const APP_LOGO_FALLBACK_IMAGE = `/images/apps/app-placeholder.svg`
 
 const getIframeContent = (url: string, width: number, height: number): string => {
   return `
-     <body style="margin: 0;">
+     <body style="margin: 0; overflow: hidden;">
        <img src="${encodeURI(url)}" alt="App logo" width="${width}" height="${height}" />
        <script>
           document.querySelector("img").onerror = (e) => {


### PR DESCRIPTION
## What it solves

Resolves #1564

## How this PR fixes it

The `overflow` of the `SafeAppIcon` is not `hidden`.

## How to test it

Open the Safe Apps page and observe no scrollbars on icons.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/213446948-1d020a00-5b28-409d-8970-f14dd419ae73.png)