### PR TITLE
fix: asset selection validation

### DIFF
--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -95,6 +95,7 @@ const SendAssetsForm = ({ onSubmit, formData, disableSpendingLimit = false }: Se
     register,
     handleSubmit,
     setValue,
+    resetField,
     watch,
     formState: { errors },
   } = formMethods
@@ -157,7 +158,7 @@ const SendAssetsForm = ({ onSubmit, formData, disableSpendingLimit = false }: Se
               error={!!errors.tokenAddress}
               {...register(SendAssetsField.tokenAddress, {
                 required: true,
-                onChange: () => setValue(SendAssetsField.amount, ''),
+                onChange: () => resetField(SendAssetsField.amount),
               })}
             >
               {balances.items.map((item) => (

--- a/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
+++ b/src/components/tx/modals/TokenTransferModal/SendAssetsForm.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react'
-import { useForm, FormProvider } from 'react-hook-form'
+import { useForm, FormProvider, Controller } from 'react-hook-form'
 import {
   Button,
   FormControl,
@@ -98,6 +98,7 @@ const SendAssetsForm = ({ onSubmit, formData, disableSpendingLimit = false }: Se
     resetField,
     watch,
     formState: { errors },
+    control,
   } = formMethods
 
   const recipient = watch(SendAssetsField.recipient)
@@ -147,27 +148,34 @@ const SendAssetsForm = ({ onSubmit, formData, disableSpendingLimit = false }: Se
             )}
           </FormControl>
 
-          <FormControl fullWidth>
-            <InputLabel id="asset-label" required>
-              Select an asset
-            </InputLabel>
-            <Select
-              labelId="asset-label"
-              label={errors.tokenAddress?.message || 'Select an asset'}
-              defaultValue={formData?.tokenAddress || ''}
-              error={!!errors.tokenAddress}
-              {...register(SendAssetsField.tokenAddress, {
-                required: true,
-                onChange: () => resetField(SendAssetsField.amount),
-              })}
-            >
-              {balances.items.map((item) => (
-                <MenuItem key={item.tokenInfo.address} value={item.tokenInfo.address}>
-                  <AutocompleteItem {...item} />
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
+          <Controller
+            name={SendAssetsField.tokenAddress}
+            control={control}
+            rules={{ required: true }}
+            render={({ fieldState, field }) => (
+              <FormControl fullWidth>
+                <InputLabel id="asset-label" required>
+                  Select an asset
+                </InputLabel>
+                <Select
+                  labelId="asset-label"
+                  label={fieldState.error?.message || 'Select an asset'}
+                  error={!!fieldState.error}
+                  {...field}
+                  onChange={(e) => {
+                    field.onChange(e)
+                    resetField(SendAssetsField.amount)
+                  }}
+                >
+                  {balances.items.map((item) => (
+                    <MenuItem key={item.tokenInfo.address} value={item.tokenInfo.address}>
+                      <AutocompleteItem {...item} />
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+          />
 
           {isDisabled && (
             <Box mt={1} display="flex" alignItems="center">


### PR DESCRIPTION
## What it solves

Resolves #1545

## How this PR fixes it

The `tokenAddress` field in the `SendAssetsForm` has been converted to use RHF's `Controller` component.

Note: this partially resolves #1501 and demonstrates the importance of controlled MUI components with RHF (#1369).

## How to test it

Open the transaction creation modal and observe that the field is no longer erroneous after selecting a token. Selecting a token when a value is set should clear the value field as well.

## Screenshots

![asset-validation](https://user-images.githubusercontent.com/20442784/214026262-02a0fbae-5041-4839-b519-2f4f5f395add.gif)