### PR TITLE
Chore: remove an unnecessary deployment step

### DIFF
--- a/scripts/github/prepare_production_deployment.sh
+++ b/scripts/github/prepare_production_deployment.sh
@@ -13,5 +13,5 @@ then
      -F "variables[TRIGGER_RELEASE_COMMIT_TAG]=$VERSION_TAG" \
       $PROD_DEPLOYMENT_HOOK_URL
 else
-  echo "[ERROR] Production deployment could not be prepared"
+  echo "⚠︎ Production deployment could not be prepared"
 fi

--- a/scripts/github/s3_upload.sh
+++ b/scripts/github/s3_upload.sh
@@ -8,14 +8,10 @@ fi
 
 cd out
 
-# First, upload the new files w/o deleting the old ones
-aws s3 sync . $BUCKET
-
-# Second, upload them again but delete the old files this time
-# This allows for a no-downtime deployment
+# Upload the build to S3
 aws s3 sync . $BUCKET --delete
 
-# Finally, upload all HTML files again but w/o an extention so that URLs like /welcome open the right page
+# Upload all HTML files again but w/o an extention so that URLs like /welcome open the right page
 for file in $(find . -name '*.html' | sed 's|^\./||'); do
     aws s3 cp ${file%} $BUCKET/${file%.*} --content-type 'text/html'
 done


### PR DESCRIPTION
## What it solves

The build is uploaded to S3 to a new folder every time we deploy a release, so it makes no sense trying to keep old files while uploading the new ones.

Only the dev and staging buckets use the same folder across deployments, but we don't care about downtime there.