### PR TITLE
Fix: old app export link

### DIFF
--- a/src/components/common/PsaBanner/index.tsx
+++ b/src/components/common/PsaBanner/index.tsx
@@ -8,7 +8,6 @@ import styles from './index.module.css'
 import { hasFeature } from '@/utils/chains'
 import { useCurrentChain } from '@/hooks/useChains'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
-import { useRouter } from 'next/router'
 import { selectAllAddressBooks } from '@/store/addressBookSlice'
 import { useAppSelector } from '@/store'
 
@@ -16,9 +15,7 @@ const WARNING_BANNER = 'WARNING_BANNER'
 const OLD_APP = 'https://gnosis-safe.io/app'
 
 const ExportLink = ({ children }: { children: ReactNode }): ReactElement => {
-  const router = useRouter()
-  const safeAddress = router.query.safe as string
-  const url = safeAddress ? `${OLD_APP}/${safeAddress}/settings/details` : `${OLD_APP}/export`
+  const url = `${OLD_APP}/export`
 
   return (
     <a href={url} target="_blank" rel="noreferrer">


### PR DESCRIPTION
Fixes the link in the blue banner. The old app will redirect to the new app, except for the export path, so we shouldn't link to settings.