### PR TITLE
Fix: propose immediately executed txs

### DIFF
--- a/src/components/settings/ContractVersion/UpdateSafeDialog.tsx
+++ b/src/components/settings/ContractVersion/UpdateSafeDialog.tsx
@@ -41,7 +41,7 @@ const UpdateSafeDialog = () => {
   )
 }
 
-const ReviewUpdateSafeStep = ({ onSubmit }: { onSubmit: (txId?: string) => void }) => {
+const ReviewUpdateSafeStep = ({ onSubmit }: { onSubmit: () => void }) => {
   const { safe, safeLoaded } = useSafeInfo()
   const chain = useCurrentChain()
   const { createMultiSendCallOnlyTx } = useTxSender()

--- a/src/components/settings/SafeModules/RemoveModule/steps/ReviewRemoveModule.tsx
+++ b/src/components/settings/SafeModules/RemoveModule/steps/ReviewRemoveModule.tsx
@@ -9,13 +9,7 @@ import { useEffect } from 'react'
 import { Errors, logError } from '@/services/exceptions'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 
-export const ReviewRemoveModule = ({
-  data,
-  onSubmit,
-}: {
-  data: RemoveModuleData
-  onSubmit: (txId?: string) => void
-}) => {
+export const ReviewRemoveModule = ({ data, onSubmit }: { data: RemoveModuleData; onSubmit: () => void }) => {
   const { createRemoveModuleTx } = useTxSender()
   const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
     return createRemoveModuleTx(data.address)
@@ -27,10 +21,10 @@ export const ReviewRemoveModule = ({
     }
   }, [safeTxError])
 
-  const onFormSubmit = (txId?: string) => {
+  const onFormSubmit = () => {
     trackEvent(SETTINGS_EVENTS.MODULES.REMOVE_MODULE)
 
-    onSubmit(txId)
+    onSubmit()
   }
 
   return (

--- a/src/components/settings/SpendingLimits/NewSpendingLimit/steps/ReviewSpendingLimit.tsx
+++ b/src/components/settings/SpendingLimits/NewSpendingLimit/steps/ReviewSpendingLimit.tsx
@@ -21,7 +21,7 @@ import type { NewSpendingLimitData } from '@/services/tx/tx-sender'
 
 type Props = {
   data: NewSpendingLimitData
-  onSubmit: (txId?: string) => void
+  onSubmit: () => void
 }
 
 export const ReviewSpendingLimit = ({ data, onSubmit }: Props) => {
@@ -52,13 +52,13 @@ export const ReviewSpendingLimit = ({ data, onSubmit }: Props) => {
     return createNewSpendingLimitTx(data, spendingLimits, chainId, decimals, existingSpendingLimit)
   }, [data, spendingLimits, chainId, decimals, existingSpendingLimit, createNewSpendingLimitTx])
 
-  const onFormSubmit = (txId?: string) => {
+  const onFormSubmit = () => {
     trackEvent({
       ...SETTINGS_EVENTS.SPENDING_LIMIT.RESET_PERIOD,
       label: resetTime,
     })
 
-    onSubmit(txId)
+    onSubmit()
   }
 
   return (

--- a/src/components/settings/SpendingLimits/RemoveSpendingLimit/index.tsx
+++ b/src/components/settings/SpendingLimits/RemoveSpendingLimit/index.tsx
@@ -15,13 +15,7 @@ import { TokenTransferReview } from '@/components/tx/modals/TokenTransferModal/R
 import { safeFormatUnits } from '@/utils/formatters'
 import SpendingLimitLabel from '@/components/common/SpendingLimitLabel'
 
-export const RemoveSpendingLimit = ({
-  data,
-  onSubmit,
-}: {
-  data: SpendingLimitState
-  onSubmit: (txId?: string) => void
-}) => {
+export const RemoveSpendingLimit = ({ data, onSubmit }: { data: SpendingLimitState; onSubmit: () => void }) => {
   const { createTx } = useTxSender()
   const chainId = useChainId()
   const provider = useWeb3()
@@ -44,10 +38,10 @@ export const RemoveSpendingLimit = ({
     return createTx(txParams)
   }, [provider, chainId, data.beneficiary, data.token, createTx])
 
-  const onFormSubmit = (txId?: string) => {
+  const onFormSubmit = () => {
     trackEvent(SETTINGS_EVENTS.SPENDING_LIMIT.LIMIT_REMOVED)
 
-    onSubmit(txId)
+    onSubmit()
   }
 
   return (

--- a/src/components/settings/TransactionGuards/RemoveGuard/steps/ReviewRemoveGuard.tsx
+++ b/src/components/settings/TransactionGuards/RemoveGuard/steps/ReviewRemoveGuard.tsx
@@ -10,7 +10,7 @@ import { Errors, logError } from '@/services/exceptions'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import useTxSender from '@/hooks/useTxSender'
 
-export const ReviewRemoveGuard = ({ data, onSubmit }: { data: RemoveGuardData; onSubmit: (txId?: string) => void }) => {
+export const ReviewRemoveGuard = ({ data, onSubmit }: { data: RemoveGuardData; onSubmit: () => void }) => {
   const { createRemoveGuardTx } = useTxSender()
 
   const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
@@ -23,10 +23,10 @@ export const ReviewRemoveGuard = ({ data, onSubmit }: { data: RemoveGuardData; o
     }
   }, [safeTxError])
 
-  const onFormSubmit = (txId?: string) => {
+  const onFormSubmit = () => {
     trackEvent(SETTINGS_EVENTS.MODULES.REMOVE_GUARD)
 
-    onSubmit(txId)
+    onSubmit()
   }
 
   return (

--- a/src/components/settings/owner/AddOwnerDialog/DialogSteps/ReviewOwnerTxStep.tsx
+++ b/src/components/settings/owner/AddOwnerDialog/DialogSteps/ReviewOwnerTxStep.tsx
@@ -14,7 +14,7 @@ import useAddressBook from '@/hooks/useAddressBook'
 import React from 'react'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 
-export const ReviewOwnerTxStep = ({ data, onSubmit }: { data: ChangeOwnerData; onSubmit: (txId?: string) => void }) => {
+export const ReviewOwnerTxStep = ({ data, onSubmit }: { data: ChangeOwnerData; onSubmit: () => void }) => {
   const { createSwapOwnerTx, createAddOwnerTx } = useTxSender()
   const { safe, safeAddress } = useSafeInfo()
   const { chainId } = safe
@@ -38,7 +38,7 @@ export const ReviewOwnerTxStep = ({ data, onSubmit }: { data: ChangeOwnerData; o
 
   const isReplace = Boolean(removedOwner)
 
-  const addAddressBookEntryAndSubmit = (txId?: string) => {
+  const addAddressBookEntryAndSubmit = () => {
     if (typeof newOwner.name !== 'undefined') {
       dispatch(
         upsertAddressBookEntry({
@@ -52,7 +52,7 @@ export const ReviewOwnerTxStep = ({ data, onSubmit }: { data: ChangeOwnerData; o
     trackEvent({ ...SETTINGS_EVENTS.SETUP.THRESHOLD, label: safe.threshold })
     trackEvent({ ...SETTINGS_EVENTS.SETUP.OWNERS, label: safe.owners.length })
 
-    onSubmit(txId)
+    onSubmit()
   }
 
   return (

--- a/src/components/settings/owner/ChangeThresholdDialog/index.tsx
+++ b/src/components/settings/owner/ChangeThresholdDialog/index.tsx
@@ -48,7 +48,7 @@ export const ChangeThresholdDialog = () => {
   )
 }
 
-const ChangeThresholdStep = ({ data, onSubmit }: { data: ChangeThresholdData; onSubmit: (txId?: string) => void }) => {
+const ChangeThresholdStep = ({ data, onSubmit }: { data: ChangeThresholdData; onSubmit: () => void }) => {
   const { safe } = useSafeInfo()
   const { createUpdateThresholdTx } = useTxSender()
   const [selectedThreshold, setSelectedThreshold] = useState<number>(safe.threshold)
@@ -67,11 +67,11 @@ const ChangeThresholdStep = ({ data, onSubmit }: { data: ChangeThresholdData; on
     return createUpdateThresholdTx(selectedThreshold)
   }, [selectedThreshold, createUpdateThresholdTx])
 
-  const onChangeTheshold = (txId?: string) => {
+  const onChangeTheshold = () => {
     trackEvent({ ...SETTINGS_EVENTS.SETUP.OWNERS, label: safe.owners.length })
     trackEvent({ ...SETTINGS_EVENTS.SETUP.THRESHOLD, label: selectedThreshold })
 
-    onSubmit(txId)
+    onSubmit()
   }
 
   return (

--- a/src/components/settings/owner/RemoveOwnerDialog/DialogSteps/ReviewRemoveOwnerTxStep.tsx
+++ b/src/components/settings/owner/RemoveOwnerDialog/DialogSteps/ReviewRemoveOwnerTxStep.tsx
@@ -12,13 +12,7 @@ import type { RemoveOwnerData } from '..'
 import React from 'react'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 
-export const ReviewRemoveOwnerTxStep = ({
-  data,
-  onSubmit,
-}: {
-  data: RemoveOwnerData
-  onSubmit: (txId?: string) => void
-}) => {
+export const ReviewRemoveOwnerTxStep = ({ data, onSubmit }: { data: RemoveOwnerData; onSubmit: () => void }) => {
   const { createRemoveOwnerTx } = useTxSender()
   const { safe, safeAddress } = useSafeInfo()
   const addressBook = useAddressBook()
@@ -30,11 +24,11 @@ export const ReviewRemoveOwnerTxStep = ({
 
   const newOwnerLength = safe.owners.length - 1
 
-  const onFormSubmit = (txId?: string) => {
+  const onFormSubmit = () => {
     trackEvent({ ...SETTINGS_EVENTS.SETUP.THRESHOLD, label: safe.threshold })
     trackEvent({ ...SETTINGS_EVENTS.SETUP.OWNERS, label: safe.owners.length })
 
-    onSubmit(txId)
+    onSubmit()
   }
 
   return (

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -31,6 +31,7 @@ import useIsWrongChain from '@/hooks/useIsWrongChain'
 import { DelegateCallWarning, UnsignedWarning } from '@/components/transactions/Warning'
 import Multisend from '@/components/transactions/TxDetails/TxData/DecodedData/Multisend'
 import useSafeInfo from '@/hooks/useSafeInfo'
+import useIsPending from '@/hooks/useIsPending'
 
 export const NOT_AVAILABLE = 'n/a'
 
@@ -43,6 +44,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
   const chainId = useChainId()
   const wallet = useWallet()
   const isWrongChain = useIsWrongChain()
+  const isPending = useIsPending(txSummary.id)
   const isQueue = isTxQueued(txSummary.txStatus)
   const awaitingExecution = isAwaitingExecution(txSummary.txStatus)
   const isUnsigned =
@@ -81,7 +83,8 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
         )}
 
         <div className={css.txSummary}>
-          {isUntrusted && <UnsignedWarning />}
+          {isUntrusted && !isPending && <UnsignedWarning />}
+
           {txDetails.txData?.operation === Operation.DELEGATE && (
             <div className={css.delegateCall}>
               <DelegateCallWarning showWarning={!txDetails.txData.trustedDelegateCallTarget} />

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -26,7 +26,7 @@ import useIsValidExecution from '@/hooks/useIsValidExecution'
 type SignOrExecuteProps = {
   safeTx?: SafeTransaction
   txId?: string
-  onSubmit: (txId?: string) => void
+  onSubmit: () => void
   children?: ReactNode
   error?: Error
   isExecutable?: boolean
@@ -175,9 +175,8 @@ const SignOrExecuteForm = ({
     setIsSubmittable(false)
     setSubmitError(undefined)
 
-    let id: string | undefined
     try {
-      id = await (willExecute ? onExecute() : onSign())
+      await (willExecute ? onExecute() : onSign())
     } catch (err) {
       logError(Errors._804, (err as Error).message)
       setIsSubmittable(true)
@@ -185,7 +184,7 @@ const SignOrExecuteForm = ({
       return
     }
 
-    onSubmit(id)
+    onSubmit()
   }
 
   // On advanced params submit (nonce, gas limit, price, etc)

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -162,11 +162,11 @@ const SignOrExecuteForm = ({
     const [, createdTx, provider] = assertDependencies()
 
     // If no txId was provided, it's an immediate execution of a new tx
+    const id = txId || (await proposeTx(createdTx))
     const txOptions = getTxOptions(advancedParams, currentChain)
+    await dispatchTxExecution(createdTx, provider, txOptions, id)
 
-    await dispatchTxExecution(createdTx, provider, txOptions, txId)
-
-    return txId
+    return id
   }
 
   // On modal submit

--- a/src/components/tx/TxStepper/useTxStepper.ts
+++ b/src/components/tx/TxStepper/useTxStepper.ts
@@ -5,7 +5,7 @@ import { merge } from 'lodash'
 
 export type StepRenderProps = {
   data: unknown
-  onSubmit: (data: unknown) => void
+  onSubmit: (data?: unknown) => void
   onBack: (data?: unknown) => void
   setStep: (step: number) => void
 }

--- a/src/components/tx/modals/ConfirmTxModal/ConfirmProposedTx.tsx
+++ b/src/components/tx/modals/ConfirmTxModal/ConfirmProposedTx.tsx
@@ -13,7 +13,7 @@ import { Skeleton, Typography } from '@mui/material'
 
 type ConfirmProposedTxProps = {
   txSummary: TransactionSummary
-  onSubmit: (txId?: string) => void
+  onSubmit: () => void
 }
 
 const SIGN_TEXT = 'Sign this transaction.'

--- a/src/components/tx/modals/NftTransferModal/ReviewNftTx.tsx
+++ b/src/components/tx/modals/NftTransferModal/ReviewNftTx.tsx
@@ -13,7 +13,7 @@ import useSafeAddress from '@/hooks/useSafeAddress'
 
 type ReviewNftTxProps = {
   params: NftTransferParams
-  onSubmit: (txId?: string) => void
+  onSubmit: () => void
 }
 
 const ReviewNftTx = ({ params, onSubmit }: ReviewNftTxProps): ReactElement => {

--- a/src/components/tx/modals/RejectTxModal/RejectTx.tsx
+++ b/src/components/tx/modals/RejectTxModal/RejectTx.tsx
@@ -8,7 +8,7 @@ import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 
 type RejectTxProps = {
   txNonce: number
-  onSubmit: (txId?: string) => void
+  onSubmit: () => void
 }
 
 const RejectTx = ({ txNonce, onSubmit }: RejectTxProps): ReactElement => {

--- a/src/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx.tsx
+++ b/src/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx.tsx
@@ -86,7 +86,7 @@ const ReviewSpendingLimitTx = ({ params, onSubmit }: TokenTransferModalProps): R
     try {
       await dispatchSpendingLimitTxExecution(txParams, txOptions, chainId, provider)
 
-      onSubmit('')
+      onSubmit()
     } catch (err) {
       logError(Errors._801, (err as Error).message)
       setIsSubmittable(true)

--- a/src/components/tx/modals/TokenTransferModal/index.tsx
+++ b/src/components/tx/modals/TokenTransferModal/index.tsx
@@ -9,7 +9,7 @@ import TxModal from '@/components/tx/TxModal'
 
 export type TokenTransferModalProps = {
   params: SendAssetsFormData & { txNonce?: number; disableSpendingLimit?: boolean }
-  onSubmit: (txId?: string) => void
+  onSubmit: () => void
 }
 
 export const TokenTransferSteps: TxStepperProps['steps'] = [

--- a/src/services/tx/tx-sender/dispatch.ts
+++ b/src/services/tx/tx-sender/dispatch.ts
@@ -109,10 +109,10 @@ export const dispatchTxExecution = async (
   safeTx: SafeTransaction,
   provider: Web3Provider,
   txOptions: TransactionOptions,
-  txId?: string,
+  txId: string,
 ): Promise<string> => {
   const sdkUnchecked = await getUncheckedSafeSDK(provider)
-  const eventParams = txId ? { txId } : { groupKey: await sdkUnchecked.getTransactionHash(safeTx) }
+  const eventParams = { txId }
 
   // Execute the tx
   let result: TransactionResult | undefined

--- a/src/services/tx/tx-sender/index.test.ts
+++ b/src/services/tx/tx-sender/index.test.ts
@@ -286,22 +286,6 @@ describe('txSender', () => {
       expect(txEvents.txDispatch).toHaveBeenCalledWith('PROCESSED', { txId })
     })
 
-    it('should execute a tx without a txId', async () => {
-      const safeTx = await createTx({
-        to: '0x123',
-        value: '1',
-        data: '0x0',
-        nonce: 1,
-      })
-
-      await dispatchTxExecution(safeTx, mockProvider, {})
-
-      expect(mockSafeSDK.executeTransaction).toHaveBeenCalled()
-      expect(txEvents.txDispatch).toHaveBeenCalledWith('EXECUTING', { groupKey: '0x1234567890' })
-      expect(txEvents.txDispatch).toHaveBeenCalledWith('PROCESSING', { groupKey: '0x1234567890' })
-      expect(txEvents.txDispatch).toHaveBeenCalledWith('PROCESSED', { groupKey: '0x1234567890' })
-    })
-
     it('should fail executing a tx', async () => {
       jest.spyOn(mockSafeSDK, 'executeTransaction').mockImplementationOnce(() => Promise.reject(new Error('error')))
 


### PR DESCRIPTION
## What it solves

Resolves #1563

## How this PR fixes it
It restores the previous logic which proposes before an immediate execution.

I've also added a condition not to show the Untrusted Tx warning when executing a tx.

## How to test it
* Create a tx in the Drain app
* Immediately execute
* Click on "View transaction" in the notification
* Observe that the tx doesn't have an Untrusted warning
* Once in the history, the tx will have the Drain app logo

## Screenshots
34 is before the fix, 35 – after.
<img width="525" alt="Screenshot 2023-01-20 at 11 26 27" src="https://user-images.githubusercontent.com/381895/213674903-eb96b4e9-e8b2-45ef-a5fd-8081c2b74ac9.png">
