### PR TITLE
fix: change Safe Apps text

### DIFF
--- a/src/components/safe-apps/SafeAppsHeader/index.tsx
+++ b/src/components/safe-apps/SafeAppsHeader/index.tsx
@@ -12,13 +12,12 @@ const SafeAppsHeader = (): ReactElement => {
       <Box className={css.container}>
         {/* Safe Apps Title */}
         <Typography className={css.title} variant="h3">
-          Explore the Safe Ecosystem
+          Explore the Safe Apps ecosystem
         </Typography>
 
         {/* Safe Apps Subtitle */}
         <Typography className={css.subtitle}>
-          Connect to your favorite web3 applications with your Safe smart contract account. Safer and more efficient,
-          right from the interface.
+          Connect to your favourite web3 applications with your Safe wallet, securely and efficiently.
         </Typography>
       </Box>
 


### PR DESCRIPTION
## What it solves

Resolves #1666

## How this PR fixes it

1. The Safe Apps title has been changed to "Explore the Safe Apps ecosystem"
2. The Safe Apps subtitle has been changed to  "Connect to your favourite web3 applications with your Safe wallet, securely and efficiently"

## How to test it

Open the Safe Apps section of the Safe and observe the new text.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/219357867-a24f32f8-026b-44f1-b4fd-218181063a04.png)