### PR TITLE
test: non-owner spending limit beneficiary

### DIFF
--- a/cypress/e2e/non_owner_spending_limit.cy.js
+++ b/cypress/e2e/non_owner_spending_limit.cy.js
@@ -1,7 +1,7 @@
 const HW_WALLET = '0xff6E053fBf4E5895eDec09146Bc10f705E8c4b3D'
-const SPENDING_LIMIT_SAFE = 'gor:0x28F95E682D1dd632b54Dc61740575f49DB39Eb7F'
+const SPENDING_LIMIT_SAFE = 'gor:0xBE3C5aFF7f66c23fe71c3047911f9Aa0026b281B'
 
-describe('Check spending limit modal', () => {
+describe('Check non-owner spending limit beneficiary modal', () => {
   before(() => {
     cy.connectE2EWallet()
 
@@ -34,7 +34,7 @@ describe('Check spending limit modal', () => {
     cy.get('ul[role="listbox"]').contains('Görli Ether').click()
 
     // Insert max amount
-    cy.contains('Spending Limit Transaction (0.1 GOR)').click()
+    cy.contains('Spending Limit Transaction (100 GOR)').click()
 
     // Insert max amount
     cy.contains('Max').click()


### PR DESCRIPTION
## What it solves

Adds a test for non-owner spending limit beneficiaries (https://github.com/safe-global/web-core/pull/1572).

## How this PR fixes it

An E2E test has been added that checks whether the "New transaction" button is enabled and the transaction creation modal flow is accessible/submittable for non-owner spending limit beneficiaries.

## How to test it

Run Cypress locally and execute the `non_owner_spending_limit.cy.js` test.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/215734517-e73edf67-af18-4d44-9caa-3cbdcc38960c.png)