### PR TITLE
Fix: single transaction skeleton

### DIFF
--- a/cypress/e2e/smoke/dashboard.cy.js
+++ b/cypress/e2e/smoke/dashboard.cy.js
@@ -1,9 +1,9 @@
-const SAFE = 'gor:0xCD4FddB8FfA90012DFE11eD4bf258861204FeEAE'
+const SAFE = encodeURIComponent('gor:0xCD4FddB8FfA90012DFE11eD4bf258861204FeEAE')
 
 describe('Dashboard', () => {
   before(() => {
     // Go to the test Safe home page
-    cy.visit(`/${SAFE}/home`, { failOnStatusCode: false })
+    cy.visit(`/home?safe=${SAFE}`, { failOnStatusCode: false })
     cy.contains('button', 'Accept selection').click()
 
     // Wait for dashboard to initialize
@@ -18,7 +18,7 @@ describe('Dashboard', () => {
       // Prefix is separated across elements in EthHashInfo
       cy.contains('0xCD4FddB8FfA90012DFE11eD4bf258861204FeEAE').should('exist')
       cy.contains('2/3')
-      cy.get(`a[href="/balances?safe=${encodeURIComponent(SAFE)}"]`).contains('View assets')
+      cy.get(`a[href="/balances?safe=${SAFE}"]`).contains('View assets')
       cy.contains('p', 'Tokens').next().contains('1')
       cy.contains('p', 'NFTs').next().contains('0')
     })
@@ -34,10 +34,11 @@ describe('Dashboard', () => {
 
       // Queued txns
       cy.contains(
-        `a[href="/transactions/queue?safe=${SAFE}"]`,
+        `a[href^="/transactions/tx?id=multisig_0x"]`,
         '1' + 'Contract interaction' + '3 actions' + '1/2',
       ).should('exist')
-      cy.contains(`a[href="/transactions/queue?safe=${SAFE}"]`, '2' + 'Send' + '-1 USDC' + '1/2').should('exist')
+
+      cy.contains(`a[href^="/transactions/tx?id=multisig_0x"]`, '2' + 'Send' + '-1 USDC' + '1/2').should('exist')
 
       cy.contains(`a[href="/transactions/queue?safe=${SAFE}"]`, 'View all')
     })
@@ -71,7 +72,7 @@ describe('Dashboard', () => {
     // Regular safe apps
     cy.get('@safeAppsSection').within(() => {
       // Find exactly 5 Safe Apps cards inside the Safe Apps section
-      cy.get(`a[href^="/apps/open?safe=${encodeURIComponent(SAFE)}&appUrl=http"]`).should('have.length', 5)
+      cy.get(`a[href^="/apps/open?safe=${SAFE}&appUrl=http"]`).should('have.length', 5)
     })
   })
 })

--- a/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
@@ -1,6 +1,7 @@
 import NextLink from 'next/link'
-import type { LinkProps } from 'next/link'
+import { useRouter } from 'next/router'
 import type { ReactElement } from 'react'
+import { useMemo } from 'react'
 import ChevronRight from '@mui/icons-material/ChevronRight'
 import type { TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import { Box, SvgIcon, Typography } from '@mui/material'
@@ -10,13 +11,27 @@ import TxType from '@/components/transactions/TxType'
 import css from './styles.module.css'
 import classNames from 'classnames'
 import OwnersIcon from '@/public/images/common/owners.svg'
+import { AppRoutes } from '@/config/routes'
 
 type PendingTxType = {
   transaction: TransactionSummary
-  url: LinkProps['href']
 }
 
-const PendingTx = ({ transaction, url }: PendingTxType): ReactElement => {
+const PendingTx = ({ transaction }: PendingTxType): ReactElement => {
+  const router = useRouter()
+  const { id } = transaction
+
+  const url = useMemo(
+    () => ({
+      pathname: AppRoutes.transactions.tx,
+      query: {
+        id,
+        safe: router.query.safe,
+      },
+    }),
+    [router, id],
+  )
+
   return (
     <NextLink href={url} passHref>
       <a>

--- a/src/components/dashboard/PendingTxs/PendingTxsList.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxsList.tsx
@@ -44,14 +44,18 @@ const EmptyState = () => {
 
 const PendingTxsList = ({ size = 4 }: { size?: number }): ReactElement | null => {
   const { page, loading } = useTxQueue()
-  const router = useRouter()
-  const url = `${AppRoutes.transactions.queue}?safe=${router.query.safe}`
-
   const queuedTxns = useMemo(() => getLatestTransactions(page?.results), [page?.results])
-
   const queuedTxsToDisplay = queuedTxns.slice(0, size)
-
   const totalQueuedTxs = getQueuedTransactionCount(page)
+  const router = useRouter()
+
+  const queueUrl = useMemo(
+    () => ({
+      pathname: AppRoutes.transactions.queue,
+      query: { safe: router.query.safe },
+    }),
+    [router],
+  )
 
   const LoadingState = useMemo(
     () => (
@@ -70,11 +74,11 @@ const PendingTxsList = ({ size = 4 }: { size?: number }): ReactElement | null =>
     () => (
       <StyledList>
         {queuedTxsToDisplay.map((transaction) => (
-          <PendingTxListItem transaction={transaction.transaction} url={url} key={transaction.transaction.id} />
+          <PendingTxListItem transaction={transaction.transaction} key={transaction.transaction.id} />
         ))}
       </StyledList>
     ),
-    [queuedTxsToDisplay, url],
+    [queuedTxsToDisplay],
   )
 
   const getWidgetBody = () => {
@@ -89,7 +93,7 @@ const PendingTxsList = ({ size = 4 }: { size?: number }): ReactElement | null =>
         <Typography component="h2" variant="subtitle1" fontWeight={700} mb={2}>
           Transaction queue {totalQueuedTxs ? ` (${totalQueuedTxs})` : ''}
         </Typography>
-        {queuedTxns.length > 0 && <ViewAllLink url={url} />}
+        {queuedTxns.length > 0 && <ViewAllLink url={queueUrl} />}
       </StyledWidgetTitle>
       <WidgetBody>{getWidgetBody()}</WidgetBody>
     </WidgetContainer>

--- a/src/components/transactions/SingleTx/index.tsx
+++ b/src/components/transactions/SingleTx/index.tsx
@@ -1,4 +1,3 @@
-import { CircularProgress } from '@mui/material'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import { useRouter } from 'next/router'
 import useSafeInfo from '@/hooks/useSafeInfo'
@@ -10,7 +9,9 @@ import { sameAddress } from '@/utils/addresses'
 import type { ReactElement } from 'react'
 import { makeTxFromDetails } from '@/utils/transactions'
 import { TxListGrid } from '@/components/transactions/TxList'
-import ExpandableTransactionItem from '@/components/transactions/TxListItem/ExpandableTransactionItem'
+import ExpandableTransactionItem, {
+  TransactionSkeleton,
+} from '@/components/transactions/TxListItem/ExpandableTransactionItem'
 import GroupLabel from '../GroupLabel'
 import { isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
 
@@ -63,7 +64,8 @@ const SingleTx = () => {
     return <SingleTxGrid txDetails={txDetails} />
   }
 
-  return <CircularProgress />
+  // Loading skeleton
+  return <TransactionSkeleton />
 }
 
 export default SingleTx

--- a/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
+++ b/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
@@ -1,5 +1,5 @@
 import { type Transaction, type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
-import { Accordion, AccordionDetails, AccordionSummary } from '@mui/material'
+import { Accordion, AccordionDetails, AccordionSummary, Box, Skeleton } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import TxSummary from '@/components/transactions/TxSummary'
 import TxDetails from '@/components/transactions/TxDetails'
@@ -52,5 +52,23 @@ export const ExpandableTransactionItem = ({
     </Accordion>
   )
 }
+
+export const TransactionSkeleton = () => (
+  <>
+    <Box pt="20px" pb="4px">
+      <Skeleton variant="text" width="35px" />
+    </Box>
+
+    <Accordion disableGutters elevation={0} defaultExpanded className={css.accordion}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ justifyContent: 'flex-start', overflowX: 'auto' }}>
+        <Skeleton width="100%" />
+      </AccordionSummary>
+
+      <AccordionDetails sx={{ padding: 0 }}>
+        <Skeleton variant="rounded" width="100%" height="325px" />
+      </AccordionDetails>
+    </Accordion>
+  </>
+)
 
 export default ExpandableTransactionItem


### PR DESCRIPTION
## What it solves

Resolves #1671

The final piece of #1671 – a skeleton for the single tx page.

<img width="1014" alt="Screenshot 2023-02-28 at 12 21 47" src="https://user-images.githubusercontent.com/381895/221840411-3edc46a1-694b-4492-b77b-3dea72aad151.png">

## How this PR fixes it
I've replaced the circular loader with a skeleton in an expanded accordion.
Also changed the links from the dashboard queue widget to open individual txs instead of the entire queue. "View all" still links to the queue.