### PR TITLE
fix: migrate/sanitise legacy owner format

### DIFF
--- a/src/services/ls-migration/addedSafes.ts
+++ b/src/services/ls-migration/addedSafes.ts
@@ -1,6 +1,9 @@
 import { type AddedSafesState, type AddedSafesOnChain } from '@/store/addedSafesSlice'
 import type { LOCAL_STORAGE_DATA } from './common'
 import { parseLsValue } from './common'
+import { isChecksummedAddress } from '@/utils/addresses'
+import { isObject } from 'lodash'
+import type { AddressEx } from '@safe-global/safe-gateway-typescript-sdk'
 
 const IMMORTAL_PREFIX = '_immortal|v2_'
 
@@ -30,16 +33,24 @@ type OldAddedSafes = Record<
 
 export const migrateAddedSafesOwners = (
   owners: OldAddedSafes[string]['owners'],
-): AddedSafesState[string][string]['owners'] => {
-  return owners.map((value) => {
-    if (typeof value === 'string') {
-      return { value }
-    }
-    return {
-      value: value.address,
-      ...(value.name && { name: value.name }),
-    }
-  })
+): AddedSafesState[string][string]['owners'] | undefined => {
+  const migratedOwners = owners
+    .map((value) => {
+      if (typeof value === 'string' && isChecksummedAddress(value)) {
+        return { value }
+      }
+
+      if (isObject(value) && typeof value.address === 'string' && isChecksummedAddress(value.address)) {
+        const owner: AddressEx = {
+          value: value.address,
+          ...(typeof value.name === 'string' && { name: value.name }),
+        }
+        return owner
+      }
+    })
+    .filter((owner): owner is AddressEx => !!owner)
+
+  return migratedOwners.length > 0 ? migratedOwners : undefined
 }
 
 export const migrateAddedSafes = (lsData: LOCAL_STORAGE_DATA): AddedSafesState | void => {
@@ -53,11 +64,16 @@ export const migrateAddedSafes = (lsData: LOCAL_STORAGE_DATA): AddedSafesState |
       console.log('Migrating added safes on chain', chainId)
 
       const safesPerChain = Object.values(legacyAddedSafes).reduce<AddedSafesOnChain>((acc, oldItem) => {
-        acc[oldItem.address] = {
-          ethBalance: oldItem.ethBalance,
-          owners: migrateAddedSafesOwners(oldItem.owners),
-          threshold: oldItem.threshold,
+        const migratedOwners = migrateAddedSafesOwners(oldItem.owners)
+
+        if (migratedOwners) {
+          acc[oldItem.address] = {
+            ethBalance: oldItem.ethBalance,
+            owners: migratedOwners,
+            threshold: oldItem.threshold,
+          }
         }
+
         return acc
       }, {})
 

--- a/src/services/ls-migration/index.ts
+++ b/src/services/ls-migration/index.ts
@@ -16,7 +16,7 @@ const useStorageMigration = (): void => {
 
   useEffect(() => {
     if (isMigrationFinished) {
-      dispatch(addedSafesSlice.actions.fixOwners())
+      dispatch(addedSafesSlice.actions.fixLegacyOwners())
       return
     }
 

--- a/src/services/ls-migration/index.ts
+++ b/src/services/ls-migration/index.ts
@@ -16,7 +16,7 @@ const useStorageMigration = (): void => {
 
   useEffect(() => {
     if (isMigrationFinished) {
-      dispatch(addedSafesSlice.actions.fixLegacyOwners())
+      dispatch(addedSafesSlice.actions.migrateLegacyOwners())
       return
     }
 

--- a/src/services/ls-migration/index.ts
+++ b/src/services/ls-migration/index.ts
@@ -15,7 +15,7 @@ const useStorageMigration = (): void => {
   const [isMigrationFinished = false, setIsMigrationFinished] = useLocalStorage<boolean>(MIGRATION_KEY)
 
   useEffect(() => {
-    if (isMigrationFinished || !IS_PRODUCTION) {
+    if (isMigrationFinished) {
       dispatch(addedSafesSlice.actions.migrateLegacyOwners())
       return
     }
@@ -39,4 +39,4 @@ const useStorageMigration = (): void => {
   }, [isMigrationFinished, setIsMigrationFinished, dispatch])
 }
 
-export default useStorageMigration
+export default IS_PRODUCTION ? useStorageMigration : () => void null

--- a/src/services/ls-migration/index.ts
+++ b/src/services/ls-migration/index.ts
@@ -15,7 +15,10 @@ const useStorageMigration = (): void => {
   const [isMigrationFinished = false, setIsMigrationFinished] = useLocalStorage<boolean>(MIGRATION_KEY)
 
   useEffect(() => {
-    if (isMigrationFinished) return
+    if (isMigrationFinished) {
+      dispatch(addedSafesSlice.actions.fixOwners())
+      return
+    }
 
     const unmount = createMigrationBus((lsData: LOCAL_STORAGE_DATA) => {
       const abData = migrateAddressBook(lsData)

--- a/src/services/ls-migration/index.ts
+++ b/src/services/ls-migration/index.ts
@@ -15,7 +15,7 @@ const useStorageMigration = (): void => {
   const [isMigrationFinished = false, setIsMigrationFinished] = useLocalStorage<boolean>(MIGRATION_KEY)
 
   useEffect(() => {
-    if (isMigrationFinished) {
+    if (isMigrationFinished || !IS_PRODUCTION) {
       dispatch(addedSafesSlice.actions.migrateLegacyOwners())
       return
     }
@@ -39,4 +39,4 @@ const useStorageMigration = (): void => {
   }, [isMigrationFinished, setIsMigrationFinished, dispatch])
 }
 
-export default IS_PRODUCTION ? useStorageMigration : () => void null
+export default useStorageMigration

--- a/src/services/ls-migration/tests.test.ts
+++ b/src/services/ls-migration/tests.test.ts
@@ -128,8 +128,62 @@ describe('Local storage migration', () => {
           value: '0x9913B9180C20C6b0F21B6480c84422F6ebc4B808',
           name: 'Bob',
         },
-        { value: '0xdef' },
       ])
+    })
+
+    it('should return undefined if there are no owners', () => {
+      const newData = migrateAddedSafesOwners([])
+
+      expect(newData).toEqual(undefined)
+    })
+
+    it('should format invalid owners', () => {
+      const oldOwners = [
+        {
+          address: '0x9913B9180C20C6b0F21B6480c84422F6ebc4B808',
+          name: 'Bob',
+        },
+        {
+          address: '0x501E66bF7a8F742FA40509588eE751e93fA354Df',
+          name: 123,
+        },
+        {
+          address: 123,
+          name: 'Alice',
+        },
+        '0xdef',
+        { invalid: 'Object' },
+        null,
+        true,
+      ] as Parameters<typeof migrateAddedSafesOwners>[0]
+
+      const newData = migrateAddedSafesOwners(oldOwners)
+
+      expect(newData).toEqual([
+        {
+          value: '0x9913B9180C20C6b0F21B6480c84422F6ebc4B808',
+          name: 'Bob',
+        },
+        {
+          value: '0x501E66bF7a8F742FA40509588eE751e93fA354Df',
+        },
+      ])
+    })
+
+    it('should undefined if all owners are invalid', () => {
+      const oldOwners = [
+        {
+          address: 123,
+          name: 'Alice',
+        },
+        { invalid: 'Object' } as unknown as Parameters<typeof migrateAddedSafesOwners>[0][number],
+        null,
+        true,
+      ] as Parameters<typeof migrateAddedSafesOwners>[0]
+
+      const newData = migrateAddedSafesOwners(oldOwners)
+
+      expect(newData).toEqual(undefined)
     })
   })
 
@@ -150,6 +204,10 @@ describe('Local storage migration', () => {
           owners: [
             '0x501E66bF7a8F742FA40509588eE751e93fA354Df',
             { address: '0x9913B9180C20C6b0F21B6480c84422F6ebc4B808', name: 'Charlie' },
+            { invalid: 'Object' },
+            null,
+            true,
+            123,
           ],
           threshold: 2,
         },
@@ -205,7 +263,6 @@ describe('Local storage migration', () => {
             ethBalance: '0.00001',
             owners: [
               { value: '0x979774d85274A5F63C85786aC4Fa54B9A4f391c2' },
-              { value: '0xdef' },
               { value: '0x1F2504De05f5167650bE5B28c472601Be434b60A' },
             ],
             threshold: 2,

--- a/src/services/ls-migration/tests.test.ts
+++ b/src/services/ls-migration/tests.test.ts
@@ -1,6 +1,6 @@
 import { waitFor } from '@testing-library/react'
 import { migrateAddressBook } from './addressBook'
-import { migrateAddedSafes } from './addedSafes'
+import { migrateAddedSafes, migrateAddedSafesOwners } from './addedSafes'
 import { createIframe, sendReadyMessage, receiveMessage } from './iframe'
 
 describe('Local storage migration', () => {
@@ -97,6 +97,42 @@ describe('Local storage migration', () => {
     })
   })
 
+  describe('migratedAddedSafesOwners', () => {
+    it('should migrate the owners of the added Safes', () => {
+      const oldOwners = [
+        {
+          address: '0x1F2504De05f5167650bE5B28c472601Be434b60A',
+        },
+        {
+          address: '0x501E66bF7a8F742FA40509588eE751e93fA354Df',
+          name: 'Alice',
+        },
+        {
+          address: '0x9913B9180C20C6b0F21B6480c84422F6ebc4B808',
+          name: 'Bob',
+        },
+        '0xdef',
+      ]
+
+      const newData = migrateAddedSafesOwners(oldOwners)
+
+      expect(newData).toEqual([
+        {
+          value: '0x1F2504De05f5167650bE5B28c472601Be434b60A',
+        },
+        {
+          value: '0x501E66bF7a8F742FA40509588eE751e93fA354Df',
+          name: 'Alice',
+        },
+        {
+          value: '0x9913B9180C20C6b0F21B6480c84422F6ebc4B808',
+          name: 'Bob',
+        },
+        { value: '0xdef' },
+      ])
+    })
+  })
+
   describe('migrateAddedSafes', () => {
     const oldStorage = {
       '_immortal|v2_MAINNET__SAFES': JSON.stringify({
@@ -111,7 +147,10 @@ describe('Local storage migration', () => {
           address: '0x501E66bF7a8F742FA40509588eE751e93fA354Df',
           chainId: '1',
           ethBalance: '20.3',
-          owners: ['0x501E66bF7a8F742FA40509588eE751e93fA354Df', '0x9913B9180C20C6b0F21B6480c84422F6ebc4B808'],
+          owners: [
+            '0x501E66bF7a8F742FA40509588eE751e93fA354Df',
+            { address: '0x9913B9180C20C6b0F21B6480c84422F6ebc4B808', name: 'Charlie' },
+          ],
           threshold: 2,
         },
       }),
@@ -127,7 +166,11 @@ describe('Local storage migration', () => {
           address: '0x979774d85274A5F63C85786aC4Fa54B9A4f391c2',
           chainId: '1313161554',
           ethBalance: '0.00001',
-          owners: ['0x979774d85274A5F63C85786aC4Fa54B9A4f391c2', '0xdef', '0x1F2504De05f5167650bE5B28c472601Be434b60A'],
+          owners: [
+            '0x979774d85274A5F63C85786aC4Fa54B9A4f391c2',
+            '0xdef',
+            { address: '0x1F2504De05f5167650bE5B28c472601Be434b60A' },
+          ],
           threshold: 2,
         },
       }),
@@ -147,7 +190,7 @@ describe('Local storage migration', () => {
             ethBalance: '20.3',
             owners: [
               { value: '0x501E66bF7a8F742FA40509588eE751e93fA354Df' },
-              { value: '0x9913B9180C20C6b0F21B6480c84422F6ebc4B808' },
+              { value: '0x9913B9180C20C6b0F21B6480c84422F6ebc4B808', name: 'Charlie' },
             ],
             threshold: 2,
           },

--- a/src/store/__tests__/addedSafesSlice.test.ts
+++ b/src/store/__tests__/addedSafesSlice.test.ts
@@ -131,7 +131,7 @@ describe('addedSafesSlice', () => {
     })
   })
 
-  describe('fixLegacyOwners', () => {
+  describe('migrateLegacyOwners', () => {
     const ADDRESS_1 = hexZeroPad('0x1', 20)
     const ADDRESS_2 = hexZeroPad('0x2', 20)
 
@@ -166,7 +166,7 @@ describe('addedSafesSlice', () => {
             } as unknown as SafeInfo,
           },
         },
-        addedSafesSlice.actions.fixLegacyOwners(),
+        addedSafesSlice.actions.migrateLegacyOwners(),
       )
       expect(state).toEqual({
         '1': {
@@ -232,7 +232,7 @@ describe('addedSafesSlice', () => {
             } as unknown as SafeInfo,
           },
         },
-        addedSafesSlice.actions.fixLegacyOwners(),
+        addedSafesSlice.actions.migrateLegacyOwners(),
       )
       expect(state).toEqual({
         '1': {
@@ -294,7 +294,7 @@ describe('addedSafesSlice', () => {
             } as unknown as SafeInfo,
           },
         },
-        addedSafesSlice.actions.fixLegacyOwners(),
+        addedSafesSlice.actions.migrateLegacyOwners(),
       )
       expect(state).toEqual({
         '1': {
@@ -353,7 +353,7 @@ describe('addedSafesSlice', () => {
             } as unknown as SafeInfo,
           },
         },
-        addedSafesSlice.actions.fixLegacyOwners(),
+        addedSafesSlice.actions.migrateLegacyOwners(),
       )
 
       expect(state).toEqual({})

--- a/src/store/__tests__/addedSafesSlice.test.ts
+++ b/src/store/__tests__/addedSafesSlice.test.ts
@@ -1,189 +1,362 @@
 import type { SafeBalanceResponse, SafeInfo, TokenType } from '@safe-global/safe-gateway-typescript-sdk'
+import { hexZeroPad } from 'ethers/lib/utils'
 import type { AddedSafesState } from '../addedSafesSlice'
 import { addOrUpdateSafe, removeSafe, addedSafesSlice, updateAddedSafeBalance } from '../addedSafesSlice'
 
 describe('addedSafesSlice', () => {
-  it('should add a Safe to the store', () => {
-    const safe0 = { chainId: '1', address: { value: '0x0' }, threshold: 1, owners: [{ value: '0x123' }] } as SafeInfo
-    const state = addedSafesSlice.reducer(undefined, addOrUpdateSafe({ safe: safe0 }))
-    expect(state).toEqual({
-      '1': { ['0x0']: { owners: [{ value: '0x123' }], threshold: 1 } },
-    })
+  describe('addOrUpdateSafe', () => {
+    it('should add a Safe to the store', () => {
+      const safe0 = { chainId: '1', address: { value: '0x0' }, threshold: 1, owners: [{ value: '0x123' }] } as SafeInfo
+      const state = addedSafesSlice.reducer(undefined, addOrUpdateSafe({ safe: safe0 }))
+      expect(state).toEqual({
+        '1': { ['0x0']: { owners: [{ value: '0x123' }], threshold: 1 } },
+      })
 
-    const safe1 = { chainId: '4', address: { value: '0x1' }, threshold: 1, owners: [{ value: '0x456' }] } as SafeInfo
-    const stateB = addedSafesSlice.reducer(state, addOrUpdateSafe({ safe: safe1 }))
-    expect(stateB).toEqual({
-      '1': { ['0x0']: { owners: [{ value: '0x123' }], threshold: 1 } },
-      '4': { ['0x1']: { threshold: 1, owners: [{ value: '0x456' }] } },
-    })
+      const safe1 = { chainId: '4', address: { value: '0x1' }, threshold: 1, owners: [{ value: '0x456' }] } as SafeInfo
+      const stateB = addedSafesSlice.reducer(state, addOrUpdateSafe({ safe: safe1 }))
+      expect(stateB).toEqual({
+        '1': { ['0x0']: { owners: [{ value: '0x123' }], threshold: 1 } },
+        '4': { ['0x1']: { threshold: 1, owners: [{ value: '0x456' }] } },
+      })
 
-    const safe2 = { chainId: '1', address: { value: '0x2' }, threshold: 1, owners: [{ value: '0x789' }] } as SafeInfo
-    const stateC = addedSafesSlice.reducer(stateB, addOrUpdateSafe({ safe: safe2 }))
-    expect(stateC).toEqual({
-      '1': {
-        ['0x0']: { owners: [{ value: '0x123' }], threshold: 1 },
-        ['0x2']: { owners: [{ value: '0x789' }], threshold: 1 },
-      },
-      '4': { ['0x1']: { threshold: 1, owners: [{ value: '0x456' }] } },
-    })
-  })
-
-  it('should add the Safe balance to the store', () => {
-    const balances: SafeBalanceResponse = {
-      fiatTotal: '',
-      items: [
-        {
-          tokenInfo: {
-            type: 'NATIVE_TOKEN' as TokenType,
-            address: '',
-            decimals: 18,
-            symbol: '',
-            name: '',
-            logoUri: '',
-          },
-          balance: '8000000000000000000',
-          fiatBalance: '',
-          fiatConversion: '',
+      const safe2 = { chainId: '1', address: { value: '0x2' }, threshold: 1, owners: [{ value: '0x789' }] } as SafeInfo
+      const stateC = addedSafesSlice.reducer(stateB, addOrUpdateSafe({ safe: safe2 }))
+      expect(stateC).toEqual({
+        '1': {
+          ['0x0']: { owners: [{ value: '0x123' }], threshold: 1 },
+          ['0x2']: { owners: [{ value: '0x789' }], threshold: 1 },
         },
-        {
-          tokenInfo: {
-            type: 'ERC20' as TokenType,
-            address: '',
-            decimals: 18,
-            symbol: '',
-            name: '',
-            logoUri: '',
-          },
-          balance: '9000000000000000000',
-          fiatBalance: '',
-          fiatConversion: '',
-        },
-      ],
-    }
-    const state: AddedSafesState = {
-      '4': { ['0x1']: { threshold: 1, owners: [{ value: '0x456' }] } },
-    }
-
-    const result = addedSafesSlice.reducer(state, updateAddedSafeBalance({ chainId: '4', address: '0x1', balances }))
-    expect(result).toEqual({
-      '4': { ['0x1']: { threshold: 1, owners: [{ value: '0x456' }], ethBalance: '8' } },
+        '4': { ['0x1']: { threshold: 1, owners: [{ value: '0x456' }] } },
+      })
     })
   })
 
-  it("shouldn't add the balance if the Safe isn't added", () => {
-    const balances: SafeBalanceResponse = {
-      fiatTotal: '',
-      items: [
-        {
-          tokenInfo: {
-            type: 'NATIVE_TOKEN' as TokenType,
-            address: '',
-            decimals: 18,
-            symbol: '',
-            name: '',
-            logoUri: '',
+  describe('updateAddedSafeBalance', () => {
+    it('should add the Safe balance to the store', () => {
+      const balances: SafeBalanceResponse = {
+        fiatTotal: '',
+        items: [
+          {
+            tokenInfo: {
+              type: 'NATIVE_TOKEN' as TokenType,
+              address: '',
+              decimals: 18,
+              symbol: '',
+              name: '',
+              logoUri: '',
+            },
+            balance: '8000000000000000000',
+            fiatBalance: '',
+            fiatConversion: '',
           },
-          balance: '123',
-          fiatBalance: '',
-          fiatConversion: '',
-        },
-        {
-          tokenInfo: {
-            type: 'ERC20' as TokenType,
-            address: '',
-            decimals: 18,
-            symbol: '',
-            name: '',
-            logoUri: '',
+          {
+            tokenInfo: {
+              type: 'ERC20' as TokenType,
+              address: '',
+              decimals: 18,
+              symbol: '',
+              name: '',
+              logoUri: '',
+            },
+            balance: '9000000000000000000',
+            fiatBalance: '',
+            fiatConversion: '',
           },
-          balance: '456',
-          fiatBalance: '',
-          fiatConversion: '',
+        ],
+      }
+      const state: AddedSafesState = {
+        '4': { ['0x1']: { threshold: 1, owners: [{ value: '0x456' }] } },
+      }
+
+      const result = addedSafesSlice.reducer(state, updateAddedSafeBalance({ chainId: '4', address: '0x1', balances }))
+      expect(result).toEqual({
+        '4': { ['0x1']: { threshold: 1, owners: [{ value: '0x456' }], ethBalance: '8' } },
+      })
+    })
+
+    it("shouldn't add the balance if the Safe isn't added", () => {
+      const balances: SafeBalanceResponse = {
+        fiatTotal: '',
+        items: [
+          {
+            tokenInfo: {
+              type: 'NATIVE_TOKEN' as TokenType,
+              address: '',
+              decimals: 18,
+              symbol: '',
+              name: '',
+              logoUri: '',
+            },
+            balance: '123',
+            fiatBalance: '',
+            fiatConversion: '',
+          },
+          {
+            tokenInfo: {
+              type: 'ERC20' as TokenType,
+              address: '',
+              decimals: 18,
+              symbol: '',
+              name: '',
+              logoUri: '',
+            },
+            balance: '456',
+            fiatBalance: '',
+            fiatConversion: '',
+          },
+        ],
+      }
+      const state: AddedSafesState = {}
+
+      const result = addedSafesSlice.reducer(state, updateAddedSafeBalance({ chainId: '4', address: '0x1', balances }))
+      expect(result).toStrictEqual({})
+    })
+  })
+
+  describe('removeSafe', () => {
+    it('should remove a Safe from the store', () => {
+      const state = addedSafesSlice.reducer(
+        { '1': { ['0x0']: {} as SafeInfo, ['0x1']: {} as SafeInfo }, '4': { ['0x0']: {} as SafeInfo } },
+        removeSafe({ chainId: '1', address: '0x1' }),
+      )
+      expect(state).toEqual({ '1': { ['0x0']: {} as SafeInfo }, '4': { ['0x0']: {} as SafeInfo } })
+    })
+
+    it('should remove the chain from the store', () => {
+      const state = addedSafesSlice.reducer(
+        { '1': { ['0x0']: {} as SafeInfo }, '4': { ['0x0']: {} as SafeInfo } },
+        removeSafe({ chainId: '1', address: '0x0' }),
+      )
+      expect(state).toEqual({ '4': { ['0x0']: {} as SafeInfo } })
+    })
+  })
+
+  describe('fixLegacyOwners', () => {
+    const ADDRESS_1 = hexZeroPad('0x1', 20)
+    const ADDRESS_2 = hexZeroPad('0x2', 20)
+
+    it('should fix legacy owners', () => {
+      const state = addedSafesSlice.reducer(
+        {
+          '1': {
+            ['0x0']: {
+              owners: [
+                {
+                  value: ADDRESS_1,
+                  name: true,
+                } as unknown as SafeInfo['owners'][number],
+              ],
+            } as SafeInfo,
+            ['0x1']: {
+              owners: [
+                {
+                  value: { address: ADDRESS_1 },
+                },
+                { value: ADDRESS_2 },
+              ],
+            } as unknown as SafeInfo,
+          },
+          '4': {
+            ['0x0']: {
+              owners: [
+                {
+                  value: { address: ADDRESS_1, name: 'Test' },
+                },
+              ],
+            } as unknown as SafeInfo,
+          },
         },
-      ],
-    }
-    const state: AddedSafesState = {}
-
-    const result = addedSafesSlice.reducer(state, updateAddedSafeBalance({ chainId: '4', address: '0x1', balances }))
-    expect(result).toStrictEqual({})
-  })
-
-  it('should remove a Safe from the store', () => {
-    const state = addedSafesSlice.reducer(
-      { '1': { ['0x0']: {} as SafeInfo, ['0x1']: {} as SafeInfo }, '4': { ['0x0']: {} as SafeInfo } },
-      removeSafe({ chainId: '1', address: '0x1' }),
-    )
-    expect(state).toEqual({ '1': { ['0x0']: {} as SafeInfo }, '4': { ['0x0']: {} as SafeInfo } })
-  })
-
-  it('should remove the chain from the store', () => {
-    const state = addedSafesSlice.reducer(
-      { '1': { ['0x0']: {} as SafeInfo }, '4': { ['0x0']: {} as SafeInfo } },
-      removeSafe({ chainId: '1', address: '0x0' }),
-    )
-    expect(state).toEqual({ '4': { ['0x0']: {} as SafeInfo } })
-  })
-
-  it('should fix corrupt owners', () => {
-    const state = addedSafesSlice.reducer(
-      {
+        addedSafesSlice.actions.fixLegacyOwners(),
+      )
+      expect(state).toEqual({
         '1': {
           ['0x0']: {
             owners: [
               {
-                value: '0x123',
+                value: ADDRESS_1,
               },
             ],
           } as SafeInfo,
           ['0x1']: {
             owners: [
               {
-                value: { address: '0x123' },
+                value: ADDRESS_1,
               },
-              { value: '0x456' },
+              { value: ADDRESS_2 },
             ],
-          } as unknown as SafeInfo,
+          } as SafeInfo,
         },
         '4': {
           ['0x0']: {
             owners: [
               {
-                value: { address: '0x123', name: 'Test' },
+                value: ADDRESS_1,
+                name: 'Test',
               },
             ],
-          } as unknown as SafeInfo,
+          } as SafeInfo,
         },
-      },
-      addedSafesSlice.actions.fixOwners(),
-    )
-    expect(state).toEqual({
-      '1': {
-        ['0x0']: {
-          owners: [
-            {
-              value: '0x123',
-            },
-          ],
-        } as SafeInfo,
-        ['0x1']: {
-          owners: [
-            {
-              value: '0x123',
-            },
-            { value: '0x456' },
-          ],
-        } as SafeInfo,
-      },
-      '4': {
-        ['0x0']: {
-          owners: [
-            {
-              value: '0x123',
-              name: 'Test',
-            },
-          ],
-        } as SafeInfo,
-      },
+      })
+    })
+
+    it('should remove corrupt owners', () => {
+      const state = addedSafesSlice.reducer(
+        {
+          '1': {
+            ['0x0']: {
+              owners: [
+                {
+                  value: ADDRESS_1,
+                },
+              ],
+            } as SafeInfo,
+            ['0x1']: {
+              owners: [
+                {
+                  value: { address: true },
+                },
+                { value: ADDRESS_2 },
+              ],
+            } as unknown as SafeInfo,
+          },
+          '4': {
+            ['0x0']: {
+              owners: [
+                {
+                  value: { address: ADDRESS_1, name: 'Test' },
+                },
+                {
+                  value: { address: null, name: 'Test' } as unknown as SafeInfo['owners'][number],
+                },
+              ],
+            } as unknown as SafeInfo,
+          },
+        },
+        addedSafesSlice.actions.fixLegacyOwners(),
+      )
+      expect(state).toEqual({
+        '1': {
+          ['0x0']: {
+            owners: [
+              {
+                value: ADDRESS_1,
+              },
+            ],
+          } as SafeInfo,
+          ['0x1']: {
+            owners: [{ value: ADDRESS_2 }],
+          } as SafeInfo,
+        },
+        '4': {
+          ['0x0']: {
+            owners: [
+              {
+                name: 'Test',
+                value: ADDRESS_1,
+              },
+            ],
+          } as SafeInfo,
+        },
+      })
+    })
+
+    it('should remove added Safe if all owners are corrupt', () => {
+      const state = addedSafesSlice.reducer(
+        {
+          '1': {
+            ['0x0']: {
+              owners: [
+                {
+                  value: ADDRESS_1,
+                },
+              ],
+            } as SafeInfo,
+            ['0x1']: {
+              owners: [
+                {
+                  value: { address: 123 },
+                },
+                { value: null },
+                { value: '0x123' },
+              ],
+            } as unknown as SafeInfo,
+          },
+          '4': {
+            ['0x0']: {
+              owners: [
+                {
+                  value: {
+                    address: ADDRESS_1,
+                    name: 'Test',
+                  },
+                },
+              ],
+            } as unknown as SafeInfo,
+          },
+        },
+        addedSafesSlice.actions.fixLegacyOwners(),
+      )
+      expect(state).toEqual({
+        '1': {
+          ['0x0']: {
+            owners: [
+              {
+                value: ADDRESS_1,
+              },
+            ],
+          } as SafeInfo,
+        },
+        '4': {
+          ['0x0']: {
+            owners: [
+              {
+                value: ADDRESS_1,
+                name: 'Test',
+              },
+            ],
+          } as SafeInfo,
+        },
+      })
+    })
+
+    it('should remove the chain if all Safes are removed due to all corrupt owners', () => {
+      const state = addedSafesSlice.reducer(
+        {
+          '1': {
+            ['0x0']: {
+              owners: [
+                {
+                  value: 1234,
+                } as unknown as SafeInfo['owners'][number],
+              ],
+            } as SafeInfo,
+            ['0x1']: {
+              owners: [
+                {
+                  value: { address: 123 },
+                },
+                { value: null },
+                { value: '0x123' },
+              ],
+            } as unknown as SafeInfo,
+          },
+          '4': {
+            ['0x0']: {
+              owners: [
+                {
+                  value: {
+                    address: true,
+                    name: 'Test',
+                  },
+                },
+              ],
+            } as unknown as SafeInfo,
+          },
+        },
+        addedSafesSlice.actions.fixLegacyOwners(),
+      )
+
+      expect(state).toEqual({})
     })
   })
 })

--- a/src/store/__tests__/addedSafesSlice.test.ts
+++ b/src/store/__tests__/addedSafesSlice.test.ts
@@ -123,4 +123,67 @@ describe('addedSafesSlice', () => {
     )
     expect(state).toEqual({ '4': { ['0x0']: {} as SafeInfo } })
   })
+
+  it('should fix corrupt owners', () => {
+    const state = addedSafesSlice.reducer(
+      {
+        '1': {
+          ['0x0']: {
+            owners: [
+              {
+                value: '0x123',
+              },
+            ],
+          } as SafeInfo,
+          ['0x1']: {
+            owners: [
+              {
+                value: { address: '0x123' },
+              },
+              { value: '0x456' },
+            ],
+          } as unknown as SafeInfo,
+        },
+        '4': {
+          ['0x0']: {
+            owners: [
+              {
+                value: { address: '0x123', name: 'Test' },
+              },
+            ],
+          } as unknown as SafeInfo,
+        },
+      },
+      addedSafesSlice.actions.fixOwners(),
+    )
+    expect(state).toEqual({
+      '1': {
+        ['0x0']: {
+          owners: [
+            {
+              value: '0x123',
+            },
+          ],
+        } as SafeInfo,
+        ['0x1']: {
+          owners: [
+            {
+              value: '0x123',
+            },
+            { value: '0x456' },
+          ],
+        } as SafeInfo,
+      },
+      '4': {
+        ['0x0']: {
+          owners: [
+            {
+              value: '0x123',
+              name: 'Test',
+            },
+          ],
+        } as SafeInfo,
+      },
+    })
+  })
 })

--- a/src/store/addedSafesSlice.ts
+++ b/src/store/addedSafesSlice.ts
@@ -42,8 +42,7 @@ export const addedSafesSlice = createSlice({
         for (const [safeAddress, safe] of Object.entries(addedSafesOnChain)) {
           // Previously migrated corrupt owners in { address: string, value: string } format
           if (safe.owners.some(({ value }) => value !== 'string')) {
-            // @ts-expect-error
-            state[chainId][safeAddress].owners = migrateAddedSafesOwners(safe.owners)
+            state[chainId][safeAddress].owners = migrateAddedSafesOwners(safe.owners.map(({ value }) => value))
           }
         }
       }

--- a/src/store/addedSafesSlice.ts
+++ b/src/store/addedSafesSlice.ts
@@ -37,7 +37,7 @@ export const addedSafesSlice = createSlice({
       // Otherwise, migrate
       return action.payload
     },
-    fixLegacyOwners: (state) => {
+    migrateLegacyOwners: (state) => {
       for (const [chainId, addedSafesOnChain] of Object.entries(state)) {
         for (const [safeAddress, safe] of Object.entries(addedSafesOnChain)) {
           // Previously migrated corrupt owners


### PR DESCRIPTION
## What it solves

Resolves #1603 

## How this PR fixes it

Legacy added Safe owner formats (from the original address book) are now migrated correctly and sanitised post-corrupt migration.

The original address book format alteration can be found [here](https://github.com/safe-global/safe-react/pull/2296/files#diff-bd2bbcb55c5dde038dc34315180a7f921a4df36bd925a72a39c8ffd33676392a):

![image](https://user-images.githubusercontent.com/20442784/215033071-82ee7e4f-654a-4e4b-9a0a-a18fbf7abc10.png)

## How to test it

1. Modify added Safe `localStorage` on `safe-react` to have `owners` as `Array<{ address: string, name: string }>` and reattempt migration. Observe no crashing when opening the sidebar in `web-core`.
2. Modify added Safe `localStorage` on `web-core` to have `owners` as `Array<{value: { address: string, name: string }}>` and refresh. Observe no crashing when opening the sidebar.