### PR TITLE
fix: Reduce cummulative layout shift (CLS)

### DIFF
--- a/public/safe.webmanifest
+++ b/public/safe.webmanifest
@@ -15,7 +15,5 @@
     }
   ],
   "start_url": "/",
-  "theme_color": "#0FDA6D",
-  "background_color": "#121312",
   "display": "standalone"
 }

--- a/public/safe.webmanifest
+++ b/public/safe.webmanifest
@@ -15,5 +15,7 @@
     }
   ],
   "start_url": "/",
+  "theme_color": "#0FDA6D",
+  "background_color": "#121312",
   "display": "standalone"
 }

--- a/src/components/common/ChainIndicator/index.tsx
+++ b/src/components/common/ChainIndicator/index.tsx
@@ -38,7 +38,7 @@ const ChainIndicator = ({
 
   return chainConfig?.chainName ? (
     <span style={style} className={classnames(inline ? css.inlineIndicator : css.indicator, className)}>
-      {chainConfig.chainName || ' '}
+      {chainConfig.chainName}
     </span>
   ) : (
     <Skeleton width="100%" height="22px" variant="rectangular" sx={{ flexShrink: 0 }} />

--- a/src/components/common/ChainIndicator/index.tsx
+++ b/src/components/common/ChainIndicator/index.tsx
@@ -5,6 +5,7 @@ import { useAppSelector } from '@/store'
 import { selectChainById } from '@/store/chainsSlice'
 import css from './styles.module.css'
 import useChainId from '@/hooks/useChainId'
+import { Skeleton } from '@mui/material'
 
 type ChainIndicatorProps = {
   chainId?: string
@@ -35,10 +36,12 @@ const ChainIndicator = ({
 
   if (!chainConfig?.chainName && !renderWhiteSpaceIfNoChain) return null
 
-  return (
+  return chainConfig?.chainName ? (
     <span style={style} className={classnames(inline ? css.inlineIndicator : css.indicator, className)}>
-      {chainConfig?.chainName || ' '}
+      {chainConfig.chainName || ' '}
     </span>
+  ) : (
+    <Skeleton width="100%" height="22px" variant="rectangular" sx={{ flexShrink: 0 }} />
   )
 }
 

--- a/src/components/common/NetworkSelector/index.tsx
+++ b/src/components/common/NetworkSelector/index.tsx
@@ -1,5 +1,5 @@
 import type { SelectChangeEvent } from '@mui/material'
-import { Box, MenuItem, Select, Skeleton } from '@mui/material'
+import { MenuItem, Select, Skeleton } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import useChains from '@/hooks/useChains'
 import { useRouter } from 'next/router'
@@ -76,9 +76,7 @@ const NetworkSelector = (): ReactElement => {
       })}
     </Select>
   ) : (
-    <Box px={2}>
-      <Skeleton width={94} height={31} />
-    </Box>
+    <Skeleton width={94} height={31} sx={{ mx: 2 }} />
   )
 }
 

--- a/src/components/common/NetworkSelector/index.tsx
+++ b/src/components/common/NetworkSelector/index.tsx
@@ -1,5 +1,5 @@
 import type { SelectChangeEvent } from '@mui/material'
-import { MenuItem, Select, Skeleton } from '@mui/material'
+import { Box, MenuItem, Select, Skeleton } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import useChains from '@/hooks/useChains'
 import { useRouter } from 'next/router'
@@ -76,7 +76,9 @@ const NetworkSelector = (): ReactElement => {
       })}
     </Select>
   ) : (
-    <Skeleton width={94} height={31} />
+    <Box px={2}>
+      <Skeleton width={94} height={31} />
+    </Box>
   )
 }
 

--- a/src/components/dashboard/Overview/Overview.tsx
+++ b/src/components/dashboard/Overview/Overview.tsx
@@ -47,7 +47,7 @@ const SkeletonOverview = (
           <Skeleton variant="circular" width="48px" height="48px" />
         </IdenticonContainer>
 
-        <Box mb={2}>
+        <Box mb={4} mt={4}>
           <Typography fontSize="lg">
             <Skeleton variant="text" height={28} />
           </Typography>
@@ -60,7 +60,7 @@ const SkeletonOverview = (
     </Grid>
     <Grid container>
       <Grid item xs={3}>
-        <Typography color="inputDefault" fontSize="lg">
+        <Typography color="border.main" variant="body2">
           Tokens
         </Typography>
         <StyledText fontSize="lg">
@@ -68,7 +68,7 @@ const SkeletonOverview = (
         </StyledText>
       </Grid>
       <Grid item xs={3}>
-        <Typography color="inputDefault" fontSize="lg">
+        <Typography color="border.main" variant="body2">
           NFTs
         </Typography>
         <StyledText fontSize="lg">
@@ -82,7 +82,7 @@ const SkeletonOverview = (
 const Overview = (): ReactElement => {
   const router = useRouter()
   const safeAddress = useSafeAddress()
-  const { safe, safeLoading } = useSafeInfo()
+  const { safe, safeLoading, safeLoaded } = useSafeInfo()
   const { balances } = useVisibleBalances()
   const [nfts] = useCollectibles()
   const chain = useCurrentChain()
@@ -101,6 +101,8 @@ const Overview = (): ReactElement => {
   const tokenCount = useMemo(() => balances.items.filter((token) => token.balance !== '0').length, [balances])
   const nftsCount = useMemo(() => (nfts ? `${nfts.next ? '>' : ''}${nfts.results.length}` : ''), [nfts])
 
+  const isInitialState = !safeLoaded && !safeLoading
+
   return (
     <WidgetContainer>
       <Typography component="h2" variant="subtitle1" fontWeight={700} mb={2}>
@@ -108,7 +110,7 @@ const Overview = (): ReactElement => {
       </Typography>
 
       <WidgetBody>
-        {safeLoading ? (
+        {safeLoading || isInitialState ? (
           SkeletonOverview
         ) : (
           <Card>
@@ -123,7 +125,11 @@ const Overview = (): ReactElement => {
             </Grid>
 
             <Box mt={2} mb={4}>
-              <EthHashInfo showAvatar={false} address={safeAddress} shortAddress={false} showCopyButton hasExplorer />
+              {safeAddress ? (
+                <EthHashInfo showAvatar={false} address={safeAddress} shortAddress={false} showCopyButton hasExplorer />
+              ) : (
+                <Skeleton />
+              )}
             </Box>
 
             <Grid container>
@@ -133,7 +139,7 @@ const Overview = (): ReactElement => {
                     <Typography color="border.main" variant="body2">
                       Tokens
                     </Typography>
-                    <StyledText fontSize="lg">{tokenCount}</StyledText>
+                    <StyledText fontSize="lg">{tokenCount || <ValueSkeleton />}</StyledText>
                   </a>
                 </Link>
               </Grid>

--- a/src/components/dashboard/Overview/Overview.tsx
+++ b/src/components/dashboard/Overview/Overview.tsx
@@ -47,7 +47,7 @@ const SkeletonOverview = (
           <Skeleton variant="circular" width="48px" height="48px" />
         </IdenticonContainer>
 
-        <Box mb={4} mt={4}>
+        <Box my={4}>
           <Typography fontSize="lg">
             <Skeleton variant="text" height={28} />
           </Typography>


### PR DESCRIPTION
## What it solves

Reduces CLS caused by elements in the header and sidebar

## How this PR fixes it

- Adds padding to the `NetworkSelector` in the header
- Adds a skeleton for the `ChainIndicator`
- Removes a redundant loading state for the overview widget on the dashboard

## Screenshots

Before:

[before.webm](https://user-images.githubusercontent.com/5880855/214008107-3df65843-3638-4395-9b8e-c01cad9bad88.webm)

After:

[after.webm](https://user-images.githubusercontent.com/5880855/214008217-78b685ec-965b-4e48-ba3c-b59d82d7ba6c.webm)


