### PR TITLE
Fix: default wallet when none are enabled

### DIFF
--- a/src/hooks/wallets/wallets.ts
+++ b/src/hooks/wallets/wallets.ts
@@ -67,9 +67,13 @@ export const getSupportedWallets = (chain: ChainInfo): WalletInit[] => {
   if (window.Cypress && CYPRESS_MNEMONIC) {
     return [e2eWalletModule(chain.rpcUri)]
   }
-  return Object.entries(WALLET_MODULES)
-    .filter(([key]) => isWalletSupported(chain.disabledWallets, key))
-    .map(([, module]) => module())
+  const enabledWallets = Object.entries(WALLET_MODULES).filter(([key]) => isWalletSupported(chain.disabledWallets, key))
+
+  if (enabledWallets.length === 0) {
+    return [WALLET_MODULES.INJECTED()]
+  }
+
+  return enabledWallets.map(([, module]) => module())
 }
 
 export const isHardwareWallet = (wallet: ConnectedWallet): boolean => {


### PR DESCRIPTION
## What it solves

Resolves #1596

## How this PR fixes it

When all wallets are disabled, we pass an empty array to onboard, but it needs at least one wallet. So I made it return the "injected" wallet as a default.

## How to test it
Cello has currently 0 wallets enabled in the staging config.