### PR TITLE
fix blur nft links

### DIFF
--- a/src/components/nfts/config.ts
+++ b/src/components/nfts/config.ts
@@ -27,7 +27,7 @@ export const nftPlatforms: Record<keyof typeof chains, Array<NftPlatform>> = {
     {
       title: 'Blur',
       logo: '/images/common/nft-blur.svg',
-      getUrl: (item) => `https://blur.io/asset/${item.address}/${item.id}`,
+      getUrl: (item) => `https://blur.io/asset/${item.address.toLowerCase()}/${item.id}`,
     },
   ],
 


### PR DESCRIPTION
## What it solves
Blur links for assets aren't working, there's leading to empty asset pages:
![Kapture 2023-02-16 at 06 19 59](https://user-images.githubusercontent.com/7328115/219390293-6bb8e091-a828-4708-acb4-9b807575b461.gif)

This is because blur expects contract addresses to be lowercase

Resolves #

## How this PR fixes it
Transform blur asset links to lowercase

## How to test it
1. Go to assets > nfts > click on the blur link for an nft

## Analytics changes

## Screenshots


