### PR TITLE
fix: Reuse amount validation for spending limits

### DIFF
--- a/src/components/settings/SpendingLimits/NewSpendingLimit/steps/SpendingLimitForm.tsx
+++ b/src/components/settings/SpendingLimits/NewSpendingLimit/steps/SpendingLimitForm.tsx
@@ -15,7 +15,7 @@ import {
   FormGroup,
 } from '@mui/material'
 import AddressBookInput from '@/components/common/AddressBookInput'
-import { validateAmount } from '@/utils/validation'
+import { validateAmount, validateDecimalLength } from '@/utils/validation'
 import { AutocompleteItem } from '@/components/tx/modals/TokenTransferModal/SendAssetsForm'
 import useChainId from '@/hooks/useChainId'
 import { getResetTimeOptions } from '@/components/transactions/TxDetails/TxData/SpendingLimits'
@@ -113,8 +113,14 @@ export const SpendingLimitForm = ({ data, onSubmit }: Props) => {
               required
               {...register('amount', {
                 required: true,
-                validate: (val) =>
-                  validateAmount(val) || _validateSpendingLimit(val, selectedToken?.tokenInfo.decimals),
+                validate: (val) => {
+                  const decimals = selectedToken?.tokenInfo.decimals
+                  return (
+                    validateAmount(val) ||
+                    validateDecimalLength(val, decimals) ||
+                    _validateSpendingLimit(val, selectedToken?.tokenInfo.decimals)
+                  )
+                },
               })}
             />
           </FormControl>


### PR DESCRIPTION
## What it solves

Resolves #1654 

## How this PR fixes it

- Adds decimal validation to the amount input in `SpendingLimitForm`

## How to test it

1. Open a Safe
2. Create a new Spending Limit
5. Amount can't have too little or too many decimals

## Analytics changes


## Screenshots
<img width="634" alt="Screenshot 2023-03-01 at 17 09 44" src="https://user-images.githubusercontent.com/5880855/222196532-53f99938-b113-4cb9-be47-809a6ba94aa2.png">

