### PR TITLE
[EIP-1271] Decode eip712 messages

### DIFF
--- a/src/components/safe-messages/DecodedMsg/index.tsx
+++ b/src/components/safe-messages/DecodedMsg/index.tsx
@@ -1,0 +1,70 @@
+import { generateDataRowValue, TxDataRow } from '@/components/transactions/TxDetails/Summary/TxDataRow'
+import { Value } from '@/components/transactions/TxDetails/TxData/DecodedData/ValueArray'
+import { isByte } from '@/utils/transaction-guards'
+import { normalizeTypedData } from '@/utils/web3'
+import { Box, Typography } from '@mui/material'
+import type { EIP712TypedData, SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
+import { isAddress } from 'ethers/lib/utils'
+import { isObject } from 'lodash'
+import type { ReactElement } from 'react'
+import Msg from '../Msg'
+
+export const DecodedMsg = ({ message }: { message: SafeMessage['message'] }): ReactElement => {
+  const isTextMessage = typeof message === 'string'
+
+  if (isTextMessage) {
+    return <Msg message={message} />
+  }
+
+  // Hash each data object to one of hash, rawData, address, bytes or undefined (if rendered as string)
+
+  // Normalize message such that we know the primaryType
+  const normalizedMsg = normalizeTypedData(message) as EIP712TypedData & {
+    primaryType: string
+  }
+
+  const { primaryType, types, message: msg } = normalizedMsg
+
+  const findTypeInPrimaryType = (paramName: string) => types[primaryType].find((type) => type.name === paramName)?.type
+
+  return (
+    <Box>
+      <Typography variant="overline" sx={({ palette }) => ({ color: `${palette.border.main}` })}>
+        <b>{primaryType}</b>
+      </Typography>
+
+      {Object.entries(msg).map((param, index) => {
+        const [paramName, paramValue] = param
+        const type = findTypeInPrimaryType(paramName) || 'string'
+
+        const isArrayValueParam = Array.isArray(paramValue)
+        const isNested = isObject(paramValue)
+        const inlineType = isAddress(paramValue as string) ? 'address' : isByte(type) ? 'bytes' : undefined
+
+        return (
+          <TxDataRow key={`${primaryType}_param-${index}`} title={`${param[0]}(${type}):`}>
+            {isArrayValueParam ? (
+              <Value method={primaryType} type={type} value={JSON.stringify(paramValue, null, 2)} />
+            ) : isNested ? (
+              <Box
+                sx={{
+                  border: ({ palette }) => `1px ${palette.border.main} solid`,
+                  whiteSpace: 'pre',
+                  fontFamily: 'monospace',
+                  fontSize: '0.85rem',
+                  overflow: 'auto',
+                  borderRadius: '6px',
+                  padding: 1,
+                }}
+              >
+                {JSON.stringify(paramValue, null, 2)}
+              </Box>
+            ) : (
+              generateDataRowValue(paramValue as string, inlineType, true)
+            )}
+          </TxDataRow>
+        )
+      })}
+    </Box>
+  )
+}

--- a/src/components/safe-messages/DecodedMsg/index.tsx
+++ b/src/components/safe-messages/DecodedMsg/index.tsx
@@ -40,11 +40,11 @@ export const DecodedMsg = ({ message }: { message: SafeMessage['message'] }): Re
         const isArrayValueParam = Array.isArray(paramValue)
         const isNested = isObject(paramValue)
         const inlineType = isAddress(paramValue as string) ? 'address' : isByte(type) ? 'bytes' : undefined
-
+        const paramValueAsString = typeof paramValue === 'string' ? paramValue : JSON.stringify(paramValue, null, 2)
         return (
           <TxDataRow key={`${primaryType}_param-${index}`} title={`${param[0]}(${type}):`}>
             {isArrayValueParam ? (
-              <Value method={primaryType} type={type} value={JSON.stringify(paramValue, null, 2)} />
+              <Value method={primaryType} type={type} value={paramValueAsString} />
             ) : isNested ? (
               <Box
                 sx={{
@@ -57,10 +57,10 @@ export const DecodedMsg = ({ message }: { message: SafeMessage['message'] }): Re
                   padding: 1,
                 }}
               >
-                {JSON.stringify(paramValue, null, 2)}
+                {paramValueAsString}
               </Box>
             ) : (
-              generateDataRowValue(paramValue as string, inlineType, true)
+              generateDataRowValue(paramValueAsString, inlineType, true)
             )}
           </TxDataRow>
         )

--- a/src/components/safe-messages/MsgDetails/index.tsx
+++ b/src/components/safe-messages/MsgDetails/index.tsx
@@ -15,12 +15,13 @@ import MsgSigners from '@/components/safe-messages/MsgSigners'
 import useWallet from '@/hooks/wallets/useWallet'
 import SignMsgButton from '@/components/safe-messages/SignMsgButton'
 import useIsWrongChain from '@/hooks/useIsWrongChain'
-import Msg from '@/components/safe-messages/Msg'
 import { generateSafeMessageMessage } from '@/utils/safe-messages'
 
 import txDetailsCss from '@/components/transactions/TxDetails/styles.module.css'
 import singleTxDecodedCss from '@/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/styles.module.css'
 import infoDetailsCss from '@/components/transactions/InfoDetails/styles.module.css'
+import { DecodedMsg } from '../DecodedMsg'
+import CopyButton from '@/components/common/CopyButton'
 
 const MsgDetails = ({ msg }: { msg: SafeMessage }): ReactElement => {
   const wallet = useWallet()
@@ -51,10 +52,13 @@ const MsgDetails = ({ msg }: { msg: SafeMessage }): ReactElement => {
           <TxDataRow title="Last modified:">{formatDateTime(msg.modifiedTimestamp)}</TxDataRow>
           <TxDataRow title="Message hash:">{generateDataRowValue(msg.messageHash, 'hash')}</TxDataRow>
           <TxDataRow title="SafeMessage:">{generateDataRowValue(safeMessage, 'hash')}</TxDataRow>
-          <Typography fontWeight={700} mb={1}>
-            Message:
-          </Typography>
-          <Msg message={msg.message} />
+          <TxDataRow title="Raw Message">
+            <Box display="flex" alignItems="center">
+              <div>{JSON.stringify(msg.message, null, 2).length} characters</div>
+              <CopyButton text={JSON.stringify(msg.message, null, 2)} />
+            </Box>
+          </TxDataRow>
+          <DecodedMsg message={msg.message} />
         </div>
 
         {msg.preparedSignature && (

--- a/src/components/safe-messages/MsgModal/index.tsx
+++ b/src/components/safe-messages/MsgModal/index.tsx
@@ -7,7 +7,6 @@ import type { RequestId } from '@gnosis.pm/safe-apps-sdk'
 
 import ModalDialog, { ModalDialogTitle } from '@/components/common/ModalDialog'
 import SafeAppIcon from '@/components/safe-apps/SafeAppIcon'
-import Msg from '@/components/safe-messages/Msg'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import RequiredIcon from '@/public/images/messages/required.svg'
 import { dispatchSafeMsgConfirmation, dispatchSafeMsgProposal } from '@/services/safe-messages/safeMsgSender'
@@ -24,6 +23,7 @@ import { isSafeMessageListItem } from '@/utils/safe-message-guards'
 import { useWeb3 } from '@/hooks/wallets/web3'
 
 import txStepperCss from '@/components/tx/TxStepper/styles.module.css'
+import { DecodedMsg } from '../DecodedMsg'
 
 const APP_LOGO_FALLBACK_IMAGE = '/images/apps/apps-icon.svg'
 const APP_NAME_FALLBACK = 'Sign message off-chain'
@@ -151,7 +151,7 @@ const MsgModal = ({
             Message:
           </Typography>
           <Typography variant="body2">
-            <Msg message={decodedMessage} />
+            <DecodedMsg message={decodedMessage} />
           </Typography>
           <Typography fontWeight={700} mt={2}>
             SafeMessage:

--- a/src/components/transactions/TxNavigation/index.tsx
+++ b/src/components/transactions/TxNavigation/index.tsx
@@ -6,7 +6,6 @@ import { FEATURES } from '@safe-global/safe-gateway-typescript-sdk'
 
 const TxNavigation = () => {
   const chain = useCurrentChain()
-  debugger
   const isEIP1271 = chain && hasFeature(chain, FEATURES.EIP1271)
 
   return (


### PR DESCRIPTION
## What it solves
Instead of showing the raw JSON we show the messages data is a more human readable way.


## How this PR fixes it
Uses the types to show a better component for each message field.
Similar to how transaction data gets decoded.

## How to test it
Sign a EIP 712 message
Observe the new message display.

## Analytics changes
None

## Screenshots
tbd
