### PR TITLE
fix: `EthHashInfo` nesting

### DIFF
--- a/src/components/common/WalletInfo/index.tsx
+++ b/src/components/common/WalletInfo/index.tsx
@@ -21,7 +21,7 @@ const WalletInfo = ({ wallet, chain }: { wallet: ConnectedWallet; chain: ChainIn
         <Typography variant="caption" component="div" className={css.walletDetails}>
           {wallet.label} @ {chain.chainName}
         </Typography>
-        <Typography variant="caption" fontWeight="bold">
+        <Typography variant="caption" fontWeight="bold" component="div">
           {wallet.ens ? (
             <div>{wallet.ens}</div>
           ) : (

--- a/src/components/new-safe/OwnerRow/index.tsx
+++ b/src/components/new-safe/OwnerRow/index.tsx
@@ -96,7 +96,7 @@ export const OwnerRow = ({
       </Grid>
       <Grid item xs={11} md={7}>
         {readOnly ? (
-          <Typography variant="body2">
+          <Typography variant="body2" component="div">
             <EthHashInfo address={owner.address} shortAddress hasExplorer showCopyButton />
           </Typography>
         ) : (

--- a/src/components/tx/SendToBlock/index.tsx
+++ b/src/components/tx/SendToBlock/index.tsx
@@ -8,7 +8,7 @@ const SendToBlock = ({ address, title = 'Recipient' }: { address: string; title?
         {title}
       </Typography>
 
-      <Typography variant="body2">
+      <Typography variant="body2" component="div">
         <EthHashInfo address={address} shortAddress={false} hasExplorer showCopyButton />
       </Typography>
     </Box>


### PR DESCRIPTION
## What it solves

Resolves invalid DOM nested, on top of https://github.com/safe-global/web-core/pull/1585

![image](https://user-images.githubusercontent.com/20442784/214252997-39d2951f-711f-4c50-8792-f97870e98f7c.png)

## How this PR fixes it

All instances of `EthHashInfo` found inside `Typography` have been changed to use `div` elements as they shouldn't be nested inside `p` elements.

## How to test it

1. Open the account centre when connected to a wallet without an ENS and observe no console error.
2. Load a Safe and observe no console errors on the owner overview step.
3. Review a transaction to be created and observe console errors.