### PR TITLE
fix: position executor in transaction stepper

### DIFF
--- a/src/components/transactions/TxDetails/styles.module.css
+++ b/src/components/transactions/TxDetails/styles.module.css
@@ -49,7 +49,6 @@
 .txSigners {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   padding: var(--space-3);
   border-left: 1px solid var(--color-border-light);
 }

--- a/src/components/transactions/TxSigners/index.tsx
+++ b/src/components/transactions/TxSigners/index.tsx
@@ -129,18 +129,10 @@ export const TxSigners = ({ txDetails, txSummary }: TxSignersProps): ReactElemen
   const canExecute = wallet?.address ? isExecutable(txSummary, wallet.address, safe) : false
   const confirmationsNeeded = confirmationsRequired - confirmations.length
   const isConfirmed = confirmationsNeeded <= 0 || canExecute
-  const showExecutor = executor || !isConfirmed
 
   return (
     <>
-      <List
-        className={css.signers}
-        sx={{
-          '::before': {
-            height: `calc(100% - ${showExecutor ? '80px' : '40px'})`,
-          },
-        }}
-      >
+      <List className={css.signers}>
         <ListItem>
           {isCancellationTxInfo(txInfo) ? (
             <>
@@ -199,30 +191,26 @@ export const TxSigners = ({ txDetails, txSummary }: TxSignersProps): ReactElemen
             {executor ? 'Executed' : isPending ? txStatus : 'Can be executed'}
           </ListItemText>
         </ListItem>
-        {showExecutor && (
-          <ListItem>
-            {executor ? (
-              <Box className={css.listFooter}>
-                <EthHashInfo
-                  address={executor.value}
-                  name={executor.name}
-                  customAvatar={executor.logoUri}
-                  hasExplorer
-                  showCopyButton
-                />
-              </Box>
-            ) : (
-              !isConfirmed && (
-                <Box className={css.listFooter}>
-                  <Typography sx={({ palette }) => ({ color: palette.border.main })}>
-                    Can be executed once the threshold is reached
-                  </Typography>
-                </Box>
-              )
-            )}
-          </ListItem>
-        )}
       </List>
+      {executor ? (
+        <Box className={css.listFooter}>
+          <EthHashInfo
+            address={executor.value}
+            name={executor.name}
+            customAvatar={executor.logoUri}
+            hasExplorer
+            showCopyButton
+          />
+        </Box>
+      ) : (
+        !isConfirmed && (
+          <Box className={css.listFooter}>
+            <Typography sx={({ palette }) => ({ color: palette.border.main })}>
+              Can be executed once the threshold is reached
+            </Typography>
+          </Box>
+        )
+      )}
     </>
   )
 }

--- a/src/components/transactions/TxSigners/styles.module.css
+++ b/src/components/transactions/TxSigners/styles.module.css
@@ -44,7 +44,6 @@
 }
 
 .listFooter {
-  display: block;
   margin-left: var(--space-4);
   margin-top: calc(var(--space-1) * -1);
 }

--- a/src/components/transactions/TxSigners/styles.module.css
+++ b/src/components/transactions/TxSigners/styles.module.css
@@ -18,6 +18,7 @@
   border-left: 2px solid var(--color-border-light);
   left: 15px;
   top: 20px;
+  height: calc(100% - 40px);
 }
 
 .signers :global .MuiListItem-root:first-of-type {
@@ -45,5 +46,4 @@
 
 .listFooter {
   margin-left: var(--space-4);
-  margin-top: calc(var(--space-1) * -1);
 }

--- a/src/components/transactions/TxSigners/styles.module.css
+++ b/src/components/transactions/TxSigners/styles.module.css
@@ -18,7 +18,6 @@
   border-left: 2px solid var(--color-border-light);
   left: 15px;
   top: 20px;
-  height: calc(100% - 40px);
 }
 
 .signers :global .MuiListItem-root:first-of-type {
@@ -45,6 +44,7 @@
 }
 
 .listFooter {
+  display: block;
   margin-left: var(--space-4);
   margin-top: calc(var(--space-1) * -1);
 }


### PR DESCRIPTION
## What it solves

Resolves incorrect placement of executor in transaction stepper:

![image](https://user-images.githubusercontent.com/20442784/213715097-9c984731-8f8f-4604-ad5d-c3495a1965ff.png)

## How this PR fixes it

The stepper "line" (`::before`) length is relevant to the display of executor/hint about execution.

## How to test it

- Queue a transaction and observe the hint regarding execution positioned correctly.
- Execute a transaction and observe the executor positions correctly.
- Observe no line that spreads beyond the final step.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/213715428-eb294753-173e-4f99-b949-1c331c15428a.png)

![image](https://user-images.githubusercontent.com/20442784/213715470-d28fc3c2-f2ba-4cde-a5a1-7765174f7e7b.png)

![image](https://user-images.githubusercontent.com/20442784/213715397-8044bbe3-5af5-48d0-a841-c318cb20bf75.png)

![image](https://user-images.githubusercontent.com/20442784/213715380-9d2e621b-ee67-40cf-8efd-68d067b97c1d.png)
