### PR TITLE
fix: alphabetically sort remote apps

### DIFF
--- a/src/hooks/__tests__/useRemoteSafeApps.test.ts
+++ b/src/hooks/__tests__/useRemoteSafeApps.test.ts
@@ -1,0 +1,73 @@
+import { act, renderHook } from '@testing-library/react'
+import * as gateway from '@safe-global/safe-gateway-typescript-sdk'
+
+import * as useChainIdHook from '@/hooks/useChainId'
+import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
+import type { SafeAppsTag } from '@/config/constants'
+
+jest.mock('@safe-global/safe-gateway-typescript-sdk')
+
+describe('useRemoteSafeApps', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+
+    jest.spyOn(useChainIdHook, 'default').mockReturnValue('5')
+    jest
+      .spyOn(gateway, 'getSafeApps')
+      .mockResolvedValue([
+        { name: 'B', tags: ['test'] } as gateway.SafeAppData,
+        { name: 'A', tags: [] as gateway.SafeAppData['tags'] } as gateway.SafeAppData,
+        { name: 'C', tags: ['test'] } as gateway.SafeAppData,
+      ])
+  })
+
+  it('should alphabetically return the remote safe apps', async () => {
+    const { result } = renderHook(() => useRemoteSafeApps())
+
+    var [data, error, loading] = result.current
+
+    // Check that the loading state is true
+    expect(loading).toBe(true)
+    expect(error).toBe(undefined)
+    expect(data).toEqual(undefined)
+
+    // Check that the loading state is false after the promise resolves
+    await act(async () => {
+      jest.advanceTimersByTime(100)
+    })
+
+    var [data, error, loading] = result.current
+
+    expect(loading).toBe(false)
+    expect(error).toBe(undefined)
+    expect(data).toStrictEqual([
+      { name: 'A', tags: [] },
+      { name: 'B', tags: ['test'] },
+      { name: 'C', tags: ['test'] },
+    ])
+  })
+  it('should alphabetically return the remote safe apps filtered by tag', async () => {
+    const { result } = renderHook(() => useRemoteSafeApps('test' as SafeAppsTag))
+
+    var [data, error, loading] = result.current
+
+    // Check that the loading state is true
+    expect(loading).toBe(true)
+    expect(error).toBe(undefined)
+    expect(data).toEqual(undefined)
+
+    // Check that the loading state is false after the promise resolves
+    await act(async () => {
+      jest.advanceTimersByTime(100)
+    })
+
+    var [data, error, loading] = result.current
+
+    expect(loading).toBe(false)
+    expect(error).toBe(undefined)
+    expect(data).toStrictEqual([
+      { name: 'B', tags: ['test'] },
+      { name: 'C', tags: ['test'] },
+    ])
+  })
+})

--- a/src/hooks/safe-apps/useRemoteSafeApps.ts
+++ b/src/hooks/safe-apps/useRemoteSafeApps.ts
@@ -41,11 +41,7 @@ const useRemoteSafeApps = (tag?: SafeAppsTag): AsyncResult<SafeAppsResponse> => 
 
   const apps = useMemo(() => {
     if (!remoteApps || !tag) return remoteApps
-    return remoteApps
-      .filter((app) => app.tags.includes(tag))
-      .sort((a, b) => {
-        return a.name < b.name ? -1 : a.name > b.name ? 1 : 0
-      })
+    return remoteApps.filter((app) => app.tags.includes(tag))
   }, [remoteApps, tag])
 
   const sortedApps = useMemo(() => {

--- a/src/hooks/safe-apps/useRemoteSafeApps.ts
+++ b/src/hooks/safe-apps/useRemoteSafeApps.ts
@@ -41,10 +41,18 @@ const useRemoteSafeApps = (tag?: SafeAppsTag): AsyncResult<SafeAppsResponse> => 
 
   const apps = useMemo(() => {
     if (!remoteApps || !tag) return remoteApps
-    return remoteApps.filter((app) => app.tags.includes(tag))
+    return remoteApps
+      .filter((app) => app.tags.includes(tag))
+      .sort((a, b) => {
+        return a.name < b.name ? -1 : a.name > b.name ? 1 : 0
+      })
   }, [remoteApps, tag])
 
-  return [apps, error, loading]
+  const sortedApps = useMemo(() => {
+    return apps?.sort((a, b) => a.name.localeCompare(b.name))
+  }, [apps])
+
+  return [sortedApps, error, loading]
 }
 
 export { useRemoteSafeApps }

--- a/src/hooks/safe-apps/useSafeApps.ts
+++ b/src/hooks/safe-apps/useSafeApps.ts
@@ -23,24 +23,20 @@ type ReturnType = {
 }
 
 const useSafeApps = (): ReturnType => {
-  const [remoteSafeApps, remoteSafeAppsError, remoteSafeAppsLoading] = useRemoteSafeApps()
+  const [remoteSafeApps = [], remoteSafeAppsError, remoteSafeAppsLoading] = useRemoteSafeApps()
   const { customSafeApps, loading: customSafeAppsLoading, updateCustomSafeApps } = useCustomSafeApps()
   const { pinnedSafeAppIds, updatePinnedSafeApps } = usePinnedSafeApps()
   const { removePermissions: removeSafePermissions } = useSafePermissions()
   const { removePermissions: removeBrowserPermissions } = useBrowserPermissions()
 
-  const sortedRemoteSafeApps = useMemo(() => {
-    return (remoteSafeApps || []).sort((a, b) => a.name.localeCompare(b.name))
-  }, [remoteSafeApps])
-
   const allSafeApps = useMemo(
-    () => sortedRemoteSafeApps.concat(customSafeApps).sort((a, b) => a.name.localeCompare(b.name)),
-    [sortedRemoteSafeApps, customSafeApps],
+    () => remoteSafeApps.concat(customSafeApps).sort((a, b) => a.name.localeCompare(b.name)),
+    [remoteSafeApps, customSafeApps],
   )
 
   const pinnedSafeApps = useMemo(
-    () => sortedRemoteSafeApps.filter((app) => pinnedSafeAppIds.has(app.id)),
-    [sortedRemoteSafeApps, pinnedSafeAppIds],
+    () => remoteSafeApps.filter((app) => pinnedSafeAppIds.has(app.id)),
+    [remoteSafeApps, pinnedSafeAppIds],
   )
 
   const rankedSafeApps = useRankedSafeApps(allSafeApps, pinnedSafeApps)
@@ -84,7 +80,7 @@ const useSafeApps = (): ReturnType => {
     allSafeApps,
     rankedSafeApps,
 
-    remoteSafeApps: sortedRemoteSafeApps,
+    remoteSafeApps,
     remoteSafeAppsLoading: remoteSafeAppsLoading || !(remoteSafeApps || remoteSafeAppsError),
     remoteSafeAppsError,
 


### PR DESCRIPTION
## What it solves

Resolves #1713

## How this PR fixes it

`useRemoteSafeApps` sorts the remote apps alphabetically.

## How to test it

1. Open the Safe Apps list and observe it alphabetically sorted (before filter).
2. Open the NFT list and observe the NFT Safe Apps sorted alphabetically.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/222113129-e21b8584-5a2c-43a3-a1ae-3e1ca28d8d91.png)

![image](https://user-images.githubusercontent.com/20442784/222113153-7ec553f9-33ef-47df-8039-8721485ba26c.png)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
