### PR TITLE
fix: fallback to `chainId` of `wallet`

### DIFF
--- a/src/hooks/__tests__/useChainId.test.ts
+++ b/src/hooks/__tests__/useChainId.test.ts
@@ -3,6 +3,10 @@ import useChainId from '@/hooks/useChainId'
 import { useAppDispatch } from '@/store'
 import { setLastChainId } from '@/store/sessionSlice'
 import { renderHook } from '@/tests/test-utils'
+import * as useWalletHook from '@/hooks/wallets/useWallet'
+import * as useChains from '@/hooks/useChains'
+import type { ConnectedWallet } from '@/services/onboard'
+import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
 // mock useRouter
 jest.mock('next/router', () => ({
@@ -105,7 +109,47 @@ describe('useChainId hook', () => {
     expect(result.current).toBe('137')
   })
 
-  it('should return the last used chain id if no chain in the URL', () => {
+  it('should return the wallet chain id if no chain in the URL and it is present in the chain configs', () => {
+    ;(useRouter as any).mockImplementation(() => ({
+      query: {},
+    }))
+
+    jest.spyOn(useWalletHook, 'default').mockImplementation(
+      () =>
+        ({
+          chainId: '1337',
+        } as ConnectedWallet),
+    )
+
+    jest.spyOn(useChains, 'default').mockImplementation(() => ({
+      configs: [{ chainId: '1337' } as ChainInfo],
+    }))
+
+    const { result } = renderHook(() => useChainId())
+    expect(result.current).toBe('1337')
+  })
+
+  it('should return the last used chain id if no chain in the URL and the connect wallet chain id is not present in the chain configs', () => {
+    ;(useRouter as any).mockImplementation(() => ({
+      query: {},
+    }))
+
+    jest.spyOn(useWalletHook, 'default').mockImplementation(
+      () =>
+        ({
+          chainId: '1337',
+        } as ConnectedWallet),
+    )
+
+    jest.spyOn(useChains, 'default').mockImplementation(() => ({
+      configs: [],
+    }))
+
+    const { result } = renderHook(() => useChainId())
+    expect(result.current).toBe('5')
+  })
+
+  it('should return the last used chain id if no wallet is connected and there is no chain in the URL', () => {
     ;(useRouter as any).mockImplementation(() => ({
       query: {},
     }))

--- a/src/hooks/__tests__/useVisibleBalances.test.ts
+++ b/src/hooks/__tests__/useVisibleBalances.test.ts
@@ -28,6 +28,7 @@ describe('useVisibleBalances', () => {
           },
           hiddenTokens: { ['4']: [hiddenTokenAddress] },
         },
+        chains: { data: [], error: undefined, loading: false },
       } as unknown as store.RootState),
     )
 
@@ -85,6 +86,7 @@ describe('useVisibleBalances', () => {
           },
           hiddenTokens: { ['4']: [hiddenTokenAddress] },
         },
+        chains: { data: [], error: undefined, loading: false },
       } as unknown as store.RootState),
     )
 
@@ -155,6 +157,7 @@ describe('useVisibleBalances', () => {
           },
           hiddenTokens: { ['4']: [hiddenTokenAddress] },
         },
+        chains: { data: [], error: undefined, loading: false },
       } as unknown as store.RootState),
     )
 
@@ -213,6 +216,7 @@ describe('useVisibleBalances', () => {
           },
           hiddenTokens: { ['4']: [hiddenTokenAddress] },
         },
+        chains: { data: [], error: undefined, loading: false },
       } as unknown as store.RootState),
     )
 

--- a/src/hooks/useChainId.ts
+++ b/src/hooks/useChainId.ts
@@ -6,6 +6,8 @@ import { useAppSelector } from '@/store'
 import { selectSession } from '@/store/sessionSlice'
 import { parsePrefixedAddress } from '@/utils/addresses'
 import { prefixedAddressRe } from '@/utils/url'
+import useWallet from './wallets/useWallet'
+import useChains from './useChains'
 
 const defaultChainId = IS_PRODUCTION ? chains.eth : chains.gor
 
@@ -44,7 +46,15 @@ export const useUrlChainId = (): string | undefined => {
 export const useChainId = (): string => {
   const session = useAppSelector(selectSession)
   const urlChainId = useUrlChainId()
-  return urlChainId || session.lastChainId || defaultChainId
+  const wallet = useWallet()
+  const chains = useChains()
+
+  const fallbackChainId =
+    wallet?.chainId && chains?.configs.some(({ chainId }) => chainId === wallet.chainId)
+      ? wallet.chainId
+      : defaultChainId
+
+  return urlChainId || session.lastChainId || fallbackChainId
 }
 
 export default useChainId

--- a/src/hooks/useChainId.ts
+++ b/src/hooks/useChainId.ts
@@ -49,12 +49,10 @@ export const useChainId = (): string => {
   const wallet = useWallet()
   const chains = useChains()
 
-  const fallbackChainId =
-    wallet?.chainId && chains?.configs.some(({ chainId }) => chainId === wallet.chainId)
-      ? wallet.chainId
-      : defaultChainId
+  const walletChainId =
+    wallet?.chainId && chains?.configs.some(({ chainId }) => chainId === wallet.chainId) ? wallet.chainId : undefined
 
-  return urlChainId || session.lastChainId || fallbackChainId
+  return urlChainId || walletChainId || session.lastChainId || defaultChainId
 }
 
 export default useChainId


### PR DESCRIPTION
## What it solves

Resolves #1554

## How this PR fixes it

`useChainId` returns the `chainId` of the connected wallet if no `chainId` is present in the URL or cached from the last session.

## How to test it

1. Open a "non-`chainId`" URL in an Incognito window (e.g. `/welcome`).
2. Ensure the wallet is connected to a chain that is present in the environment chain configuration and connect the wallet.
3. Observe the chain in the top right matches that of the wallet.

---

1. Open a "non-`chainId`" URL in an Incognito window (e.g. `/welcome`).
2. Ensure the wallet is connected to a chain that is NOT present in the environment chain configuration and connect the wallet.
3. Observe the chain in the top right is the default fallback, Mainnet on prod. or Goerli on dev.