### PR TITLE
fix: "Recipient" -> "Recipient address or ENS"

### DIFF
--- a/src/components/address-book/EntryDialog/index.tsx
+++ b/src/components/address-book/EntryDialog/index.tsx
@@ -59,7 +59,7 @@ const EntryDialog = ({
             <Box>
               <AddressInput
                 name="address"
-                label="Address"
+                label="Contact"
                 variant="outlined"
                 fullWidth
                 required

--- a/src/components/common/AddressInput/index.tsx
+++ b/src/components/common/AddressInput/index.tsx
@@ -29,6 +29,7 @@ const AddressInput = ({ name, validate, required = true, deps, ...props }: Addre
 
   // Fetch an ENS resolution for the current address
   const isDomainLookupEnabled = !!currentChain && hasFeature(currentChain, FEATURES.DOMAIN_LOOKUP)
+  const label = `${props.label} address${isDomainLookupEnabled ? ' or ENS' : ''}`
   const { address, resolverError, resolving } = useNameResolver(isDomainLookupEnabled ? watchedValue : '')
 
   // errors[name] doesn't work with nested field names like 'safe.address', need to use the lodash get
@@ -61,7 +62,7 @@ const AddressInput = ({ name, validate, required = true, deps, ...props }: Addre
         <TextField
           {...props}
           autoComplete="off"
-          label={<>{error?.message || props.label}</>}
+          label={<>{error?.message || label}</>}
           error={!!error}
           fullWidth
           spellCheck={false}

--- a/src/components/new-safe/OwnerRow/index.tsx
+++ b/src/components/new-safe/OwnerRow/index.tsx
@@ -101,12 +101,7 @@ export const OwnerRow = ({
           </Typography>
         ) : (
           <FormControl fullWidth>
-            <AddressBookInput
-              name={`${fieldName}.address`}
-              label="Owner address"
-              validate={validateSafeAddress}
-              deps={deps}
-            />
+            <AddressBookInput name={`${fieldName}.address`} label="Owner" validate={validateSafeAddress} deps={deps} />
           </FormControl>
         )}
       </Grid>

--- a/src/components/new-safe/load/steps/SetAddressStep/index.tsx
+++ b/src/components/new-safe/load/steps/SetAddressStep/index.tsx
@@ -133,7 +133,7 @@ const SetAddressStep = ({ data, onSubmit, onBack }: StepRenderProps<LoadSafeForm
             </Grid>
           </Grid>
 
-          <AddressInput label="Safe address" validate={validateSafeAddress} name={Field.address} />
+          <AddressInput label="Safe" validate={validateSafeAddress} name={Field.address} />
 
           <Typography mt={4}>
             By continuing you consent to the <ExternalLink href="https://safe.global/terms">terms of use</ExternalLink>{' '}

--- a/src/components/settings/owner/AddOwnerDialog/DialogSteps/ChooseOwnerStep.tsx
+++ b/src/components/settings/owner/AddOwnerDialog/DialogSteps/ChooseOwnerStep.tsx
@@ -90,7 +90,7 @@ export const ChooseOwnerStep = ({
             </FormControl>
 
             <FormControl>
-              <AddressBookInput name="address" label="Owner address" validate={combinedValidate} />
+              <AddressBookInput name="address" label="Owner" validate={combinedValidate} />
             </FormControl>
           </Box>
 

--- a/src/components/transactions/TxFilterForm/index.tsx
+++ b/src/components/transactions/TxFilterForm/index.tsx
@@ -209,7 +209,7 @@ const TxFilterForm = ({ toggleFilter }: { toggleFilter: () => void }): ReactElem
                   {isIncomingFilter && (
                     <Grid item xs={12} md={6}>
                       <AddressBookInput
-                        label="Token address"
+                        label="Token"
                         name={TxFilterFormFieldNames.TOKEN_ADDRESS}
                         required={false}
                         fullWidth

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -12,7 +12,7 @@ import {
   Box,
   SvgIcon,
 } from '@mui/material'
-import { type TokenInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { FEATURES, type TokenInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { BigNumber } from '@ethersproject/bignumber'
 
 import TokenIcon from '@/components/common/TokenIcon'
@@ -32,6 +32,8 @@ import InfoIcon from '@/public/images/notifications/info.svg'
 import useIsSafeTokenPaused from '@/components/tx/modals/TokenTransferModal/useIsSafeTokenPaused'
 import NumberField from '@/components/common/NumberField'
 import { useVisibleBalances } from '@/hooks/useVisibleBalances'
+import { useCurrentChain } from '@/hooks/useChains'
+import { hasFeature } from '@/utils/chains'
 
 export const AutocompleteItem = (item: { tokenInfo: TokenInfo; balance: string }): ReactElement => (
   <Grid container alignItems="center" gap={1}>
@@ -78,6 +80,8 @@ const SendAssetsForm = ({ onSubmit, formData, disableSpendingLimit = false }: Se
   const chainId = useChainId()
   const safeTokenAddress = getSafeTokenAddress(chainId)
   const isSafeTokenPaused = useIsSafeTokenPaused()
+  const chainInfo = useCurrentChain()
+  const isDomainLookupEnabled = !!chainInfo && hasFeature(chainInfo, FEATURES.DOMAIN_LOOKUP)
 
   const formMethods = useForm<SendAssetsFormData>({
     defaultValues: {
@@ -142,7 +146,10 @@ const SendAssetsForm = ({ onSubmit, formData, disableSpendingLimit = false }: Se
                 <SendToBlock address={recipient} />
               </Box>
             ) : (
-              <AddressBookInput name={SendAssetsField.recipient} label="Recipient" />
+              <AddressBookInput
+                name={SendAssetsField.recipient}
+                label={`Recipient address${isDomainLookupEnabled ? ' or ENS' : ''}`}
+              />
             )}
           </FormControl>
 

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -12,7 +12,7 @@ import {
   Box,
   SvgIcon,
 } from '@mui/material'
-import { FEATURES, type TokenInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { type TokenInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { BigNumber } from '@ethersproject/bignumber'
 
 import TokenIcon from '@/components/common/TokenIcon'
@@ -32,8 +32,6 @@ import InfoIcon from '@/public/images/notifications/info.svg'
 import useIsSafeTokenPaused from '@/components/tx/modals/TokenTransferModal/useIsSafeTokenPaused'
 import NumberField from '@/components/common/NumberField'
 import { useVisibleBalances } from '@/hooks/useVisibleBalances'
-import { useCurrentChain } from '@/hooks/useChains'
-import { hasFeature } from '@/utils/chains'
 
 export const AutocompleteItem = (item: { tokenInfo: TokenInfo; balance: string }): ReactElement => (
   <Grid container alignItems="center" gap={1}>
@@ -80,8 +78,6 @@ const SendAssetsForm = ({ onSubmit, formData, disableSpendingLimit = false }: Se
   const chainId = useChainId()
   const safeTokenAddress = getSafeTokenAddress(chainId)
   const isSafeTokenPaused = useIsSafeTokenPaused()
-  const chainInfo = useCurrentChain()
-  const isDomainLookupEnabled = !!chainInfo && hasFeature(chainInfo, FEATURES.DOMAIN_LOOKUP)
 
   const formMethods = useForm<SendAssetsFormData>({
     defaultValues: {
@@ -146,10 +142,7 @@ const SendAssetsForm = ({ onSubmit, formData, disableSpendingLimit = false }: Se
                 <SendToBlock address={recipient} />
               </Box>
             ) : (
-              <AddressBookInput
-                name={SendAssetsField.recipient}
-                label={`Recipient address${isDomainLookupEnabled ? ' or ENS' : ''}`}
-              />
+              <AddressBookInput name={SendAssetsField.recipient} label="Recipient" />
             )}
           </FormControl>
 


### PR DESCRIPTION
## What it solves

This PR makes it clearer that you can enter either an address or an ENS name in the recipient field.

## Screenshots
<img width="564" alt="Screenshot 2023-01-20 at 11 37 54" src="https://user-images.githubusercontent.com/381895/213675661-0ad1dc7c-9d06-4c4c-ac85-3bbc73df0f46.png">

## How to test
All the places where we have address inputs – the recipient field in tx modals, address book entry modal, owner management etc – will have "or ENS" added in the label.