### PR TITLE
Fix: avoid flashing the sidebar on mobile and desktop

### DIFF
--- a/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -113,7 +113,13 @@ const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
 
           <ChainSwitcher fullWidth />
 
-          <Button variant="contained" size="small" onClick={handleSwitchWallet} fullWidth>
+          <Button
+            variant="contained"
+            size="small"
+            onClick={handleSwitchWallet}
+            fullWidth
+            sx={{ display: ['none', 'block'] }}
+          >
             Switch wallet
           </Button>
 

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -17,7 +17,7 @@ import Link from 'next/link'
 import useSafeAddress from '@/hooks/useSafeAddress'
 
 type HeaderProps = {
-  onMenuToggle: Dispatch<SetStateAction<boolean>>
+  onMenuToggle?: Dispatch<SetStateAction<boolean>>
 }
 
 const Header = ({ onMenuToggle }: HeaderProps): ReactElement => {
@@ -30,7 +30,11 @@ const Header = ({ onMenuToggle }: HeaderProps): ReactElement => {
   const logoHref = router.pathname === AppRoutes.home ? AppRoutes.welcome : AppRoutes.index
 
   const handleMenuToggle = () => {
-    onMenuToggle((isOpen) => !isOpen)
+    if (onMenuToggle) {
+      onMenuToggle((isOpen) => !isOpen)
+    } else {
+      router.push(logoHref)
+    }
   }
 
   return (

--- a/src/components/common/PageLayout/SideDrawer.tsx
+++ b/src/components/common/PageLayout/SideDrawer.tsx
@@ -10,6 +10,7 @@ import classnames from 'classnames'
 import Sidebar from '@/components/sidebar/Sidebar'
 import css from './styles.module.css'
 import { AppRoutes } from '@/config/routes'
+import useDebounce from '@/hooks/useDebounce'
 
 type SideDrawerProps = {
   isOpen: boolean
@@ -35,6 +36,9 @@ const SideDrawer = ({ isOpen, onToggle }: SideDrawerProps): ReactElement => {
   const { breakpoints } = useTheme()
   const isSmallScreen = useMediaQuery(breakpoints.down('md'))
   const showSidebarToggle = isSafeAppRoute(pathname, query) && !isSmallScreen
+  // Keep the sidebar hidden on small screens via CSS until we collapse it via JS.
+  // With a small delay to avoid flickering.
+  const smDrawerHidden = useDebounce(!isSmallScreen, 300)
 
   useEffect(() => {
     const hideSidebar = isNoSidebarRoute(pathname)
@@ -49,6 +53,7 @@ const SideDrawer = ({ isOpen, onToggle }: SideDrawerProps): ReactElement => {
         anchor="left"
         open={isOpen}
         onClose={() => onToggle(false)}
+        className={smDrawerHidden ? css.smDrawerHidden : undefined}
       >
         <aside>
           <Sidebar />

--- a/src/components/common/PageLayout/SideDrawer.tsx
+++ b/src/components/common/PageLayout/SideDrawer.tsx
@@ -21,16 +21,6 @@ const isSafeAppRoute = (pathname: string, query: ParsedUrlQuery): boolean => {
   return pathname === AppRoutes.apps && !!query.appUrl
 }
 
-export const isNoSidebarRoute = (pathname: string): boolean => {
-  return [
-    AppRoutes.share.safeApp,
-    AppRoutes.newSafe.create,
-    AppRoutes.newSafe.load,
-    AppRoutes.welcome,
-    AppRoutes.index,
-  ].includes(pathname)
-}
-
 const SideDrawer = ({ isOpen, onToggle }: SideDrawerProps): ReactElement => {
   const { pathname, query } = useRouter()
   const { breakpoints } = useTheme()
@@ -41,8 +31,7 @@ const SideDrawer = ({ isOpen, onToggle }: SideDrawerProps): ReactElement => {
   const smDrawerHidden = useDebounce(!isSmallScreen, 300)
 
   useEffect(() => {
-    const hideSidebar = isNoSidebarRoute(pathname)
-    const closeSidebar = hideSidebar || isSmallScreen || isSafeAppRoute(pathname, query)
+    const closeSidebar = isSmallScreen || isSafeAppRoute(pathname, query)
     onToggle(!closeSidebar)
   }, [isSmallScreen, onToggle, pathname, query])
 

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -30,7 +30,7 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
     <>
       <header className={css.header}>
         <PsaBanner />
-        <Header onMenuToggle={setSidebarOpen} />
+        <Header onMenuToggle={noSidebar ? undefined : setSidebarOpen} />
       </header>
 
       {!noSidebar && <SideDrawer isOpen={isSidebarOpen} onToggle={setSidebarOpen} />}

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -5,11 +5,26 @@ import Header from '@/components/common//Header'
 import css from './styles.module.css'
 import SafeLoadingError from '../SafeLoadingError'
 import Footer from '../Footer'
-import SideDrawer, { isNoSidebarRoute } from './SideDrawer'
+import SideDrawer from './SideDrawer'
 import PsaBanner from '../PsaBanner'
+import { AppRoutes } from '@/config/routes'
+import useDebounce from '@/hooks/useDebounce'
+
+const isNoSidebarRoute = (pathname: string): boolean => {
+  return [
+    AppRoutes.share.safeApp,
+    AppRoutes.newSafe.create,
+    AppRoutes.newSafe.load,
+    AppRoutes.welcome,
+    AppRoutes.index,
+  ].includes(pathname)
+}
 
 const PageLayout = ({ pathname, children }: { pathname: string; children: ReactElement }): ReactElement => {
-  const [isSidebarOpen, setSidebarOpen] = useState<boolean>(!isNoSidebarRoute(pathname))
+  const noSidebar = isNoSidebarRoute(pathname)
+  const [isSidebarOpen, setSidebarOpen] = useState<boolean>(true)
+  let isAnimated = useDebounce(!noSidebar, 300)
+  if (noSidebar) isAnimated = false
 
   return (
     <>
@@ -18,9 +33,14 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
         <Header onMenuToggle={setSidebarOpen} />
       </header>
 
-      <SideDrawer isOpen={isSidebarOpen} onToggle={setSidebarOpen} />
+      {!noSidebar && <SideDrawer isOpen={isSidebarOpen} onToggle={setSidebarOpen} />}
 
-      <div className={classnames(css.main, !isSidebarOpen && css.mainNoSidebar)}>
+      <div
+        className={classnames(css.main, {
+          [css.mainNoSidebar]: noSidebar || !isSidebarOpen,
+          [css.mainAnimated]: isAnimated,
+        })}
+      >
         <div className={css.content}>
           <SafeLoadingError>{children}</SafeLoadingError>
         </div>

--- a/src/components/common/PageLayout/styles.module.css
+++ b/src/components/common/PageLayout/styles.module.css
@@ -13,6 +13,9 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+}
+
+.mainAnimated {
   transition: padding 225ms cubic-bezier(0, 0, 0.2, 1) 0ms;
 }
 

--- a/src/components/common/PageLayout/styles.module.css
+++ b/src/components/common/PageLayout/styles.module.css
@@ -73,6 +73,10 @@
   .main {
     padding-left: 0;
   }
+
+  .smDrawerHidden {
+    display: none;
+  }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## What it solves

The sidebar is initially rendered in an uncollapsed state because that's how it will stay on the desktop.
Then we detect if it's a small screen via JS and collapse the sidebar. This causes the sidebar to flash on the initial page load on mobile.

This PR hides the sidebar via CSS on mobile until it's collapsed.

## How to test
* The sidebar should not be initially visible on mobile (compare to prod)
* On desktop, when going from Safe Creation to an individual Safe, the sidebar should appear instantly (it's animated on on prod)
* In individual Safe Apps, the sidebar should still be animated when collapsing/expanding it.