### PR TITLE
Fix: type=url for env var inputs

### DIFF
--- a/src/components/settings/EnvironmentVariables/index.tsx
+++ b/src/components/settings/EnvironmentVariables/index.tsx
@@ -100,6 +100,7 @@ const EnvironmentVariables = () => {
               <TextField
                 {...register(EnvVariablesField.rpc)}
                 variant="outlined"
+                type="url"
                 placeholder={chain?.rpcUri.value}
                 InputProps={{
                   endAdornment: rpc ? (
@@ -148,6 +149,7 @@ const EnvironmentVariables = () => {
                 <Grid item xs={12} md={6}>
                   <TextField
                     {...register(EnvVariablesField.tenderlyURL)}
+                    type="url"
                     variant="outlined"
                     label="Tenderly API URL"
                     placeholder={TENDERLY_SIMULATE_ENDPOINT_URL}


### PR DESCRIPTION
A small fix for settings inputs as per @JagoFigueroa's [suggestion](https://github.com/safe-global/web-core/pull/1648#issuecomment-1422263256).