### PR TITLE
fix: balances loading flag

### DIFF
--- a/src/components/dashboard/Overview/Overview.tsx
+++ b/src/components/dashboard/Overview/Overview.tsx
@@ -83,7 +83,7 @@ const Overview = (): ReactElement => {
   const router = useRouter()
   const safeAddress = useSafeAddress()
   const { safe, safeLoading, safeLoaded } = useSafeInfo()
-  const { balances } = useVisibleBalances()
+  const { balances, loading: balancesLoading } = useVisibleBalances()
   const [nfts] = useCollectibles()
   const chain = useCurrentChain()
   const { chainId } = chain || {}
@@ -139,7 +139,7 @@ const Overview = (): ReactElement => {
                     <Typography color="border.main" variant="body2">
                       Tokens
                     </Typography>
-                    <StyledText fontSize="lg">{tokenCount || <ValueSkeleton />}</StyledText>
+                    <StyledText fontSize="lg">{balancesLoading ? <ValueSkeleton /> : tokenCount}</StyledText>
                   </a>
                 </Link>
               </Grid>

--- a/src/hooks/useBalances.ts
+++ b/src/hooks/useBalances.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import isEqual from 'lodash/isEqual'
 import { type SafeBalanceResponse } from '@safe-global/safe-gateway-typescript-sdk'
 import { useAppSelector } from '@/store'
-import { selectBalances } from '@/store/balancesSlice'
+import { initialBalancesState, selectBalances } from '@/store/balancesSlice'
 
 const useBalances = (): {
   balances: SafeBalanceResponse
@@ -16,7 +16,7 @@ const useBalances = (): {
     () => ({
       balances: data,
       error,
-      loading,
+      loading: loading || initialBalancesState === data,
     }),
     [data, error, loading],
   )

--- a/src/store/balancesSlice.ts
+++ b/src/store/balancesSlice.ts
@@ -2,12 +2,12 @@ import { type TokenInfo, type SafeBalanceResponse } from '@safe-global/safe-gate
 import { createSelector } from '@reduxjs/toolkit'
 import { makeLoadableSlice } from './common'
 
-const initialState: SafeBalanceResponse = {
+export const initialBalancesState: SafeBalanceResponse = {
   items: [],
   fiatTotal: '',
 }
 
-const { slice, selector } = makeLoadableSlice('balances', initialState)
+const { slice, selector } = makeLoadableSlice('balances', initialBalancesState)
 
 export const balancesSlice = slice
 export const selectBalances = selector


### PR DESCRIPTION
## What it solves

Resolves #1607

## How this PR fixes it

The balances `loading` flag now checks the reference equality of the initial state.

## How to test it

1. Open a Safe with multiple tokens and observe that the "Tokens" amount on the dashboard switches from the loading skeleton to the number of tokens owned.
2. Navigate to the assets page and hide all tokens then back to the dashboard and refresh. Observe that the "Tokens" amount changes from the loading skeleton to 0.
3. Switch to a Safe that has fewer tokens (hidden token amount is higher). Observe that the the loading skeleton switches from loading skeleton to 0.

Varing amounts of hidden tokens should no make the loading skeleton change to 0 to n. It should always change from the skeleton to the amount of tokens not hidden.

## Screenshots

![hidden-tokens](https://user-images.githubusercontent.com/20442784/215434980-d43a90bd-fde6-4218-a90b-bcbe8b062fe5.gif)