### PR TITLE
refactor: helper for checking version features

### DIFF
--- a/src/components/settings/TransactionGuards/index.tsx
+++ b/src/components/settings/TransactionGuards/index.tsx
@@ -1,12 +1,12 @@
 import EthHashInfo from '@/components/common/EthHashInfo'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { Paper, Grid, Typography, Box } from '@mui/material'
-import { gte } from 'semver'
 import { RemoveGuard } from './RemoveGuard'
 import useIsGranted from '@/hooks/useIsGranted'
 
 import css from './styles.module.css'
 import ExternalLink from '@/components/common/ExternalLink'
+import { FEATURES, hasFeature } from '@/utils/safe-versions'
 
 const NoTransactionGuard = () => {
   return (
@@ -27,12 +27,10 @@ const GuardDisplay = ({ guardAddress, chainId }: { guardAddress: string; chainId
   )
 }
 
-const GUARD_SUPPORTED_SAFE_VERSION = '1.3.0'
-
 const TransactionGuards = () => {
   const { safe, safeLoaded } = useSafeInfo()
 
-  const isVersionWithGuards = safeLoaded && safe.version && gte(safe.version, GUARD_SUPPORTED_SAFE_VERSION)
+  const isVersionWithGuards = safeLoaded && hasFeature(FEATURES.SAFE_TX_GUARDS, safe.version)
 
   if (!isVersionWithGuards) {
     return null

--- a/src/services/tx/safeUpdateParams.ts
+++ b/src/services/tx/safeUpdateParams.ts
@@ -1,20 +1,18 @@
 import type { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
 import { OperationType } from '@safe-global/safe-core-sdk-types'
-import semverSatisfies from 'semver/functions/satisfies'
 import type GnosisSafeContractEthers from '@safe-global/safe-ethers-lib/dist/src/contracts/GnosisSafe/GnosisSafeContractEthers'
 import type { ChainInfo, SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { getFallbackHandlerContractInstance, getGnosisSafeContractInstance } from '@/services/contracts/safeContracts'
 import { LATEST_SAFE_VERSION } from '@/config/constants'
 import { assertValidSafeVersion } from '@/hooks/coreSDK/safeCoreSDK'
+import { FEATURES, hasFeature } from '@/utils/safe-versions'
 
 const getChangeFallbackHandlerCallData = (
   safe: SafeInfo,
   chain: ChainInfo,
   safeContractInstance: GnosisSafeContractEthers,
 ): string => {
-  const SUPPORTS_FALLBACK_HANDLER = '>=1.1.0'
-
-  if (!safe.version || !semverSatisfies(safe.version, SUPPORTS_FALLBACK_HANDLER)) {
+  if (hasFeature(FEATURES.SAFE_FALLBACK_HANDLER, safe.version)) {
     return '0x'
   }
 

--- a/src/services/tx/tx-sender/sdk.ts
+++ b/src/services/tx/tx-sender/sdk.ts
@@ -3,10 +3,10 @@ import type Safe from '@safe-global/safe-core-sdk'
 import EthersAdapter from '@safe-global/safe-ethers-lib'
 import { ethers } from 'ethers'
 import type { Web3Provider } from '@ethersproject/providers'
-import semverSatisfies from 'semver/functions/satisfies'
 import { isWalletRejection } from '@/utils/wallets'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { FEATURES, hasFeature } from '@/utils/safe-versions'
 
 export const getAndValidateSafeSDK = (): Safe => {
   const safeSDK = getSafeSDK()
@@ -37,12 +37,10 @@ export const getUncheckedSafeSDK = (provider: Web3Provider): Promise<Safe> => {
 type SigningMethods = Parameters<Safe['signTransaction']>[1]
 
 export const _getSupportedSigningMethods = (safeVersion: SafeInfo['version']): SigningMethods[] => {
-  const SAFE_VERSION_SUPPORTS_ETH_SIGN = '>=1.1.0'
-
   const ETH_SIGN_TYPED_DATA: SigningMethods = 'eth_signTypedData'
   const ETH_SIGN: SigningMethods = 'eth_sign'
 
-  if (!safeVersion || !semverSatisfies(safeVersion, SAFE_VERSION_SUPPORTS_ETH_SIGN)) {
+  if (!hasFeature(FEATURES.ETH_SIGN, safeVersion)) {
     return [ETH_SIGN_TYPED_DATA]
   }
 

--- a/src/utils/__tests__/safe-version.test.ts
+++ b/src/utils/__tests__/safe-version.test.ts
@@ -1,0 +1,70 @@
+import { hasFeature, enabledFeatures, FEATURES } from '../safe-versions'
+
+describe('safe-version', () => {
+  describe('enabledFeatures', () => {
+    it('should return an empty array if the version is null', () => {
+      expect(enabledFeatures(null)).toEqual([])
+    })
+
+    it('should return an array of the supported features of the specified version', () => {
+      // 1.0.0
+      expect(enabledFeatures('1.0.0')).toEqual([])
+
+      // 1.1.0
+      expect(enabledFeatures('1.1.0')).toEqual([FEATURES.ETH_SIGN])
+
+      // 1.1.1
+      expect(enabledFeatures('1.1.1')).toEqual([FEATURES.SAFE_FALLBACK_HANDLER, FEATURES.ETH_SIGN])
+
+      // 1.3.0
+      expect(enabledFeatures('1.3.0')).toEqual([
+        FEATURES.SAFE_TX_GAS_OPTIONAL,
+        FEATURES.SAFE_TX_GUARDS,
+        FEATURES.SAFE_FALLBACK_HANDLER,
+        FEATURES.ETH_SIGN,
+      ])
+    })
+  })
+
+  describe('hasFeature', () => {
+    it('should return an false if the version is null', () => {
+      expect(hasFeature(FEATURES.SAFE_FALLBACK_HANDLER, null)).toEqual(false)
+    })
+
+    it('should return false if the feature is not a valid feature', () => {
+      // @ts-ignore
+      expect(hasFeature('FAKE_FEATURE', '1.0.0')).toEqual(false)
+    })
+
+    it('should return an false if the version does not support the feature', () => {
+      // 1.0.0
+      expect(hasFeature(FEATURES.ETH_SIGN, '1.0.0')).toEqual(false)
+      expect(hasFeature(FEATURES.SAFE_FALLBACK_HANDLER, '1.0.0')).toEqual(false)
+      expect(hasFeature(FEATURES.SAFE_TX_GAS_OPTIONAL, '1.0.0')).toEqual(false)
+      expect(hasFeature(FEATURES.SAFE_TX_GUARDS, '1.0.0')).toEqual(false)
+
+      // 1.1.0
+      expect(hasFeature(FEATURES.SAFE_TX_GAS_OPTIONAL, '1.1.0')).toEqual(false)
+      expect(hasFeature(FEATURES.SAFE_TX_GUARDS, '1.1.0')).toEqual(false)
+
+      // 1.1.1
+      expect(hasFeature(FEATURES.SAFE_TX_GAS_OPTIONAL, '1.1.1')).toEqual(false)
+      expect(hasFeature(FEATURES.SAFE_TX_GUARDS, '1.1.1')).toEqual(false)
+    })
+
+    it('should return true if the version supports the feature', () => {
+      // 1.1.0
+      expect(hasFeature(FEATURES.ETH_SIGN, '1.1.0')).toEqual(true)
+
+      // 1.1.1
+      expect(hasFeature(FEATURES.ETH_SIGN, '1.1.1')).toEqual(true)
+      expect(hasFeature(FEATURES.SAFE_FALLBACK_HANDLER, '1.1.1')).toEqual(true)
+
+      // 1.3.0
+      expect(hasFeature(FEATURES.ETH_SIGN, '1.3.0')).toEqual(true)
+      expect(hasFeature(FEATURES.SAFE_FALLBACK_HANDLER, '1.3.1')).toEqual(true)
+      expect(hasFeature(FEATURES.SAFE_TX_GAS_OPTIONAL, '1.3.1')).toEqual(true)
+      expect(hasFeature(FEATURES.SAFE_TX_GUARDS, '1.3.0')).toEqual(true)
+    })
+  })
+})

--- a/src/utils/safe-versions.ts
+++ b/src/utils/safe-versions.ts
@@ -1,0 +1,40 @@
+import semverSatisfies from 'semver/functions/satisfies'
+
+import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
+
+export enum FEATURES {
+  SAFE_TX_GAS_OPTIONAL = 'SAFE_TX_GAS_OPTIONAL',
+  SAFE_TX_GUARDS = 'SAFE_TX_GUARDS',
+  SAFE_FALLBACK_HANDLER = 'SAFE_FALLBACK_HANDLER',
+  ETH_SIGN = 'ETH_SIGN',
+}
+
+const FEATURES_BY_VERSION: Record<FEATURES, string> = {
+  [FEATURES.ETH_SIGN]: '>=1.1.0',
+  [FEATURES.SAFE_FALLBACK_HANDLER]: '>=1.1.1',
+  [FEATURES.SAFE_TX_GAS_OPTIONAL]: '>=1.3.0',
+  [FEATURES.SAFE_TX_GUARDS]: '>=1.3.0',
+}
+
+// Note: backend returns `SafeInfo['version']` as `null` for unsupported contracts
+
+const isEnabledByVersion = (feature: FEATURES, version: SafeInfo['version']): boolean => {
+  if (!version || !(feature in FEATURES_BY_VERSION)) {
+    return false
+  }
+  return semverSatisfies(version, FEATURES_BY_VERSION[feature])
+}
+
+export const enabledFeatures = (version: SafeInfo['version']): FEATURES[] => {
+  if (!version) {
+    return []
+  }
+  return Object.values(FEATURES).filter((feature) => isEnabledByVersion(feature, version))
+}
+
+export const hasFeature = (name: FEATURES, version: SafeInfo['version']): boolean => {
+  if (!version) {
+    return false
+  }
+  return enabledFeatures(version).includes(name)
+}


### PR DESCRIPTION
## What it solves

Resolves #1593

## How this PR fixes it

A new helper function `hasFeature` has been created to check the enabled features relevant to a Safe version. Instances where it can be used have been replaced.

## How to test it

- Ensure added guards can be seen
- Ensure v1.0.0 Safes upgrade as expected
- Ensure v1.0.0 Safes sign correctly