### PR TITLE
Fix: remove unnecessary safe contract fallback

### DIFF
--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -136,15 +136,10 @@ export const getMultiSendCallOnlyContractInstance = (
 // GnosisSafeProxyFactory
 
 const getProxyFactoryContractDeployment = (chainId: string) => {
-  return (
-    getProxyFactoryDeployment({
-      version: LATEST_SAFE_VERSION,
-      network: chainId,
-    }) ||
-    getProxyFactoryDeployment({
-      version: LATEST_SAFE_VERSION,
-    })
-  )
+  return getProxyFactoryDeployment({
+    version: LATEST_SAFE_VERSION,
+    network: chainId,
+  })
 }
 
 export const getProxyFactoryContractInstance = (chainId: string, safeVersion: string = LATEST_SAFE_VERSION) => {
@@ -159,15 +154,10 @@ export const getProxyFactoryContractInstance = (chainId: string, safeVersion: st
 // Fallback handler
 
 const getFallbackHandlerContractDeployment = (chainId: string) => {
-  return (
-    getFallbackHandlerDeployment({
-      version: LATEST_SAFE_VERSION,
-      network: chainId,
-    }) ||
-    getFallbackHandlerDeployment({
-      version: LATEST_SAFE_VERSION,
-    })
-  )
+  return getFallbackHandlerDeployment({
+    version: LATEST_SAFE_VERSION,
+    network: chainId,
+  })
 }
 
 export const getFallbackHandlerContractInstance = (


### PR DESCRIPTION
## What it solves
Falling back to default contract addresses was a leftover from safe-react.
Safe Core SDK will fail to initialize if a fallback handler is missing in safe-deployments for a particular chain, so the app won't work anyway. We can thus remove the fallbacks and assume that all supported chains are present in safe-deployments.

## How to test
This should affect only Safe creation.
Test it on a couple different chains.