### PR TITLE
Add Metis Goerli testnet

### DIFF
--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -133,6 +133,7 @@ const chains: Record<string, string> = {
   tao: '558',
   'metis-stardust': '588',
   maca: '595',
+  'metis-goerli': '599',
   'mesh-chain-testnet': '600',
   'pixie-chain-testnet': '666',
   kar: '686',


### PR DESCRIPTION
## What it solves:
Error 104: Invalid chain short name in the URL
This happens when opening safes prefixed with metis-goerli

https://chainlist.org/chain/599
https://github.com/safe-global/safe-deployments/pull/161