### PR TITLE
fix: Only use multisend call if its more than 1 transaction

### DIFF
--- a/src/components/safe-apps/SafeAppsTxModal/ReviewSafeAppsTx.tsx
+++ b/src/components/safe-apps/SafeAppsTxModal/ReviewSafeAppsTx.tsx
@@ -27,7 +27,7 @@ type ReviewSafeAppsTxProps = {
 const ReviewSafeAppsTx = ({
   safeAppsTx: { txs, requestId, params, appId, app },
 }: ReviewSafeAppsTxProps): ReactElement => {
-  const { createMultiSendCallOnlyTx, dispatchSafeAppsTx } = useTxSender()
+  const { createMultiSendCallOnlyTx, dispatchSafeAppsTx, createTx } = useTxSender()
   const chainId = useChainId()
   const chain = useCurrentChain()
   const [submitError, setSubmitError] = useState<Error>()
@@ -35,7 +35,7 @@ const ReviewSafeAppsTx = ({
   const isMultiSend = txs.length > 1
 
   const [safeTx, safeTxError] = useAsync<SafeTransaction | undefined>(async () => {
-    const tx = await createMultiSendCallOnlyTx(txs)
+    const tx = isMultiSend ? await createMultiSendCallOnlyTx(txs) : await createTx(txs[0])
 
     if (params?.safeTxGas) {
       // FIXME: do it properly via the Core SDK


### PR DESCRIPTION
## What it solves

Resolves #1536 

Note: Somehow the Tenderly simulation shows success but I think its a general issue with 1.1.1 Safe contracts that the simulation doesn't propagate if the call was reverted so Tenderly still returns "Success". I think its unrelated to this issue and would fix it seperately.

## How this PR fixes it

Checks the number of transactions that are submitted through safe apps and calls `createMultiSendCallOnlyTx` or `createTx`. Previously it would try to call `createMultiSendCallOnlyTx` but without passing any `safeTxGas` which caused it to fail because the logic inside `safe-core-sdk` falls back to creating a single safe transaction if the array only contains one transaction so we should also handle that case on our side.

## How to test it

1. Open a 1.1.1 Safe
2. Open the TxBuilder safe app
3. Create and batch **one** transaction that would fail/revert e.g. by interacting with 0x22e3f828b3f47dacfacd875d20bd5cc0879c96e7 on mainnet
4. Observe the Submit button being enabled
5. Batch more than one transaction through safe apps in 1.1.1 and 1.3.0 safes and observe being able to queue/execute the tx

## Screenshots
<img width="638" alt="Screenshot 2023-01-30 at 16 44 48" src="https://user-images.githubusercontent.com/5880855/215523995-69b62b6b-0b7f-4609-8557-eed68beaf7cf.png">
