### PR TITLE
fix: Handle safe creation errors

### DIFF
--- a/src/components/new-safe/create/logic/index.test.ts
+++ b/src/components/new-safe/create/logic/index.test.ts
@@ -64,12 +64,10 @@ describe('checkSafeCreationTx', () => {
     expect(result).toBe(SafeCreationStatus.REVERTED)
   })
 
-  it('returns TIMEOUT if transaction couldnt be found within the timeout limit', async () => {
+  it('returns TIMEOUT if transaction could not be found within the timeout limit', async () => {
     const mockEthersError = {
       ...new Error(),
-      receipt: {
-        status: 1,
-      },
+      code: ErrorCode.TIMEOUT,
     }
 
     waitForTxSpy.mockImplementationOnce(() => Promise.reject(mockEthersError))
@@ -173,7 +171,7 @@ describe('handleSafeCreationError', () => {
     expect(result).toEqual(SafeCreationStatus.SUCCESS)
   })
 
-  it('returns TIMEOUT if the tx was not rejected, cancelled or replaced', () => {
+  it('returns ERROR if the tx was not rejected, cancelled or replaced', () => {
     const mockEthersError = {
       ...new Error(),
       code: ErrorCode.UNKNOWN_ERROR,
@@ -183,7 +181,7 @@ describe('handleSafeCreationError', () => {
 
     const result = handleSafeCreationError(mockEthersError)
 
-    expect(result).toEqual(SafeCreationStatus.TIMEOUT)
+    expect(result).toEqual(SafeCreationStatus.ERROR)
   })
 
   it('returns REVERTED if the tx failed', () => {

--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -1,5 +1,5 @@
 import type { Web3Provider, JsonRpcProvider } from '@ethersproject/providers'
-import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { getSafeInfo, type SafeInfo, type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import {
   getFallbackHandlerContractInstance,
   getGnosisSafeContractInstance,
@@ -26,7 +26,6 @@ import type Safe from '@safe-global/safe-core-sdk'
 import type { DeploySafeProps } from '@safe-global/safe-core-sdk'
 import { createEthersAdapter } from '@/hooks/coreSDK/safeCoreSDK'
 import type { PredictSafeProps } from '@safe-global/safe-core-sdk/dist/src/safeFactory'
-import { getSafeInfo, type SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { backOff } from 'exponential-backoff'
 import { LATEST_SAFE_VERSION } from '@/config/constants'
 import { EMPTY_DATA, ZERO_ADDRESS } from '@safe-global/safe-core-sdk/dist/src/utils/constants'
@@ -184,7 +183,11 @@ export const handleSafeCreationError = (error: EthersError) => {
     return SafeCreationStatus.REVERTED
   }
 
-  return SafeCreationStatus.TIMEOUT
+  if (error.code === ErrorCode.TIMEOUT) {
+    return SafeCreationStatus.TIMEOUT
+  }
+
+  return SafeCreationStatus.ERROR
 }
 
 export const SAFE_CREATION_ERROR_KEY = 'create-safe-error'


### PR DESCRIPTION
## What it solves

Resolves #1558 

Note: I couldn't reproduce ethers returning an error but the transaction still being executed/being in the mempool.

## How this PR fixes it

Uses the generic `ERROR` instead of `TIMEOUT` as a fall-through when creating a safe. This makes more sense since ethers returns a specific error code for timeouts but not for other possible errors like the one reported.

## How to test it

1. Create a new safe
2. Select 21000 gas limit in your wallet
3. Submit transaction
4. Observe a generic error in the UI instead of a timeout error
5. Create a new safe
6. Select extremely low gas and maxPrioFee
7. Reload the page
8. Wait for 6.5 minutes
9. Observe a timeout error