### PR TITLE
[WIP] eth_signTypedData_v3 for HW wallets and mobile pairing

### DIFF
--- a/src/services/tx/tx-sender/dispatch.ts
+++ b/src/services/tx/tx-sender/dispatch.ts
@@ -59,11 +59,11 @@ export const dispatchTxProposal = async ({
  */
 export const dispatchTxSigning = async (
   safeTx: SafeTransaction,
-  shouldEthSign: boolean,
+  isLegacySignMethod: boolean,
   txId?: string,
 ): Promise<SafeTransaction> => {
   const sdk = getAndValidateSafeSDK()
-  const signingMethod = shouldEthSign ? 'eth_sign' : 'eth_signTypedData'
+  const signingMethod = isLegacySignMethod ? ('eth_signTypedData_v3' as 'eth_signTypedData') : 'eth_signTypedData'
 
   let signedTx: SafeTransaction | undefined
   try {

--- a/src/services/tx/tx-sender/index.test.ts
+++ b/src/services/tx/tx-sender/index.test.ts
@@ -249,7 +249,7 @@ describe('txSender', () => {
       expect(txEvents.txDispatch).toHaveBeenCalledWith('SIGNED', { txId: '345' })
     })
 
-    it('should sign a tx with eth_sign if a hardware wallet/pairing is connected', async () => {
+    it('should sign a tx with eth_signTypedData_v3 if a hardware wallet/pairing is connected', async () => {
       const tx = await createTx({
         to: '0x123',
         value: '1',
@@ -260,7 +260,7 @@ describe('txSender', () => {
       const signedTx = await dispatchTxSigning(tx, true, '0x345')
 
       expect(mockSafeSDK.createTransaction).toHaveBeenCalled()
-      expect(mockSafeSDK.signTransaction).toHaveBeenCalledWith(expect.anything(), 'eth_sign')
+      expect(mockSafeSDK.signTransaction).toHaveBeenCalledWith(expect.anything(), 'eth_signTypedData_v3')
       expect(signedTx).not.toBe(tx)
     })
   })


### PR DESCRIPTION
## What it solves

Testing eth_signTypedData_v3 for Ledger, Trezor and mobile pairing.

I've already successfully signed and executed transactions with Ledger and mobile pairing in a 1.3.0 Safe.

Need to test Trezor and earlier Safe contract versions.