### PR TITLE
fix: unread badge colour in dark mode

### DIFF
--- a/src/components/notification-center/NotificationCenter/styles.module.css
+++ b/src/components/notification-center/NotificationCenter/styles.module.css
@@ -46,7 +46,7 @@
   background: var(--color-secondary-light);
   border-radius: 6px;
   margin-left: 9px;
-  color: var(--color-primary-main);
+  color: var(--color-static-main);
   text-align: center;
   width: 18px;
   height: 18px;


### PR DESCRIPTION
## What it solves

Resolves unreadable unread notification number:

![image](https://user-images.githubusercontent.com/20442784/214782477-05e39a4f-c668-478a-9bb8-622284c5e9a7.png)

## How this PR fixes it

The colour of the text inside the unread notification badge has been changed to `static.main`.

## How to test it

Open a Safe that needs upgrading, then the Notification Centre. Observe that the unread badge numbes is legible in light/dark mode.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/214782375-5e4d4643-44e5-4db7-b7a8-26bbdfecc21b.png)

![image](https://user-images.githubusercontent.com/20442784/214782391-c98aac64-f516-4293-988a-babdfe3d74b0.png)