### PR TITLE
fix: Remove last used wallet when disconnecting

### DIFF
--- a/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -5,7 +5,7 @@ import css from '@/components/common/ConnectWallet/styles.module.css'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
-import useOnboard, { lastWalletStorage, switchWallet } from '@/hooks/wallets/useOnboard'
+import useOnboard, { forgetLastWallet, switchWallet } from '@/hooks/wallets/useOnboard'
 import { useAppSelector } from '@/store'
 import { selectChainById } from '@/store/chainsSlice'
 import Identicon from '@/components/common/Identicon'
@@ -34,7 +34,7 @@ const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
       label: wallet.label,
     })
 
-    lastWalletStorage.remove()
+    forgetLastWallet()
     handleClose()
   }
 

--- a/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -5,7 +5,7 @@ import css from '@/components/common/ConnectWallet/styles.module.css'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
-import useOnboard, { switchWallet } from '@/hooks/wallets/useOnboard'
+import useOnboard, { lastWalletStorage, switchWallet } from '@/hooks/wallets/useOnboard'
 import { useAppSelector } from '@/store'
 import { selectChainById } from '@/store/chainsSlice'
 import Identicon from '@/components/common/Identicon'
@@ -34,6 +34,7 @@ const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
       label: wallet.label,
     })
 
+    lastWalletStorage.remove()
     handleClose()
   }
 

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -19,7 +19,11 @@ export type ConnectedWallet = {
   provider: EIP1193Provider
 }
 
-export const lastWalletStorage = localItem<string>('lastWallet')
+const lastWalletStorage = localItem<string>('lastWallet')
+
+export const forgetLastWallet = () => {
+  lastWalletStorage.remove()
+}
 
 const { getStore, setStore, useStore } = new ExternalStore<OnboardAPI>()
 

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -19,7 +19,7 @@ export type ConnectedWallet = {
   provider: EIP1193Provider
 }
 
-const lastWalletStorage = localItem<string>('lastWallet')
+export const lastWalletStorage = localItem<string>('lastWallet')
 
 const { getStore, setStore, useStore } = new ExternalStore<OnboardAPI>()
 


### PR DESCRIPTION
## What it solves

Removes the last used wallet when disconnecting.

## How to test it

1. Open the Safe
2. Connect with a wallet
3. Reload the page
4. Observe it reconnecting to the wallet
5. Disconnect the wallet
6. Reload the page
7. Observe it not reconnecting to the wallet

