### PR TITLE
Fix: nft page mobile layout

### DIFF
--- a/src/components/nfts/NftGrid/index.tsx
+++ b/src/components/nfts/NftGrid/index.tsx
@@ -115,7 +115,7 @@ const NftGrid = ({ nfts, selectedNfts, isLoading, children, onSelect }: NftsTabl
                   align="left"
                   padding="normal"
                   sx={{
-                    display: headCell.xsHidden ? { xs: 'none', md: 'table-cell' } : undefined,
+                    display: headCell.xsHidden ? { xs: 'none', sm: 'table-cell' } : undefined,
                     width: headCell.width,
                   }}
                 >
@@ -183,7 +183,7 @@ const NftGrid = ({ nfts, selectedNfts, isLoading, children, onSelect }: NftsTabl
                 </TableCell>
 
                 {/* Links */}
-                <TableCell sx={{ display: { xs: 'none', md: 'table-cell' } }}>
+                <TableCell sx={{ display: { xs: 'none', sm: 'table-cell' } }}>
                   <Box display="flex" alignItems="center" alignContent="center" gap={2.5}>
                     {linkTemplates?.map(({ title, logo, getUrl }) => (
                       <ExternalLink href={getUrl(item)} key={title} onClick={stopPropagation} noIcon>
@@ -210,7 +210,7 @@ const NftGrid = ({ nfts, selectedNfts, isLoading, children, onSelect }: NftsTabl
                   {headCells.map((headCell) => (
                     <TableCell
                       key={headCell.id}
-                      sx={headCell.xsHidden ? { display: { xs: 'none', md: 'table-cell' } } : undefined}
+                      sx={headCell.xsHidden ? { display: { xs: 'none', sm: 'table-cell' } } : undefined}
                     >
                       <Box height="42px" width="42px" />
                     </TableCell>
@@ -225,7 +225,7 @@ const NftGrid = ({ nfts, selectedNfts, isLoading, children, onSelect }: NftsTabl
                   {headCells.map((headCell) => (
                     <TableCell
                       key={headCell.id}
-                      sx={headCell.xsHidden ? { display: { xs: 'none', md: 'table-cell' } } : undefined}
+                      sx={headCell.xsHidden ? { display: { xs: 'none', sm: 'table-cell' } } : undefined}
                     >
                       <Skeleton variant="rounded" height="30px" sx={{ my: '6px' }} width="100%" />
                     </TableCell>

--- a/src/components/nfts/NftSendForm/index.tsx
+++ b/src/components/nfts/NftSendForm/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react'
-import { Box, Button, SvgIcon, Typography } from '@mui/material'
+import { Box, Button, Grid, SvgIcon, Typography } from '@mui/material'
 import ArrowIcon from '@/public/images/common/arrow-nw.svg'
 import type { SafeCollectibleResponse } from '@safe-global/safe-gateway-typescript-sdk'
 import Track from '@/components/common/Track'
@@ -13,7 +13,7 @@ type NftSendFormProps = {
 
 const stickyTop = { xs: '103px', md: '111px' }
 const Sticky = ({ children }: { children: ReactElement }): ReactElement => (
-  <Box position="sticky" zIndex="1" top={stickyTop} py={1} bgcolor="background.main">
+  <Box position="sticky" zIndex="1" top={stickyTop} py={1} bgcolor="background.main" mt={-1} mb={1}>
     {children}
   </Box>
 )
@@ -25,44 +25,50 @@ const NftSendForm = ({ selectedNfts, onSelectAll }: NftSendFormProps): ReactElem
 
   return (
     <Sticky>
-      <Box display="flex" alignItems="center" gap={1}>
-        <Box bgcolor="secondary.background" py={0.75} px={2} flex={1} borderRadius={1} mr={2}>
-          <Box display="flex" alignItems="center" gap={1.5}>
-            <SvgIcon component={ArrowIcon} inheritViewBox color="border" sx={{ width: 12, height: 12 }} />
+      <Grid container spacing={1} justifyContent="flex-end" alignItems="center">
+        <Grid item display={['none', 'block']} flex="1">
+          <Box bgcolor="secondary.background" py={0.75} px={2} flex={1} borderRadius={1} mr={1}>
+            <Box display="flex" alignItems="center" gap={1.5}>
+              <SvgIcon component={ArrowIcon} inheritViewBox color="border" sx={{ width: 12, height: 12 }} />
 
-            <Typography variant="body2" lineHeight="inherit">
-              {`${selectedNfts.length} ${nftsText} selected`}
-            </Typography>
+              <Typography variant="body2" lineHeight="inherit">
+                {`${selectedNfts.length} ${nftsText} selected`}
+              </Typography>
+            </Box>
           </Box>
-        </Box>
+        </Grid>
 
-        <Button
-          onClick={onSelectAll}
-          variant="outlined"
-          size="small"
-          sx={{
-            // The custom padding is needed to align the outlined button with the adjacent filled button
-            py: '6px',
-            minWidth: '10em',
-          }}
-        >
-          {noSelected ? 'Select all' : 'Deselect all'}
-        </Button>
-
-        <Track {...NFT_EVENTS.SEND} label={selectedNfts.length}>
+        <Grid item>
           <Button
-            type="submit"
-            variant="contained"
+            onClick={onSelectAll}
+            variant="outlined"
             size="small"
-            disabled={!isGranted || noSelected}
             sx={{
+              // The custom padding is needed to align the outlined button with the adjacent filled button
+              py: '6px',
               minWidth: '10em',
             }}
           >
-            {!isGranted ? 'Read only' : selectedNfts.length ? `Send ${selectedNfts.length} ${nftsText}` : 'Send'}
+            {noSelected ? 'Select all' : 'Deselect all'}
           </Button>
-        </Track>
-      </Box>
+        </Grid>
+
+        <Grid item>
+          <Track {...NFT_EVENTS.SEND} label={selectedNfts.length}>
+            <Button
+              type="submit"
+              variant="contained"
+              size="small"
+              disabled={!isGranted || noSelected}
+              sx={{
+                minWidth: '10em',
+              }}
+            >
+              {noSelected ? 'Send' : `Send ${selectedNfts.length} ${nftsText}`}
+            </Button>
+          </Track>
+        </Grid>
+      </Grid>
     </Sticky>
   )
 }

--- a/src/pages/balances/nfts.tsx
+++ b/src/pages/balances/nfts.tsx
@@ -18,13 +18,13 @@ const NftApps = memo(function NftApps(): ReactElement | null {
 
   return (
     <>
-      <Typography component="h2" variant="subtitle1" fontWeight={700} mb={2} mt={0.3}>
+      <Typography component="h2" variant="subtitle1" fontWeight={700} mb={2} mt={0.6}>
         NFT Safe Apps
       </Typography>
 
       <Grid container spacing={3}>
         {nftApps.map((nftApp) => (
-          <Grid item xs={12} lg={12} md={4} key={nftApp.id}>
+          <Grid item lg={12} md={4} xs={6} key={nftApp.id}>
             <AppCard safeApp={nftApp} />
           </Grid>
         ))}
@@ -44,11 +44,11 @@ const NFTs: NextPage = () => {
 
       <main>
         <Grid container spacing={3}>
-          <Grid item md={12} lg={3} order={{ lg: 1 }}>
+          <Grid item sm={12} lg={3} order={{ lg: 1 }}>
             <NftApps />
           </Grid>
 
-          <Grid item md={12} lg={9}>
+          <Grid item sm={12} lg={9}>
             <NftCollections />
           </Grid>
         </Grid>

--- a/src/pages/balances/nfts.tsx
+++ b/src/pages/balances/nfts.tsx
@@ -17,7 +17,7 @@ const NftApps = memo(function NftApps(): ReactElement | null {
   }
 
   return (
-    <>
+    <Grid item sm={12} lg={3} order={{ lg: 1 }}>
       <Typography component="h2" variant="subtitle1" fontWeight={700} mb={2} mt={0.6}>
         NFT Safe Apps
       </Typography>
@@ -29,7 +29,7 @@ const NftApps = memo(function NftApps(): ReactElement | null {
           </Grid>
         ))}
       </Grid>
-    </>
+    </Grid>
   )
 })
 
@@ -44,11 +44,9 @@ const NFTs: NextPage = () => {
 
       <main>
         <Grid container spacing={3}>
-          <Grid item sm={12} lg={3} order={{ lg: 1 }}>
-            <NftApps />
-          </Grid>
+          <NftApps />
 
-          <Grid item sm={12} lg={9}>
+          <Grid item xs>
             <NftCollections />
           </Grid>
         </Grid>


### PR DESCRIPTION
A few small fixes for the NFT page layout on mobile and tablet.

This is how it was:
<img width="400" src="https://user-images.githubusercontent.com/381895/215977297-7aa7b48d-ac39-4924-8384-b4bd9d396ebc.png" />

Now:
<img width="351" alt="Screenshot 2023-02-01 at 08 22 35" src="https://user-images.githubusercontent.com/381895/215977650-b9ee53fd-de9b-49b0-83ca-2b4141bf9cad.png">
