### PR TITLE
fix: fetch queue when Safe list item is visible

### DIFF
--- a/src/components/common/InfiniteScroll/index.tsx
+++ b/src/components/common/InfiniteScroll/index.tsx
@@ -1,28 +1,5 @@
-import { type MutableRefObject, useEffect, useRef, useState, type ReactElement, useCallback } from 'react'
-
-const useIntersectionObserver = (element: MutableRefObject<HTMLElement | null>): boolean => {
-  const [isIntersecting, setIsIntersecting] = useState<boolean>(false)
-  const observer = useRef<IntersectionObserver | undefined>()
-
-  const callback = useCallback(([entry]: IntersectionObserverEntry[]) => {
-    setIsIntersecting(entry.isIntersecting)
-  }, [])
-
-  useEffect(() => {
-    if (element.current) {
-      observer.current = new IntersectionObserver(callback)
-
-      observer.current.observe(element.current)
-    }
-
-    return () => {
-      observer.current?.disconnect()
-      observer.current = undefined
-    }
-  }, [callback, element])
-
-  return isIntersecting
-}
+import { useEffect, useRef, type ReactElement } from 'react'
+import useIntersectionObserver from '@/hooks/useIntersectionObserver'
 
 const InfiniteScroll = ({ onLoadMore }: { onLoadMore: () => void }): ReactElement => {
   const elementRef = useRef<HTMLDivElement | null>(null)

--- a/src/components/sidebar/SafeListItem/index.tsx
+++ b/src/components/sidebar/SafeListItem/index.tsx
@@ -21,6 +21,7 @@ import EthHashInfo from '@/components/common/EthHashInfo'
 import { sameAddress } from '@/utils/addresses'
 import PendingActionButtons from '@/components/sidebar/PendingActions'
 import usePendingActions from '@/hooks/usePendingActions'
+import useIntersectionObserver from '@/hooks/useIntersectionObserver'
 
 const SafeListItem = ({
   address,
@@ -48,7 +49,8 @@ const SafeListItem = ({
   const isCurrentSafe = chainId === currChainId && sameAddress(safeAddress, address)
   const name = allAddressBooks[chainId]?.[address]
   const shortName = chain?.shortName || ''
-  const { totalQueued, totalToSign } = usePendingActions(chainId, isAdded ? address : undefined)
+  const isVisible = useIntersectionObserver(safeRef)
+  const { totalQueued, totalToSign } = usePendingActions(chainId, isVisible, isAdded ? address : undefined)
 
   // Scroll to the current Safe
   useEffect(() => {

--- a/src/components/sidebar/SafeListItem/index.tsx
+++ b/src/components/sidebar/SafeListItem/index.tsx
@@ -50,7 +50,7 @@ const SafeListItem = ({
   const name = allAddressBooks[chainId]?.[address]
   const shortName = chain?.shortName || ''
   const isVisible = useIntersectionObserver(safeRef)
-  const { totalQueued, totalToSign } = usePendingActions(chainId, isVisible, isAdded ? address : undefined)
+  const { totalQueued, totalToSign } = usePendingActions(chainId, isAdded && isVisible ? address : undefined)
 
   // Scroll to the current Safe
   useEffect(() => {

--- a/src/hooks/__tests__/usePendingActions.test.ts
+++ b/src/hooks/__tests__/usePendingActions.test.ts
@@ -34,7 +34,7 @@ describe('usePendingActions hook', () => {
       results: [],
     })
 
-    const { result } = renderHook(() => usePendingActions(chainId, true, safeAddress))
+    const { result } = renderHook(() => usePendingActions(chainId, safeAddress))
     expect(result.current).toEqual({ totalQueued: '', totalToSign: '' })
   })
 
@@ -64,7 +64,7 @@ describe('usePendingActions hook', () => {
     }
     jest.spyOn(useTxQueue, 'default').mockReturnValue(mockPage)
 
-    const { result } = renderHook(() => usePendingActions(chainId, true, safeAddress))
+    const { result } = renderHook(() => usePendingActions(chainId, safeAddress))
     expect(result.current).toEqual({ totalQueued: '', totalToSign: '' })
   })
 
@@ -131,7 +131,7 @@ describe('usePendingActions hook', () => {
     const chainId = '5'
     const safeAddress = hexZeroPad('0x1', 20)
 
-    const { result } = renderHook(() => usePendingActions(chainId, true, safeAddress))
+    const { result } = renderHook(() => usePendingActions(chainId, safeAddress))
 
     await waitFor(() => {
       expect(result.current).toEqual({ totalQueued: '2', totalToSign: '1' })
@@ -194,7 +194,7 @@ describe('usePendingActions hook', () => {
 
     const chainId = '5'
 
-    const { result } = renderHook(() => usePendingActions(chainId, true, safeAddress))
+    const { result } = renderHook(() => usePendingActions(chainId, safeAddress))
 
     await waitFor(() => {
       expect(result.current).toEqual({ totalQueued: '1', totalToSign: '1' })

--- a/src/hooks/__tests__/usePendingActions.test.ts
+++ b/src/hooks/__tests__/usePendingActions.test.ts
@@ -34,7 +34,7 @@ describe('usePendingActions hook', () => {
       results: [],
     })
 
-    const { result } = renderHook(() => usePendingActions(chainId, safeAddress))
+    const { result } = renderHook(() => usePendingActions(chainId, true, safeAddress))
     expect(result.current).toEqual({ totalQueued: '', totalToSign: '' })
   })
 
@@ -64,7 +64,7 @@ describe('usePendingActions hook', () => {
     }
     jest.spyOn(useTxQueue, 'default').mockReturnValue(mockPage)
 
-    const { result } = renderHook(() => usePendingActions(chainId, safeAddress))
+    const { result } = renderHook(() => usePendingActions(chainId, true, safeAddress))
     expect(result.current).toEqual({ totalQueued: '', totalToSign: '' })
   })
 
@@ -131,7 +131,7 @@ describe('usePendingActions hook', () => {
     const chainId = '5'
     const safeAddress = hexZeroPad('0x1', 20)
 
-    const { result } = renderHook(() => usePendingActions(chainId, safeAddress))
+    const { result } = renderHook(() => usePendingActions(chainId, true, safeAddress))
 
     await waitFor(() => {
       expect(result.current).toEqual({ totalQueued: '2', totalToSign: '1' })
@@ -194,7 +194,7 @@ describe('usePendingActions hook', () => {
 
     const chainId = '5'
 
-    const { result } = renderHook(() => usePendingActions(chainId, safeAddress))
+    const { result } = renderHook(() => usePendingActions(chainId, true, safeAddress))
 
     await waitFor(() => {
       expect(result.current).toEqual({ totalQueued: '1', totalToSign: '1' })

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,27 @@
+import { type MutableRefObject, useEffect, useRef, useState, useCallback } from 'react'
+
+const useIntersectionObserver = (element: MutableRefObject<HTMLElement | null>): boolean => {
+  const [isIntersecting, setIsIntersecting] = useState<boolean>(false)
+  const observer = useRef<IntersectionObserver | undefined>()
+
+  const callback = useCallback(([entry]: IntersectionObserverEntry[]) => {
+    setIsIntersecting(entry.isIntersecting)
+  }, [])
+
+  useEffect(() => {
+    if (element.current) {
+      observer.current = new IntersectionObserver(callback)
+
+      observer.current.observe(element.current)
+    }
+
+    return () => {
+      observer.current?.disconnect()
+      observer.current = undefined
+    }
+  }, [callback, element])
+
+  return isIntersecting
+}
+
+export default useIntersectionObserver

--- a/src/hooks/usePendingActions.ts
+++ b/src/hooks/usePendingActions.ts
@@ -17,16 +17,16 @@ const getSignableCount = (queue: TransactionListPage, walletAddress: string): nu
   return queue.results.filter((tx) => isTransactionListItem(tx) && isSignableBy(tx.transaction, walletAddress)).length
 }
 
-const usePendingActions = (chainId: string, isVisible: boolean, safeAddress?: string): PendingActions => {
+const usePendingActions = (chainId: string, safeAddress?: string): PendingActions => {
   const wallet = useWallet()
   const { safeAddress: currentSafeAddress } = useSafeInfo()
   const { page: currentSafeQueue } = useTxQueue()
   const isCurrentSafe = currentSafeAddress === safeAddress
 
   const [loadedQueue] = useAsync<TransactionListPage>(() => {
-    if (isCurrentSafe || !safeAddress || !isVisible) return
+    if (isCurrentSafe || !safeAddress) return
     return getTransactionQueue(chainId, safeAddress)
-  }, [chainId, safeAddress, isCurrentSafe, isVisible])
+  }, [chainId, safeAddress, isCurrentSafe])
 
   const queue = isCurrentSafe ? currentSafeQueue : loadedQueue
 

--- a/src/hooks/usePendingActions.ts
+++ b/src/hooks/usePendingActions.ts
@@ -24,7 +24,7 @@ const usePendingActions = (chainId: string, safeAddress?: string): PendingAction
   const isCurrentSafe = currentSafeAddress === safeAddress
   const cachedQueue = useRef<Promise<TransactionListPage>>()
 
-  const [loadedQueue] = useAsync<TransactionListPage | undefined>(() => {
+  const [loadedQueue] = useAsync<TransactionListPage>(() => {
     if (isCurrentSafe || !safeAddress) return
 
     if (!cachedQueue.current) {

--- a/src/hooks/usePendingActions.ts
+++ b/src/hooks/usePendingActions.ts
@@ -22,19 +22,16 @@ const usePendingActions = (chainId: string, safeAddress?: string): PendingAction
   const { safeAddress: currentSafeAddress } = useSafeInfo()
   const { page: currentSafeQueue } = useTxQueue()
   const isCurrentSafe = currentSafeAddress === safeAddress
-  const cachedQueue = useRef<TransactionListPage>()
+  const cachedQueue = useRef<Promise<TransactionListPage>>()
 
-  const [loadedQueue] = useAsync<TransactionListPage | undefined>(async () => {
+  const [loadedQueue] = useAsync<TransactionListPage | undefined>(() => {
     if (isCurrentSafe || !safeAddress) return
 
-    if (cachedQueue.current) {
-      return cachedQueue.current
+    if (!cachedQueue.current) {
+      cachedQueue.current = getTransactionQueue(chainId, safeAddress)
     }
 
-    const fetchedQueue = await getTransactionQueue(chainId, safeAddress)
-    cachedQueue.current = fetchedQueue
-
-    return fetchedQueue
+    return cachedQueue.current
   }, [chainId, safeAddress, isCurrentSafe])
 
   const queue = isCurrentSafe ? currentSafeQueue : loadedQueue

--- a/src/hooks/usePendingActions.ts
+++ b/src/hooks/usePendingActions.ts
@@ -17,16 +17,16 @@ const getSignableCount = (queue: TransactionListPage, walletAddress: string): nu
   return queue.results.filter((tx) => isTransactionListItem(tx) && isSignableBy(tx.transaction, walletAddress)).length
 }
 
-const usePendingActions = (chainId: string, safeAddress?: string): PendingActions => {
+const usePendingActions = (chainId: string, isVisible: boolean, safeAddress?: string): PendingActions => {
   const wallet = useWallet()
   const { safeAddress: currentSafeAddress } = useSafeInfo()
   const { page: currentSafeQueue } = useTxQueue()
   const isCurrentSafe = currentSafeAddress === safeAddress
 
   const [loadedQueue] = useAsync<TransactionListPage>(() => {
-    if (isCurrentSafe || !safeAddress) return
+    if (isCurrentSafe || !safeAddress || !isVisible) return
     return getTransactionQueue(chainId, safeAddress)
-  }, [chainId, safeAddress, isCurrentSafe])
+  }, [chainId, safeAddress, isCurrentSafe, isVisible])
 
   const queue = isCurrentSafe ? currentSafeQueue : loadedQueue
 


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/web-core/issues/1610

## How this PR fixes it
Uses `IntersectionObserver` to assert that the SafeListItem is in the viewport before sending a API request

## How to test it
On adjusting the application viewport, the `transactions/queued` network requests should equal the number of Safes visible in the Safe list sidebar

## Screenshots
<img width="1249" alt="Screenshot 2023-01-31 at 11 18 08" src="https://user-images.githubusercontent.com/32431609/215732894-04a3681a-568d-4150-9401-c4c1d74f477b.png">
