### PR TITLE
Fix: track nft send only when enabled

### DIFF
--- a/src/components/nfts/NftCollections/index.tsx
+++ b/src/components/nfts/NftCollections/index.tsx
@@ -1,6 +1,4 @@
-import type { SyntheticEvent } from 'react'
-import { useCallback } from 'react'
-import { useEffect, useState } from 'react'
+import { type SyntheticEvent, type ReactElement, useCallback, useEffect, useState } from 'react'
 import { type SafeCollectibleResponse } from '@safe-global/safe-gateway-typescript-sdk'
 import { Box, CircularProgress } from '@mui/material'
 import ErrorMessage from '@/components/tx/ErrorMessage'
@@ -14,7 +12,7 @@ import { trackEvent } from '@/services/analytics'
 import NftGrid from '../NftGrid'
 import NftSendForm from '../NftSendForm'
 
-const NftCollections = () => {
+const NftCollections = (): ReactElement => {
   // Track the current NFT page url
   const [pageUrl, setPageUrl] = useState<string>()
   // Load NFTs from the backend

--- a/src/components/nfts/NftCollections/index.tsx
+++ b/src/components/nfts/NftCollections/index.tsx
@@ -1,4 +1,5 @@
 import type { SyntheticEvent } from 'react'
+import { useCallback } from 'react'
 import { useEffect, useState } from 'react'
 import { type SafeCollectibleResponse } from '@safe-global/safe-gateway-typescript-sdk'
 import { Box, CircularProgress } from '@mui/material'
@@ -8,6 +9,8 @@ import NftIcon from '@/public/images/common/nft.svg'
 import NftBatchModal from '@/components/tx/modals/NftBatchModal'
 import useCollectibles from '@/hooks/useCollectibles'
 import InfiniteScroll from '@/components/common/InfiniteScroll'
+import { NFT_EVENTS } from '@/services/analytics/events/nfts'
+import { trackEvent } from '@/services/analytics'
 import NftGrid from '../NftGrid'
 import NftSendForm from '../NftSendForm'
 
@@ -24,9 +27,24 @@ const NftCollections = () => {
   const [showSendModal, setShowSendModal] = useState<boolean>(false)
 
   // Add or remove NFT from the selected list on row click
-  const onSelect = (token: SafeCollectibleResponse) => {
+  const onSelect = useCallback((token: SafeCollectibleResponse) => {
     setSelectedNfts((prev) => (prev.includes(token) ? prev.filter((t) => t !== token) : prev.concat(token)))
-  }
+  }, [])
+
+  const onSendSubmit = useCallback(
+    (e: SyntheticEvent) => {
+      e.preventDefault()
+
+      if (selectedNfts.length) {
+        // Show the NFT transfer modal
+        setShowSendModal(true)
+
+        // Track how many NFTs are being sent
+        trackEvent({ ...NFT_EVENTS.SEND, label: selectedNfts.length })
+      }
+    },
+    [selectedNfts.length],
+  )
 
   // Add new NFTs to the accumulated list
   useEffect(() => {
@@ -47,11 +65,6 @@ const NftCollections = () => {
   // No NFTs to display
   if (nftPage && !nftPage.results.length) {
     return <PagePlaceholder img={<NftIcon />} text="No NFTs available or none detected" />
-  }
-
-  const onSendSubmit = (e: SyntheticEvent) => {
-    e.preventDefault()
-    setShowSendModal(true)
   }
 
   return (

--- a/src/components/nfts/NftSendForm/index.tsx
+++ b/src/components/nfts/NftSendForm/index.tsx
@@ -2,8 +2,6 @@ import type { ReactElement } from 'react'
 import { Box, Button, Grid, SvgIcon, Typography } from '@mui/material'
 import ArrowIcon from '@/public/images/common/arrow-nw.svg'
 import type { SafeCollectibleResponse } from '@safe-global/safe-gateway-typescript-sdk'
-import Track from '@/components/common/Track'
-import { NFT_EVENTS } from '@/services/analytics/events/nfts'
 import useIsGranted from '@/hooks/useIsGranted'
 
 type NftSendFormProps = {
@@ -54,19 +52,17 @@ const NftSendForm = ({ selectedNfts, onSelectAll }: NftSendFormProps): ReactElem
         </Grid>
 
         <Grid item>
-          <Track {...NFT_EVENTS.SEND} label={selectedNfts.length}>
-            <Button
-              type="submit"
-              variant="contained"
-              size="small"
-              disabled={!isGranted || noSelected}
-              sx={{
-                minWidth: '10em',
-              }}
-            >
-              {noSelected ? 'Send' : `Send ${selectedNfts.length} ${nftsText}`}
-            </Button>
-          </Track>
+          <Button
+            type="submit"
+            variant="contained"
+            size="small"
+            disabled={!isGranted || noSelected}
+            sx={{
+              minWidth: '10em',
+            }}
+          >
+            {noSelected ? 'Send' : `Send ${selectedNfts.length} ${nftsText}`}
+          </Button>
         </Grid>
       </Grid>
     </Sticky>


### PR DESCRIPTION
## What it solves
The Send button was tracked even if disabled.
See [this comment](https://github.com/safe-global/web-core/pull/1616#issuecomment-1411965500).