### PR TITLE
fix: ref forwarding

### DIFF
--- a/src/components/tx/modals/NewTxModal/CreationModal.tsx
+++ b/src/components/tx/modals/NewTxModal/CreationModal.tsx
@@ -50,13 +50,15 @@ const CreationModal = ({
 
           {txBuilder.app && shouldShowTxBuilder && (
             <Link href={txBuilder.link} passHref>
-              <TxButton
-                startIcon={<img src={txBuilder.app.iconUrl} height={20} width="auto" alt={txBuilder.app.name} />}
-                variant="outlined"
-                onClick={onContractInteraction}
-              >
-                Contract interaction
-              </TxButton>
+              <a>
+                <TxButton
+                  startIcon={<img src={txBuilder.app.iconUrl} height={20} width="auto" alt={txBuilder.app.name} />}
+                  variant="outlined"
+                  onClick={onContractInteraction}
+                >
+                  Contract interaction
+                </TxButton>
+              </a>
             </Link>
           )}
         </Box>

--- a/src/components/tx/modals/NewTxModal/CreationModal.tsx
+++ b/src/components/tx/modals/NewTxModal/CreationModal.tsx
@@ -50,7 +50,7 @@ const CreationModal = ({
 
           {txBuilder.app && shouldShowTxBuilder && (
             <Link href={txBuilder.link} passHref>
-              <a>
+              <a style={{ width: '100%' }}>
                 <TxButton
                   startIcon={<img src={txBuilder.app.iconUrl} height={20} width="auto" alt={txBuilder.app.name} />}
                   variant="outlined"


### PR DESCRIPTION
## What it solves

Resolves console error.

![image](https://user-images.githubusercontent.com/20442784/213996759-71344d9d-fb67-4441-8a87-6459834e2762.png)

## How this PR fixes it

The Transaction Builder link in the transaction creation modal was not forwarding a ref correctly. An interim anchor tag is used to wrap the button instead of forwarding the ref to the button.

## How to test it

Open the transaction creation modal and observe that there is no console error and that the styling/functionality of "Contract interaction" button is still the same.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/213996968-66723183-d74c-4479-9969-f131037dba67.png)