### PR TITLE
fix: useSafeTokenAlocation unit test

### DIFF
--- a/src/hooks/__tests__/useSafeTokenAllocation.test.ts
+++ b/src/hooks/__tests__/useSafeTokenAllocation.test.ts
@@ -62,6 +62,7 @@ describe('useSafeTokenAllocation', () => {
   })
 
   test('return 0 without web3Provider', async () => {
+    global.fetch = jest.fn().mockImplementation(setupFetchStub('', 404))
     const { result } = renderHook(() => useSafeTokenAllocation())
 
     await waitFor(() => {


### PR DESCRIPTION
## What it solves
Unit tests are failing in the CI without related changes

## How this PR fixes it
Mock fetch implementation in the failing test

## How to test it
Run `yarn test useSafeTokenAlocation`
