### PR TITLE
fix: transaction info styling

### DIFF
--- a/src/components/transactions/TxDetails/Summary/TxDataRow/index.tsx
+++ b/src/components/transactions/TxDetails/Summary/TxDataRow/index.tsx
@@ -15,7 +15,9 @@ export const TxDataRow = ({ title, children }: TxDataRowProps): ReactElement | n
   if (children == undefined) return null
   return (
     <div className={css.gridRow}>
-      <div className={css.title}>{title}</div>
+      <Typography className={css.detailstitle} color="text.secondary">
+        {title}
+      </Typography>
 
       <Typography component="div">{children}</Typography>
     </div>

--- a/src/components/transactions/TxDetails/Summary/TxDataRow/index.tsx
+++ b/src/components/transactions/TxDetails/Summary/TxDataRow/index.tsx
@@ -15,9 +15,7 @@ export const TxDataRow = ({ title, children }: TxDataRowProps): ReactElement | n
   if (children == undefined) return null
   return (
     <div className={css.gridRow}>
-      <Typography className={css.detailstitle} color="text.secondary">
-        {title}
-      </Typography>
+      <div className={css.detailstitle}>{title}</div>
 
       <Typography component="div">{children}</Typography>
     </div>

--- a/src/components/transactions/TxDetails/Summary/TxDataRow/index.tsx
+++ b/src/components/transactions/TxDetails/Summary/TxDataRow/index.tsx
@@ -15,7 +15,7 @@ export const TxDataRow = ({ title, children }: TxDataRowProps): ReactElement | n
   if (children == undefined) return null
   return (
     <div className={css.gridRow}>
-      <div className={css.detailstitle}>{title}</div>
+      <div className={css.title}>{title}</div>
 
       <Typography component="div">{children}</Typography>
     </div>

--- a/src/components/transactions/TxDetails/Summary/TxDataRow/styles.module.css
+++ b/src/components/transactions/TxDetails/Summary/TxDataRow/styles.module.css
@@ -7,7 +7,7 @@
 }
 
 .title {
-  font-weight: 700;
+  font-weight: 400;
   word-break: break-all;
   color: var(--color-text-secondary);
 }

--- a/src/components/transactions/TxDetails/Summary/TxDataRow/styles.module.css
+++ b/src/components/transactions/TxDetails/Summary/TxDataRow/styles.module.css
@@ -9,11 +9,6 @@
 .title {
   font-weight: 700;
   word-break: break-all;
-}
-
-.detailstitle {
-  font-weight: 400;
-  word-break: break-all;
   color: var(--color-text-secondary);
 }
 

--- a/src/components/transactions/TxDetails/Summary/TxDataRow/styles.module.css
+++ b/src/components/transactions/TxDetails/Summary/TxDataRow/styles.module.css
@@ -14,6 +14,7 @@
 .detailstitle {
   font-weight: 400;
   word-break: break-all;
+  color: var(--color-text-secondary);
 }
 
 .gridRow > * {

--- a/src/components/transactions/TxDetails/Summary/TxDataRow/styles.module.css
+++ b/src/components/transactions/TxDetails/Summary/TxDataRow/styles.module.css
@@ -11,6 +11,11 @@
   word-break: break-all;
 }
 
+.detailstitle {
+  font-weight: 400;
+  word-break: break-all;
+}
+
 .gridRow > * {
   flex-shrink: 0;
 }


### PR DESCRIPTION
## What it solves

Resolves #1523 

## How this PR fixes it
changed css, used `text.secondary` as color property.

## How to test it

## Analytics changes

## Screenshots
<img width="1196" alt="image" src="https://user-images.githubusercontent.com/90976669/213937219-2936ce27-1b70-49da-b9e7-054c4b9e618a.png">



