### PR TITLE
fix: DOM nesting error

### DIFF
--- a/src/components/tx/SendFromBlock/index.tsx
+++ b/src/components/tx/SendFromBlock/index.tsx
@@ -14,9 +14,9 @@ const SendFromBlock = (): ReactElement => {
         Sending from
       </Typography>
 
-      <Typography variant="body2">
+      <Box sx={({ typography }) => typography.body2}>
         <EthHashInfo address={address} shortAddress={false} hasExplorer showCopyButton />
-      </Typography>
+      </Box>
 
       <SouthIcon className={css.arrow} />
     </Box>

--- a/src/components/tx/SendFromBlock/index.tsx
+++ b/src/components/tx/SendFromBlock/index.tsx
@@ -14,9 +14,9 @@ const SendFromBlock = (): ReactElement => {
         Sending from
       </Typography>
 
-      <Box sx={({ typography }) => typography.body2}>
+      <Typography variant="body2" component="div">
         <EthHashInfo address={address} shortAddress={false} hasExplorer showCopyButton />
-      </Box>
+      </Typography>
 
       <SouthIcon className={css.arrow} />
     </Box>


### PR DESCRIPTION
## What it solves

Resolves console error regarding DOM nesting

![image](https://user-images.githubusercontent.com/20442784/214036005-67deb9ca-20ac-4255-a910-15630597cbf4.png)

## How this PR fixes it

The wrapper `Typography` uses specifies the `component` instead.

## How to test it

Open the transaction creation modal and observe no visual change regarding the "Sending from" block, as well as no console errors regarding DOM nesting.

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/20442784/214036271-e4628123-311b-4373-8073-5d8a42d32e6c.png)

After:
![image](https://user-images.githubusercontent.com/20442784/214036319-a1570d0a-d58b-469e-a69e-9ac27057fccf.png)