### PR TITLE
fix: Display manual gasLimit in GasParams overview

### DIFF
--- a/src/components/tx/GasParams/GasParams.test.tsx
+++ b/src/components/tx/GasParams/GasParams.test.tsx
@@ -1,0 +1,224 @@
+import { render } from '@/tests/test-utils'
+import GasParams from '@/components/tx/GasParams/index'
+import type { AdvancedParameters } from '@/components/tx/AdvancedParams'
+import { BigNumber } from '@ethersproject/bignumber'
+
+describe('GasParams', () => {
+  it('Shows the estimated fee on execution', () => {
+    const params: AdvancedParameters = {
+      gasLimit: BigNumber.from('21000'),
+      nonce: 0,
+      userNonce: 1,
+      maxFeePerGas: BigNumber.from('10000'),
+      maxPriorityFeePerGas: BigNumber.from('10000'),
+    }
+
+    const { getByText } = render(<GasParams params={params} isExecution={true} isEIP1559={true} onEdit={jest.fn} />)
+
+    expect(getByText('Estimated fee')).toBeInTheDocument()
+  })
+
+  it('Shows the nonce when signing and if it exists', () => {
+    const params: AdvancedParameters = {
+      gasLimit: BigNumber.from('21000'),
+      nonce: 0,
+      userNonce: 1,
+      maxFeePerGas: BigNumber.from('10000'),
+      maxPriorityFeePerGas: BigNumber.from('10000'),
+    }
+
+    const { getByText } = render(<GasParams params={params} isExecution={false} isEIP1559={true} onEdit={jest.fn} />)
+
+    expect(getByText('Signing the transaction with nonce 0')).toBeInTheDocument()
+  })
+
+  it("Doesn't show the nonce if it doesn't exist", () => {
+    const params: AdvancedParameters = {
+      gasLimit: BigNumber.from('21000'),
+      userNonce: 1,
+      maxFeePerGas: BigNumber.from('10000'),
+      maxPriorityFeePerGas: BigNumber.from('10000'),
+    }
+
+    const { getByText } = render(<GasParams params={params} isExecution={false} isEIP1559={true} onEdit={jest.fn} />)
+
+    expect(getByText('Signing the transaction with nonce')).toBeInTheDocument()
+  })
+
+  it('Shows an estimated fee if there is no gasLimit error', () => {
+    const params: AdvancedParameters = {
+      gasLimit: BigNumber.from('21000'),
+      userNonce: 1,
+      maxFeePerGas: BigNumber.from('10000'),
+      maxPriorityFeePerGas: BigNumber.from('10000'),
+    }
+
+    const { getByText } = render(<GasParams params={params} isExecution={true} isEIP1559={true} onEdit={jest.fn} />)
+
+    expect(getByText('Estimated fee')).toBeInTheDocument()
+    expect(getByText('0.21')).toBeInTheDocument()
+  })
+
+  it("Doesn't show an estimated fee if there is no gasLimit", () => {
+    const params: AdvancedParameters = {
+      userNonce: 1,
+      maxFeePerGas: BigNumber.from('10000'),
+      maxPriorityFeePerGas: BigNumber.from('10000'),
+    }
+
+    const { getByText, queryByText } = render(
+      <GasParams params={params} isExecution={true} isEIP1559={true} onEdit={jest.fn} />,
+    )
+
+    expect(getByText('Estimated fee')).toBeInTheDocument()
+    expect(queryByText('0.21')).not.toBeInTheDocument()
+  })
+
+  it('Shows the nonce if it exists', () => {
+    const params: AdvancedParameters = {
+      nonce: 123,
+      userNonce: 1,
+      maxFeePerGas: BigNumber.from('10000'),
+      maxPriorityFeePerGas: BigNumber.from('10000'),
+    }
+
+    const { getByText } = render(<GasParams params={params} isExecution={true} isEIP1559={true} onEdit={jest.fn} />)
+
+    expect(getByText('Safe transaction nonce')).toBeInTheDocument()
+    expect(getByText('123')).toBeInTheDocument()
+  })
+
+  it('Shows safeTxGas if it exists', () => {
+    const params: AdvancedParameters = {
+      nonce: 123,
+      userNonce: 1,
+      maxFeePerGas: BigNumber.from('10000'),
+      maxPriorityFeePerGas: BigNumber.from('10000'),
+      safeTxGas: 100,
+    }
+
+    const { getByText } = render(<GasParams params={params} isExecution={true} isEIP1559={true} onEdit={jest.fn} />)
+
+    expect(getByText('safeTxGas')).toBeInTheDocument()
+    expect(getByText('100')).toBeInTheDocument()
+  })
+
+  it('Shows gasLimit if it exists', () => {
+    const params: AdvancedParameters = {
+      nonce: 123,
+      userNonce: 1,
+      gasLimit: BigNumber.from('30000'),
+      maxFeePerGas: BigNumber.from('10000'),
+      maxPriorityFeePerGas: BigNumber.from('10000'),
+    }
+
+    const { getByText } = render(<GasParams params={params} isExecution={true} isEIP1559={true} onEdit={jest.fn} />)
+
+    expect(getByText('Gas limit')).toBeInTheDocument()
+    expect(getByText('30000')).toBeInTheDocument()
+  })
+
+  it('Shows a cannot estimate message if there is no gasLimit', () => {
+    const params: AdvancedParameters = {
+      nonce: 123,
+      userNonce: 1,
+      maxFeePerGas: BigNumber.from('10000'),
+      maxPriorityFeePerGas: BigNumber.from('10000'),
+    }
+
+    const { getByText } = render(
+      <GasParams
+        params={params}
+        isExecution={true}
+        isEIP1559={true}
+        onEdit={jest.fn}
+        gasLimitError={new Error('Error estimating gas')}
+      />,
+    )
+
+    expect(getByText('Cannot estimate')).toBeInTheDocument()
+  })
+
+  it('Shows maxFee and maxPrioFee if EIP1559', () => {
+    const params: AdvancedParameters = {
+      nonce: 123,
+      userNonce: 1,
+      gasLimit: BigNumber.from('30000'),
+      maxFeePerGas: BigNumber.from('10000'),
+      maxPriorityFeePerGas: BigNumber.from('20000'),
+    }
+
+    const { getByText } = render(<GasParams params={params} isExecution={true} isEIP1559={true} onEdit={jest.fn} />)
+
+    expect(getByText('Max priority fee (Gwei)')).toBeInTheDocument()
+    expect(getByText('0.00002')).toBeInTheDocument()
+
+    expect(getByText('Max fee (Gwei)')).toBeInTheDocument()
+    expect(getByText('0.00001')).toBeInTheDocument()
+  })
+
+  it('Shows Gas price if not EIP1559', () => {
+    const params: AdvancedParameters = {
+      nonce: 123,
+      userNonce: 1,
+      gasLimit: BigNumber.from('30000'),
+      maxFeePerGas: BigNumber.from('10000'),
+      maxPriorityFeePerGas: BigNumber.from('20000'),
+    }
+
+    const { getByText } = render(<GasParams params={params} isExecution={true} isEIP1559={false} onEdit={jest.fn} />)
+
+    expect(getByText('Gas price (Gwei)')).toBeInTheDocument()
+    expect(getByText('0.00001')).toBeInTheDocument()
+  })
+
+  it('Show Edit button if there is a gasLimitError', () => {
+    const params: AdvancedParameters = {
+      nonce: 123,
+      userNonce: 1,
+      gasLimit: BigNumber.from('30000'),
+      maxFeePerGas: BigNumber.from('10000'),
+      maxPriorityFeePerGas: BigNumber.from('20000'),
+    }
+
+    const { getByText } = render(
+      <GasParams
+        params={params}
+        isExecution={true}
+        isEIP1559={false}
+        onEdit={jest.fn}
+        gasLimitError={new Error('Error estimating gas')}
+      />,
+    )
+
+    expect(getByText('Edit')).toBeInTheDocument()
+  })
+
+  it('Show Edit button if its not an execution', () => {
+    const params: AdvancedParameters = {
+      nonce: 123,
+      userNonce: 1,
+      gasLimit: BigNumber.from('30000'),
+      maxFeePerGas: BigNumber.from('10000'),
+      maxPriorityFeePerGas: BigNumber.from('20000'),
+    }
+
+    const { getByText } = render(<GasParams params={params} isExecution={false} isEIP1559={false} onEdit={jest.fn} />)
+
+    expect(getByText('Edit')).toBeInTheDocument()
+  })
+
+  it('Show Edit button if its an execution and loading finished', () => {
+    const params: AdvancedParameters = {
+      nonce: 123,
+      userNonce: 1,
+      gasLimit: BigNumber.from('30000'),
+      maxFeePerGas: BigNumber.from('10000'),
+      maxPriorityFeePerGas: BigNumber.from('20000'),
+    }
+
+    const { getByText } = render(<GasParams params={params} isExecution={true} isEIP1559={false} onEdit={jest.fn} />)
+
+    expect(getByText('Edit')).toBeInTheDocument()
+  })
+})

--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -34,6 +34,7 @@ const GasParams = ({ params, isExecution, isEIP1559, onEdit, gasLimitError }: Ga
 
   const chain = useCurrentChain()
   const isLoading = !gasLimit || !maxFeePerGas
+  const isError = gasLimitError && !gasLimit
 
   // Total gas cost
   const totalFee = !isLoading
@@ -56,7 +57,7 @@ const GasParams = ({ params, isExecution, isEIP1559, onEdit, gasLimitError }: Ga
         {isExecution ? (
           <Typography display="flex" alignItems="center" justifyContent="space-between" width={1}>
             <span>Estimated fee </span>
-            {gasLimitError ? null : isLoading ? (
+            {isError ? null : isLoading ? (
               <Skeleton variant="text" sx={{ display: 'inline-block', minWidth: '7em' }} />
             ) : (
               <span>
@@ -79,7 +80,7 @@ const GasParams = ({ params, isExecution, isEIP1559, onEdit, gasLimitError }: Ga
       <AccordionDetails>
         {nonce !== undefined && <GasDetail isLoading={false} name="Safe transaction nonce" value={nonce.toString()} />}
 
-        {!!safeTxGas && <GasDetail isLoading={false} name="safeTxGas" value={safeTxGas.toString()} />}
+        {safeTxGas !== undefined && <GasDetail isLoading={false} name="safeTxGas" value={safeTxGas.toString()} />}
 
         {isExecution && (
           <>
@@ -87,11 +88,7 @@ const GasParams = ({ params, isExecution, isEIP1559, onEdit, gasLimitError }: Ga
               <GasDetail isLoading={false} name="Wallet nonce" value={userNonce.toString()} />
             )}
 
-            <GasDetail
-              isLoading={isLoading}
-              name="Gas limit"
-              value={gasLimitError ? 'Cannot estimate' : gasLimitString}
-            />
+            <GasDetail isLoading={isLoading} name="Gas limit" value={isError ? 'Cannot estimate' : gasLimitString} />
 
             {isEIP1559 ? (
               <>


### PR DESCRIPTION
## What it solves

Resolves #1661 

## How this PR fixes it

- Displays the manual `gasLimit` in the `GasParams` overview if it exists

## How to test it

1. Open the Safe
2. Create a transaction where gas limit estimation would fail (e.g. send an NFT to a 1.0.0 safe)
3. Observe Estimated Fee showing "Cannot estimate"
4. Edit the gas limit and save
5. Observe seeing an Estimated Fee and the manual gas limit

## Analytics changes

## Screenshots
<img width="631" alt="Screenshot 2023-02-28 at 14 08 50" src="https://user-images.githubusercontent.com/5880855/221863486-b492868e-c67a-48b3-8de6-6caa44eed7d1.png">
<img width="648" alt="Screenshot 2023-02-28 at 14 09 42" src="https://user-images.githubusercontent.com/5880855/221863669-b389e60c-72a2-418a-9ca2-7c7cb246fb5b.png">
