### PR TITLE
fix: Sticky z-index in assets and NFTs

### DIFF
--- a/src/components/balances/AssetsTable/index.tsx
+++ b/src/components/balances/AssetsTable/index.tsx
@@ -148,12 +148,7 @@ const AssetsTable = ({
                   </Track>
                 )}
                 {showHiddenAssets ? (
-                  <Checkbox
-                    size="small"
-                    checked={isSelected}
-                    onClick={() => toggleAsset(item.tokenInfo.address)}
-                    sx={{ zIndex: 0 }}
-                  />
+                  <Checkbox size="small" checked={isSelected} onClick={() => toggleAsset(item.tokenInfo.address)} />
                 ) : (
                   <Track {...ASSETS_EVENTS.HIDE_TOKEN}>
                     <Tooltip title="Hide asset" arrow disableInteractive>

--- a/src/components/balances/AssetsTable/index.tsx
+++ b/src/components/balances/AssetsTable/index.tsx
@@ -148,7 +148,12 @@ const AssetsTable = ({
                   </Track>
                 )}
                 {showHiddenAssets ? (
-                  <Checkbox size="small" checked={isSelected} onClick={() => toggleAsset(item.tokenInfo.address)} />
+                  <Checkbox
+                    size="small"
+                    checked={isSelected}
+                    onClick={() => toggleAsset(item.tokenInfo.address)}
+                    sx={{ zIndex: 0 }}
+                  />
                 ) : (
                   <Track {...ASSETS_EVENTS.HIDE_TOKEN}>
                     <Tooltip title="Hide asset" arrow disableInteractive>

--- a/src/components/balances/TokenMenu/index.tsx
+++ b/src/components/balances/TokenMenu/index.tsx
@@ -1,3 +1,4 @@
+import { Sticky } from '@/components/common/Sticky'
 import Track from '@/components/common/Track'
 import { ASSETS_EVENTS } from '@/services/analytics'
 import { VisibilityOffOutlined } from '@mui/icons-material'
@@ -22,31 +23,33 @@ const TokenMenu = ({
     return null
   }
   return (
-    <Box className={css.stickyBox}>
-      <Box className={css.hideTokensHeader}>
-        <VisibilityOffOutlined />
-        <Typography variant="body2" lineHeight="inherit">
-          {selectedAssetCount} {selectedAssetCount === 1 ? 'token' : 'tokens'} selected
-        </Typography>
+    <Sticky>
+      <Box className={css.wrapper}>
+        <Box className={css.hideTokensHeader}>
+          <VisibilityOffOutlined />
+          <Typography variant="body2" lineHeight="inherit">
+            {selectedAssetCount} {selectedAssetCount === 1 ? 'token' : 'tokens'} selected
+          </Typography>
+        </Box>
+        <Box display="flex" flexDirection="row" gap={1}>
+          <Track {...ASSETS_EVENTS.CANCEL_HIDE_DIALOG}>
+            <Button onClick={cancel} className={css.cancelButton} size="small" variant="outlined">
+              Cancel
+            </Button>
+          </Track>
+          <Track {...ASSETS_EVENTS.DESELECT_ALL_HIDE_DIALOG}>
+            <Button onClick={deselectAll} className={css.cancelButton} size="small" variant="outlined">
+              Deselect all
+            </Button>
+          </Track>
+          <Track {...ASSETS_EVENTS.SAVE_HIDE_DIALOG}>
+            <Button onClick={saveChanges} className={css.applyButton} size="small" variant="outlined">
+              Save
+            </Button>
+          </Track>
+        </Box>
       </Box>
-      <Box display="flex" flexDirection="row" gap={1}>
-        <Track {...ASSETS_EVENTS.CANCEL_HIDE_DIALOG}>
-          <Button onClick={cancel} className={css.cancelButton} size="small" variant="outlined">
-            Cancel
-          </Button>
-        </Track>
-        <Track {...ASSETS_EVENTS.DESELECT_ALL_HIDE_DIALOG}>
-          <Button onClick={deselectAll} className={css.cancelButton} size="small" variant="outlined">
-            Deselect all
-          </Button>
-        </Track>
-        <Track {...ASSETS_EVENTS.SAVE_HIDE_DIALOG}>
-          <Button onClick={saveChanges} className={css.applyButton} size="small" variant="contained">
-            Save
-          </Button>
-        </Track>
-      </Box>
-    </Box>
+    </Sticky>
   )
 }
 

--- a/src/components/balances/TokenMenu/index.tsx
+++ b/src/components/balances/TokenMenu/index.tsx
@@ -43,7 +43,7 @@ const TokenMenu = ({
             </Button>
           </Track>
           <Track {...ASSETS_EVENTS.SAVE_HIDE_DIALOG}>
-            <Button onClick={saveChanges} className={css.applyButton} size="small" variant="outlined">
+            <Button onClick={saveChanges} className={css.applyButton} size="small" variant="contained">
               Save
             </Button>
           </Track>

--- a/src/components/balances/TokenMenu/styles.module.css
+++ b/src/components/balances/TokenMenu/styles.module.css
@@ -9,24 +9,12 @@
   min-width: 185px;
 }
 
-.stickyBox {
-  position: sticky;
-  top: 111px; /* under AssetHeader */
-  z-index: 1;
-  padding: var(--space-2) 0;
-  background-color: var(--color-background-default);
+.wrapper {
   display: flex;
   flex-wrap: wrap;
   flex-direction: row;
   align-items: center;
-  margin-top: -24px;
   gap: var(--space-3);
-}
-
-@media (max-width: 600px) {
-  .stickyBox {
-    margin-top: -16px;
-  }
 }
 
 .cancelButton {

--- a/src/components/common/Sticky/index.tsx
+++ b/src/components/common/Sticky/index.tsx
@@ -1,0 +1,9 @@
+import { Box } from '@mui/material'
+import type { ReactElement } from 'react'
+
+const stickyTop = { xs: '103px', md: '111px' }
+export const Sticky = ({ children }: { children: ReactElement }): ReactElement => (
+  <Box position="sticky" zIndex="2" top={stickyTop} py={1} bgcolor="background.main" mt={-1} mb={1}>
+    {children}
+  </Box>
+)

--- a/src/components/nfts/NftSendForm/index.tsx
+++ b/src/components/nfts/NftSendForm/index.tsx
@@ -3,18 +3,12 @@ import { Box, Button, Grid, SvgIcon, Typography } from '@mui/material'
 import ArrowIcon from '@/public/images/common/arrow-nw.svg'
 import type { SafeCollectibleResponse } from '@safe-global/safe-gateway-typescript-sdk'
 import useIsGranted from '@/hooks/useIsGranted'
+import { Sticky } from '@/components/common/Sticky'
 
 type NftSendFormProps = {
   selectedNfts: SafeCollectibleResponse[]
   onSelectAll: () => void
 }
-
-const stickyTop = { xs: '103px', md: '111px' }
-const Sticky = ({ children }: { children: ReactElement }): ReactElement => (
-  <Box position="sticky" zIndex="1" top={stickyTop} py={1} bgcolor="background.main" mt={-1} mb={1}>
-    {children}
-  </Box>
-)
 
 const NftSendForm = ({ selectedNfts, onSelectAll }: NftSendFormProps): ReactElement => {
   const isGranted = useIsGranted()


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/web-core/issues/1636

## How this PR fixes it
Reuse `<Sticky/>` in `TokenMenu`

## How to test it

1. Go to This safe that has a bunch of tokens in ETH eth:0x8675B754342754A30A2AeF474D114d8460bca19b
2. Open the menu to hide tokens
3. Scroll down a bit so the save button overlaps a checkbox
4. Click the Save button where the checkbox in the row behind it would be
