### PR TITLE
fix: show new name in review modal

### DIFF
--- a/src/components/settings/owner/AddOwnerDialog/DialogSteps/ReviewOwnerTxStep.tsx
+++ b/src/components/settings/owner/AddOwnerDialog/DialogSteps/ReviewOwnerTxStep.tsx
@@ -120,7 +120,13 @@ export const ReviewOwnerTxStep = ({ data, onSubmit }: { data: ChangeOwnerData; o
           </div>
           <Divider />
           <Box padding={2}>
-            <EthHashInfo address={newOwner.address} shortAddress={false} showCopyButton hasExplorer />
+            <EthHashInfo
+              name={newOwner.name}
+              address={newOwner.address}
+              shortAddress={false}
+              showCopyButton
+              hasExplorer
+            />
           </Box>
         </Grid>
       </Grid>


### PR DESCRIPTION
## What it solves

Resolves #1613

## How this PR fixes it

The new name of the owner-to-be-added is shown in the review modal instead of that from the address book.

## How to test it

1. Add an address that is NOT AN OWNER of the current Safe to the address book.
2. Attempt to add the aformentioned address as an owner of the Safe, specifying a new name.
3. Observe the new name shown in the review modal under which the address will be stored under

## Screenshots

![new name](https://user-images.githubusercontent.com/20442784/222161071-5e9d9e32-4133-4ecb-925e-4e6e397023f9.gif)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
