### PR TITLE
Fix: apps sdk widget design

### DIFF
--- a/src/components/safe-apps/SafeAppsSDKLink/index.tsx
+++ b/src/components/safe-apps/SafeAppsSDKLink/index.tsx
@@ -1,49 +1,43 @@
-import { useState } from 'react'
-import Link from 'next/link'
-import Box from '@mui/material/Box'
-import Collapse from '@mui/material/Collapse'
-import Typography from '@mui/material/Typography'
-import MUILink from '@mui/material/Link'
-import Fab from '@mui/material/Fab'
+import { useEffect, useState } from 'react'
+import { Fab, Typography } from '@mui/material'
 import KeyboardDoubleArrowUpRoundedIcon from '@mui/icons-material/KeyboardDoubleArrowUpRounded'
-
+import classnames from 'classnames'
 import CodeIcon from '@/public/images/apps/code-icon.svg'
 import { SAFE_APPS_SDK_DOCS_URL } from '@/config/constants'
 import css from './styles.module.css'
+import ExternalLink from '@/components/common/ExternalLink'
 
 const SafeAppsSDKLink = () => {
-  const [openModal, setOpenModal] = useState<boolean>(false)
+  const [mini, setMini] = useState(false)
+
+  useEffect(() => {
+    const minScroll = 130
+    const onScroll = () => {
+      const isScrolled = document.documentElement.scrollTop > minScroll
+      setMini(isScrolled)
+    }
+
+    document.addEventListener('scroll', onScroll)
+
+    return () => document.removeEventListener('scroll', onScroll)
+  }, [])
 
   return (
-    <Box className={css.position} onMouseEnter={() => setOpenModal(true)} onMouseLeave={() => setOpenModal(false)}>
-      <Collapse in={openModal}>
-        {
-          <Box className={css.container}>
-            <CodeIcon />
+    <div className={classnames(css.container, { [css.mini]: mini })}>
+      <CodeIcon />
 
-            <Typography variant="h6" className={css.title}>
-              How to build on Safe?
-            </Typography>
+      <Typography variant="h6" className={css.title}>
+        How to build on Safe?
+      </Typography>
 
-            <Link href={SAFE_APPS_SDK_DOCS_URL} passHref>
-              <MUILink rel="noreferrer noopener" target="_blank" href={SAFE_APPS_SDK_DOCS_URL} className={css.link}>
-                Learn more about Safe Apps SDK
-              </MUILink>
-            </Link>
-          </Box>
-        }
-      </Collapse>
-      <Fab
-        className={css.openButton}
-        variant="extended"
-        size="small"
-        color="secondary"
-        aria-label="add"
-        onClick={() => setOpenModal(false)}
-      >
+      <ExternalLink href={SAFE_APPS_SDK_DOCS_URL} className={css.link} noIcon variant="body2">
+        <span>Learn more about Safe Apps SDK</span>
+      </ExternalLink>
+
+      <Fab className={css.openButton} variant="extended" size="small" color="secondary">
         <KeyboardDoubleArrowUpRoundedIcon fontSize="small" />
       </Fab>
-    </Box>
+    </div>
   )
 }
 

--- a/src/components/safe-apps/SafeAppsSDKLink/index.tsx
+++ b/src/components/safe-apps/SafeAppsSDKLink/index.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import type { SyntheticEvent } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Fab, Typography } from '@mui/material'
 import KeyboardDoubleArrowUpRoundedIcon from '@mui/icons-material/KeyboardDoubleArrowUpRounded'
 import classnames from 'classnames'
@@ -24,8 +25,13 @@ const SafeAppsSDKLink = () => {
     return () => document.removeEventListener('scroll', onScroll)
   }, [])
 
+  const onButtonClick = useCallback((e: SyntheticEvent) => {
+    e.preventDefault()
+    ;(e.target as HTMLButtonElement).parentElement?.focus()
+  }, [])
+
   return (
-    <div className={classnames(css.container, { [css.mini]: isMini })}>
+    <div className={classnames(css.container, { [css.mini]: isMini })} tabIndex={0}>
       <CodeIcon />
 
       <Typography variant="h6" className={css.title}>
@@ -36,7 +42,7 @@ const SafeAppsSDKLink = () => {
         <span>Learn more about Safe Apps SDK</span>
       </ExternalLink>
 
-      <Fab className={css.openButton} variant="extended" size="small" color="secondary">
+      <Fab className={css.openButton} variant="extended" size="small" color="secondary" onClick={onButtonClick}>
         <KeyboardDoubleArrowUpRoundedIcon fontSize="small" />
       </Fab>
     </div>

--- a/src/components/safe-apps/SafeAppsSDKLink/index.tsx
+++ b/src/components/safe-apps/SafeAppsSDKLink/index.tsx
@@ -10,10 +10,12 @@ import ExternalLink from '@/components/common/ExternalLink'
 const SafeAppsSDKLink = () => {
   const [isMini, setMini] = useState(false)
 
+  // Minimize the widget when the user scrolls down
   useEffect(() => {
-    const minScroll = 130
+    const MAX_SCROLL = 130
+
     const onScroll = () => {
-      const isScrolled = document.documentElement.scrollTop > minScroll
+      const isScrolled = document.documentElement.scrollTop > MAX_SCROLL
       setMini(isScrolled)
     }
 

--- a/src/components/safe-apps/SafeAppsSDKLink/index.tsx
+++ b/src/components/safe-apps/SafeAppsSDKLink/index.tsx
@@ -1,5 +1,4 @@
-import type { SyntheticEvent } from 'react'
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Fab, Typography } from '@mui/material'
 import KeyboardDoubleArrowUpRoundedIcon from '@mui/icons-material/KeyboardDoubleArrowUpRounded'
 import classnames from 'classnames'
@@ -25,11 +24,6 @@ const SafeAppsSDKLink = () => {
     return () => document.removeEventListener('scroll', onScroll)
   }, [])
 
-  const onButtonClick = useCallback((e: SyntheticEvent) => {
-    e.preventDefault()
-    ;(e.target as HTMLButtonElement).parentElement?.focus()
-  }, [])
-
   return (
     <div className={classnames(css.container, { [css.mini]: isMini })} tabIndex={0}>
       <CodeIcon />
@@ -42,7 +36,7 @@ const SafeAppsSDKLink = () => {
         <span>Learn more about Safe Apps SDK</span>
       </ExternalLink>
 
-      <Fab className={css.openButton} variant="extended" size="small" color="secondary" onClick={onButtonClick}>
+      <Fab className={css.openButton} variant="extended" size="small" color="secondary" tabIndex={-1}>
         <KeyboardDoubleArrowUpRoundedIcon fontSize="small" />
       </Fab>
     </div>

--- a/src/components/safe-apps/SafeAppsSDKLink/index.tsx
+++ b/src/components/safe-apps/SafeAppsSDKLink/index.tsx
@@ -8,7 +8,7 @@ import css from './styles.module.css'
 import ExternalLink from '@/components/common/ExternalLink'
 
 const SafeAppsSDKLink = () => {
-  const [mini, setMini] = useState(false)
+  const [isMini, setMini] = useState(false)
 
   useEffect(() => {
     const minScroll = 130
@@ -23,7 +23,7 @@ const SafeAppsSDKLink = () => {
   }, [])
 
   return (
-    <div className={classnames(css.container, { [css.mini]: mini })}>
+    <div className={classnames(css.container, { [css.mini]: isMini })}>
       <CodeIcon />
 
       <Typography variant="h6" className={css.title}>

--- a/src/components/safe-apps/SafeAppsSDKLink/styles.module.css
+++ b/src/components/safe-apps/SafeAppsSDKLink/styles.module.css
@@ -14,6 +14,11 @@
   transform: translateY(-24px);
 }
 
+.container:focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
 @media (max-width: 1400px) {
   .container {
     right: var(--space-3);

--- a/src/components/safe-apps/SafeAppsSDKLink/styles.module.css
+++ b/src/components/safe-apps/SafeAppsSDKLink/styles.module.css
@@ -1,30 +1,47 @@
-.position {
-  position: fixed;
-  right: 0;
-  z-index: 3;
+.container {
   width: 200px;
-  margin-right: 64px;
+  padding: var(--space-3);
+  padding-top: var(--space-6);
+  background-color: var(--color-background-main);
+  border: 1px solid var(--color-secondary-main);
+  border-radius: 0 0 12px 12px;
+  border-top: 0;
+  position: fixed;
+  z-index: 3;
+  right: 64px;
+  top: var(--header-height);
+  transition: transform 0.3s ease-in-out;
+  transform: translateY(-24px);
+}
 
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+.container.mini {
+  transform: translateY(-100%);
+  transition-duration: 0.4s;
+}
+
+.container:hover {
+  z-index: 1200;
+  transform: translateY(0);
 }
 
 .openButton {
   width: 50px;
   height: 20px;
-  margin: 0 auto 36px auto;
   border-radius: 0 0 8px 8px;
+  position: absolute;
+  z-index: 1;
+  left: 50%;
+  bottom: -20px;
+  margin-left: -25px;
 }
 
-.container {
-  width: 200px;
-  padding: var(--space-7) var(--space-3) var(--space-4) var(--space-3);
-  background-color: var(--color-background-main);
-  border: 1px solid var(--color-secondary-main);
-  border-radius: 0 0 12px 12px;
-  border-top: 0;
+.openButton svg {
+  transform: rotate(180deg);
+  transition: transform 0.3s ease-in-out;
+}
+
+.container:hover .openButton svg {
+  transform: rotate(0deg);
 }
 
 .title {
@@ -32,11 +49,25 @@
   font-size: 20px;
   line-height: 130%;
   letter-spacing: 0.15px;
-
   margin-top: var(--space-2);
-  margin-bottom: var(--space-1);
 }
 
 .link {
   font-weight: 400;
+  display: block;
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transition: all 0.3s ease-in-out;
+}
+
+.link span {
+  display: block;
+  margin-top: var(--space-1);
+}
+
+.mini .link,
+.container:hover .link {
+  opacity: 1;
+  max-height: 10ex;
 }

--- a/src/components/safe-apps/SafeAppsSDKLink/styles.module.css
+++ b/src/components/safe-apps/SafeAppsSDKLink/styles.module.css
@@ -31,6 +31,7 @@
   transition-duration: 0.4s;
 }
 
+.container:focus,
 .container:hover {
   z-index: 1200;
   transform: translateY(0);
@@ -52,6 +53,7 @@
   transition: transform 0.3s ease-in-out;
 }
 
+.container:focus .openButton svg,
 .container:hover .openButton svg {
   transform: rotate(0deg);
 }
@@ -79,6 +81,7 @@
 }
 
 .mini .link,
+.container:focus .link,
 .container:hover .link {
   opacity: 1;
   max-height: 10ex;

--- a/src/components/safe-apps/SafeAppsSDKLink/styles.module.css
+++ b/src/components/safe-apps/SafeAppsSDKLink/styles.module.css
@@ -14,6 +14,18 @@
   transform: translateY(-24px);
 }
 
+@media (max-width: 1400px) {
+  .container {
+    right: var(--space-3);
+  }
+}
+
+@media (max-width: 1210px) {
+  .container {
+    transform: translateY(-80px);
+  }
+}
+
 .container.mini {
   transform: translateY(-100%);
   transition-duration: 0.4s;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -37,7 +37,7 @@ export const SAFE_APPS_INFURA_TOKEN = process.env.NEXT_PUBLIC_SAFE_APPS_INFURA_T
 export const SAFE_APPS_THIRD_PARTY_COOKIES_CHECK_URL = 'https://third-party-cookies-check.gnosis-safe.com'
 export const SAFE_APPS_SUPPORT_CHAT_URL = 'https://chat.safe.global'
 export const SAFE_APPS_DEMO_SAFE_MAINNET = 'eth:0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7'
-export const SAFE_APPS_SDK_DOCS_URL = 'https://docs.gnosis-safe.io/learn/safe-tools/sdks/safe-apps'
+export const SAFE_APPS_SDK_DOCS_URL = 'https://docs.safe.global/learn/safe-tools/sdks/safe-apps'
 
 // Google Tag Manager
 export const GOOGLE_TAG_MANAGER_ID = process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID || ''


### PR DESCRIPTION
## What it solves

Resolves #1665

## How this PR fixes it

* I made it open on hover as per design
* Initially, it will show "How to build on Safe"
* If scrolled down a bit, it will minimize itself to not overlap with the page content

<img width="499" alt="Screenshot 2023-03-01 at 09 32 26" src="https://user-images.githubusercontent.com/381895/222086593-64112f03-f03c-4e3a-a022-ac30004bd09c.png">