### PR TITLE
Fix: lazy load app icon iframes

### DIFF
--- a/src/components/safe-apps/SafeAppIconCard/index.tsx
+++ b/src/components/safe-apps/SafeAppIconCard/index.tsx
@@ -37,6 +37,7 @@ const SafeAppIconCard = ({
       height={height}
       style={{ pointerEvents: 'none', border: 0 }}
       tabIndex={-1}
+      loading="lazy"
     />
   )
 }


### PR DESCRIPTION
## What it solves

This will defer the loading of the icon iframes until they're in the viewport.