### PR TITLE
Fix: OpenSea links for l2 chains

### DIFF
--- a/src/components/nfts/config.ts
+++ b/src/components/nfts/config.ts
@@ -40,7 +40,7 @@ export const nftPlatforms: Record<keyof typeof chains, Array<NftPlatform>> = {
     {
       title: 'OpenSea',
       logo: '/images/common/nft-opensea.svg',
-      getUrl: (item) => `https://opensea.io/matic/${item.address}/${item.id}`,
+      getUrl: (item) => `https://opensea.io/assets/matic/${item.address}/${item.id}`,
     },
   ],
 
@@ -57,6 +57,38 @@ export const nftPlatforms: Record<keyof typeof chains, Array<NftPlatform>> = {
       title: 'OpenSea',
       logo: '/images/common/nft-opensea.svg',
       getUrl: (item) => `https://testnets.opensea.io/assets/${item.address}/${item.id}`,
+    },
+  ],
+
+  [chains.oeth]: [
+    {
+      title: 'OpenSea',
+      logo: '/images/common/nft-opensea.svg',
+      getUrl: (item) => `https://opensea.io/assets/optimism/${item.address}/${item.id}`,
+    },
+  ],
+
+  [chains.arb1]: [
+    {
+      title: 'OpenSea',
+      logo: '/images/common/nft-opensea.svg',
+      getUrl: (item) => `https://opensea.io/assets/arbitrum/${item.address}/${item.id}`,
+    },
+  ],
+
+  [chains.avax]: [
+    {
+      title: 'OpenSea',
+      logo: '/images/common/nft-opensea.svg',
+      getUrl: (item) => `https://opensea.io/assets/avalanche/${item.address}/${item.id}`,
+    },
+  ],
+
+  [chains.bnb]: [
+    {
+      title: 'OpenSea',
+      logo: '/images/common/nft-opensea.svg',
+      getUrl: (item) => `https://opensea.io/assets/bsc/${item.address}/${item.id}`,
     },
   ],
 }


### PR DESCRIPTION
## What it solves

I've added OpenSea links on the NFT page for all the chains that it supports.
Also fixed the Polygon link, it was wrong.

## How to test
I've tested the links in these safes:
Polygon: matic:0xbf4C4b9Cf903a540dF752c10912de377A55e4FA6
Optimism: oeth:0xf9D445a46D65427550174ec2A49FceFA3dae7f8D
Arbitrum: arb1:0x2EBA2F2F1D599E9E2920ce4B70b1B881e76db82E
Avalanche: avax:0xbD99AB5EbD2a68e4Ad4b21dF73f5f393fe223411
Binance: bnb:0xe83FA375a2a7c383B1fB6a6ed6bB22F6A123a980

## Screenshots
<img width="1160" alt="Screenshot 2023-03-01 at 12 11 04" src="https://user-images.githubusercontent.com/381895/222123171-7eedae3a-d53f-4ee8-bb44-e4f5119f1324.png">