### PR TITLE
Fix: pre-render the nav sidebar

### DIFF
--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -16,6 +16,8 @@ const isNoSidebarRoute = (pathname: string): boolean => {
     AppRoutes.newSafe.load,
     AppRoutes.welcome,
     AppRoutes.index,
+    AppRoutes.import,
+    AppRoutes.environmentVariables,
   ].includes(pathname)
 }
 

--- a/src/components/sidebar/Sidebar/index.tsx
+++ b/src/components/sidebar/Sidebar/index.tsx
@@ -1,7 +1,6 @@
-import { useState, type ReactElement } from 'react'
-import { Divider, Drawer, IconButton } from '@mui/material'
+import { useCallback, useState, type ReactElement } from 'react'
+import { Box, Divider, Drawer, IconButton } from '@mui/material'
 import ChevronRight from '@mui/icons-material/ChevronRight'
-import { useRouter } from 'next/router'
 
 import ChainIndicator from '@/components/common/ChainIndicator'
 import SidebarHeader from '@/components/sidebar/SidebarHeader'
@@ -11,54 +10,49 @@ import SidebarFooter from '@/components/sidebar/SidebarFooter'
 
 import css from './styles.module.css'
 import { trackEvent, OVERVIEW_EVENTS } from '@/services/analytics'
-import KeyholeIcon from '@/components/common/icons/KeyholeIcon'
-import OwnedSafes from '../OwnedSafes'
 
 const Sidebar = (): ReactElement => {
-  const router = useRouter()
   const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(false)
-  const isSafeRoute = !!router.query?.safe
 
-  const onDrawerToggle = () => {
-    trackEvent({ ...OVERVIEW_EVENTS.SIDEBAR, label: isDrawerOpen ? 'Close' : 'Open' })
-    setIsDrawerOpen((prev) => !prev)
-  }
+  const onDrawerToggle = useCallback(() => {
+    setIsDrawerOpen((isOpen) => {
+      trackEvent({ ...OVERVIEW_EVENTS.SIDEBAR, label: isOpen ? 'Close' : 'Open' })
+
+      return !isOpen
+    })
+  }, [])
+
+  const closeDrawer = useCallback(() => setIsDrawerOpen(false), [])
 
   return (
     <div className={css.container}>
       <div className={css.scroll}>
         <ChainIndicator />
 
+        {/* Open the safes list */}
         <IconButton className={css.drawerButton} onClick={onDrawerToggle}>
           <ChevronRight />
         </IconButton>
 
-        {isSafeRoute ? (
-          <>
-            <SidebarHeader />
-            <Divider />
-            <SidebarNavigation />
-          </>
-        ) : (
-          <>
-            <div className={css.noSafeHeader}>
-              <KeyholeIcon />
-            </div>
+        {/* Address, balance, copy button, etc */}
+        <SidebarHeader />
 
-            <OwnedSafes />
-          </>
-        )}
+        <Divider />
 
-        <div style={{ flexGrow: 1 }} />
+        {/* Nav menu */}
+        <SidebarNavigation />
+
+        <Box flex={1} />
 
         <Divider flexItem />
 
+        {/* What's new + Need help? */}
         <SidebarFooter />
       </div>
 
       <Drawer variant="temporary" anchor="left" open={isDrawerOpen} onClose={onDrawerToggle}>
         <div className={css.drawer}>
-          <SafeList closeDrawer={() => setIsDrawerOpen(false)} />
+          <SafeList closeDrawer={closeDrawer} />
         </div>
       </Drawer>
     </div>

--- a/src/components/sidebar/SidebarHeader/index.tsx
+++ b/src/components/sidebar/SidebarHeader/index.tsx
@@ -27,11 +27,13 @@ import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
 import { SvgIcon } from '@mui/material'
 import { useVisibleBalances } from '@/hooks/useVisibleBalances'
 import EnvHintButton from '@/components/settings/EnvironmentVariables/EnvHintButton'
+import useSafeAddress from '@/hooks/useSafeAddress'
 
 const SafeHeader = (): ReactElement => {
   const currency = useAppSelector(selectCurrency)
   const { balances } = useVisibleBalances()
-  const { safe, safeAddress, safeLoading } = useSafeInfo()
+  const safeAddress = useSafeAddress()
+  const { safe } = useSafeInfo()
   const { threshold, owners } = safe
   const chain = useCurrentChain()
   const settings = useAppSelector(selectSettings)
@@ -50,10 +52,10 @@ const SafeHeader = (): ReactElement => {
       <div className={css.info}>
         <div className={css.safe}>
           <div>
-            {safeLoading ? (
-              <Skeleton variant="circular" width={40} height={40} />
-            ) : (
+            {safeAddress ? (
               <SafeIcon address={safeAddress} threshold={threshold} owners={owners?.length} />
+            ) : (
+              <Skeleton variant="circular" width={40} height={40} />
             )}
           </div>
 
@@ -63,6 +65,7 @@ const SafeHeader = (): ReactElement => {
             ) : (
               <Typography variant="body2">
                 <Skeleton variant="text" width={86} />
+                <Skeleton variant="text" width={120} />
               </Typography>
             )}
 

--- a/src/components/sidebar/SidebarHeader/index.tsx
+++ b/src/components/sidebar/SidebarHeader/index.tsx
@@ -58,12 +58,12 @@ const SafeHeader = (): ReactElement => {
           </div>
 
           <div className={css.address}>
-            {safeLoading ? (
+            {safeAddress ? (
+              <EthHashInfo address={safeAddress} shortAddress showAvatar={false} />
+            ) : (
               <Typography variant="body2">
                 <Skeleton variant="text" width={86} />
               </Typography>
-            ) : (
-              <EthHashInfo address={safeAddress} shortAddress showAvatar={false} />
             )}
 
             <Typography variant="body2" fontWeight={700}>
@@ -101,6 +101,7 @@ const SafeHeader = (): ReactElement => {
               </IconButton>
             </Tooltip>
           </Track>
+
           <EnvHintButton />
         </div>
       </div>


### PR DESCRIPTION
## What it solves

Partly #1714

## How this PR fixes it

The sidebar was previously rendered conditionally in two variants: for `?safe` routes and for non-safe routes.
Since we now don't show the sidebar for pages like Welcome, Safe Creation etc, there's no need for this variance, and we can always render the nav sidebar for a better static site performance.

## How to test it
Disable JS and load the Balances page of any Safe. The sidebar should appear much faster.