### PR TITLE
Add policy pages

### DIFF
--- a/src/components/common/Footer/index.tsx
+++ b/src/components/common/Footer/index.tsx
@@ -1,5 +1,6 @@
 import type { SyntheticEvent, ReactElement } from 'react'
-import { Link, Typography } from '@mui/material'
+import { Typography } from '@mui/material'
+import Link from 'next/link'
 import { useRouter } from 'next/router'
 import css from './styles.module.css'
 import { useAppDispatch } from '@/store'
@@ -8,8 +9,9 @@ import { AppRoutes } from '@/config/routes'
 import packageJson from '../../../../package.json'
 import AppstoreButton from '../AppStoreButton'
 import ExternalLink from '../ExternalLink'
+import MUILink from '@mui/material/Link'
 
-const footerPages = [AppRoutes.welcome, AppRoutes.settings.index]
+const footerPages = [AppRoutes.welcome, AppRoutes.settings.index, AppRoutes.imprint]
 
 const Footer = (): ReactElement | null => {
   const router = useRouter()
@@ -46,18 +48,18 @@ const Footer = (): ReactElement | null => {
           </ExternalLink>
         </li>
         <li>
-          <ExternalLink noIcon href="https://safe.global/imprint">
-            Imprint
-          </ExternalLink>
+          <Link href={AppRoutes.imprint} passHref>
+            <MUILink>Imprint</MUILink>
+          </Link>
         </li>
         <li>
           <ExternalLink noIcon href="https://safe.global/cookie">
             Cookie Policy
           </ExternalLink>
           &nbsp;&mdash;&nbsp;
-          <Link href="#" onClick={onCookieClick}>
+          <MUILink href="#" onClick={onCookieClick}>
             Preferences
-          </Link>
+          </MUILink>
         </li>
         <li>
           <ExternalLink noIcon href={`${packageJson.homepage}/releases/tag/v${packageJson.version}`}>

--- a/src/components/common/Footer/index.tsx
+++ b/src/components/common/Footer/index.tsx
@@ -17,6 +17,7 @@ const footerPages = [
   AppRoutes.imprint,
   AppRoutes.privacy,
   AppRoutes.cookie,
+  AppRoutes.terms,
 ]
 
 const Footer = (): ReactElement | null => {
@@ -39,9 +40,9 @@ const Footer = (): ReactElement | null => {
           <Typography variant="caption">&copy;2022–{new Date().getFullYear()} Safe Ecosystem Foundation</Typography>
         </li>
         <li>
-          <ExternalLink noIcon href="https://safe.global/terms">
-            Terms
-          </ExternalLink>
+          <Link href={AppRoutes.terms} passHref>
+            <MUILink>Terms</MUILink>
+          </Link>
         </li>
         <li>
           <Link href={AppRoutes.privacy} passHref>

--- a/src/components/common/Footer/index.tsx
+++ b/src/components/common/Footer/index.tsx
@@ -11,7 +11,7 @@ import AppstoreButton from '../AppStoreButton'
 import ExternalLink from '../ExternalLink'
 import MUILink from '@mui/material/Link'
 
-const footerPages = [AppRoutes.welcome, AppRoutes.settings.index, AppRoutes.imprint]
+const footerPages = [AppRoutes.welcome, AppRoutes.settings.index, AppRoutes.imprint, AppRoutes.privacy]
 
 const Footer = (): ReactElement | null => {
   const router = useRouter()

--- a/src/components/common/Footer/index.tsx
+++ b/src/components/common/Footer/index.tsx
@@ -11,7 +11,13 @@ import AppstoreButton from '../AppStoreButton'
 import ExternalLink from '../ExternalLink'
 import MUILink from '@mui/material/Link'
 
-const footerPages = [AppRoutes.welcome, AppRoutes.settings.index, AppRoutes.imprint, AppRoutes.privacy]
+const footerPages = [
+  AppRoutes.welcome,
+  AppRoutes.settings.index,
+  AppRoutes.imprint,
+  AppRoutes.privacy,
+  AppRoutes.cookie,
+]
 
 const Footer = (): ReactElement | null => {
   const router = useRouter()
@@ -38,9 +44,9 @@ const Footer = (): ReactElement | null => {
           </ExternalLink>
         </li>
         <li>
-          <ExternalLink noIcon href="https://safe.global/privacy">
-            Privacy
-          </ExternalLink>
+          <Link href={AppRoutes.privacy} passHref>
+            <MUILink>Privacy</MUILink>
+          </Link>
         </li>
         <li>
           <ExternalLink noIcon href="https://safe.global/licenses">
@@ -53,9 +59,9 @@ const Footer = (): ReactElement | null => {
           </Link>
         </li>
         <li>
-          <ExternalLink noIcon href="https://safe.global/cookie">
-            Cookie Policy
-          </ExternalLink>
+          <Link href={AppRoutes.cookie} passHref>
+            <MUILink>Cookie Policy</MUILink>
+          </Link>
           &nbsp;&mdash;&nbsp;
           <MUILink href="#" onClick={onCookieClick}>
             Preferences

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -20,6 +20,7 @@ const isNoSidebarRoute = (pathname: string): boolean => {
     AppRoutes.environmentVariables,
     AppRoutes.imprint,
     AppRoutes.privacy,
+    AppRoutes.cookie,
   ].includes(pathname)
 }
 

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -19,6 +19,7 @@ const isNoSidebarRoute = (pathname: string): boolean => {
     AppRoutes.import,
     AppRoutes.environmentVariables,
     AppRoutes.imprint,
+    AppRoutes.privacy,
   ].includes(pathname)
 }
 

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -18,6 +18,7 @@ const isNoSidebarRoute = (pathname: string): boolean => {
     AppRoutes.index,
     AppRoutes.import,
     AppRoutes.environmentVariables,
+    AppRoutes.imprint,
   ].includes(pathname)
 }
 

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -21,6 +21,7 @@ const isNoSidebarRoute = (pathname: string): boolean => {
     AppRoutes.imprint,
     AppRoutes.privacy,
     AppRoutes.cookie,
+    AppRoutes.terms,
   ].includes(pathname)
 }
 

--- a/src/components/common/TermsBanner/index.tsx
+++ b/src/components/common/TermsBanner/index.tsx
@@ -1,0 +1,44 @@
+import { AppRoutes } from '@/config/routes'
+import css from './styles.module.css'
+import { Button, Typography } from '@mui/material'
+import Link from 'next/link'
+import MUILink from '@mui/material/Link'
+import useLocalStorage from '@/services/local-storage/useLocalStorage'
+
+const TERMS_KEY = 'terms_dismissed'
+
+const TermsBanner = () => {
+  const [isDismissed = false, setIsDismissed] = useLocalStorage<boolean>(TERMS_KEY)
+
+  const dismissBanner = () => {
+    setIsDismissed(true)
+  }
+
+  if (isDismissed) return null
+
+  return (
+    <div className={css.wrapper}>
+      <Typography variant="h4" fontWeight="bold" mb={1}>
+        Terms
+      </Typography>
+      <Typography>
+        We updated our Terms and Conditions. Review the new terms{' '}
+        <Link href={AppRoutes.terms} passHref>
+          <MUILink color="success.main"> here</MUILink>
+        </Link>
+      </Typography>
+      <Button
+        variant="contained"
+        color="success"
+        size="small"
+        className={css.button}
+        onClick={dismissBanner}
+        disableElevation
+      >
+        Ok
+      </Button>
+    </div>
+  )
+}
+
+export default TermsBanner

--- a/src/components/common/TermsBanner/styles.module.css
+++ b/src/components/common/TermsBanner/styles.module.css
@@ -1,0 +1,15 @@
+.wrapper {
+  position: fixed;
+  bottom: var(--space-3);
+  right: var(--space-3);
+  width: 350px;
+  background: var(--color-text-primary);
+  color: var(--color-background-paper);
+  padding: var(--space-2);
+  z-index: 1400;
+}
+
+.button {
+  display: block;
+  margin-left: auto;
+}

--- a/src/components/cookie-policy/index.tsx
+++ b/src/components/cookie-policy/index.tsx
@@ -1,0 +1,569 @@
+import css from './styles.module.css'
+import Link from 'next/link'
+import MUILink from '@mui/material/Link'
+import { AppRoutes } from '@/config/routes'
+
+const SafeCookiePolicy = () => {
+  return (
+    <div>
+      <h1>Cookie Policy</h1>
+      <p>Last updated on March 2023</p>
+      <p>
+        As described in our{' '}
+        <Link href={AppRoutes.privacy} passHref>
+          <MUILink>Privacy Policy</MUILink>
+        </Link>
+        , For general web-browsing of this website, your personal data is not revealed to us, although certain
+        statistical information is available to us via our internet service provider as well as through the use of
+        special tracking technologies. Such information tells us about the pages you are clicking on or the hardware you
+        are using, but not your name, age, address or anything we can use to identify you personally. We exclusively
+        process your personal data in pseudonymised form.
+      </p>
+      <p>
+        This Cookie Policy applies to our website at <a href="https://app.safe.global">https://app.safe.global</a>
+        &nbsp;and sets out some further detail on how and why we use these technologies on our website.{' '}
+      </p>
+      <p>
+        In this policy, &quot;we&quot;, &quot;us&quot; and &quot;our&quot; refers to Core Contributors GmbH a company
+        incorporated in Germany with its registered address at Skalitzer Str. 85-86, ℅ Full Node, 10997 Berlin, Germany.
+        The terms &ldquo;you&rdquo; and &ldquo;your&rdquo; includes our clients, business partners and users of this
+        website.{' '}
+      </p>
+      <p>
+        By using our website, you consent to storage and access to cookies and other technologies on your device, in
+        accordance with this Cookie Policy.
+      </p>
+      <h2>What are cookies?</h2>
+      <p>
+        Cookies are a feature of web browser software that allows web servers to recognize the computer or device used
+        to access a website. A cookie is a small text file that a website saves on your computer or mobile device when
+        you visit the site. It enables the website to remember your actions and preferences (such as login, language,
+        font size and other display preferences) over a period of time, so you don&apos;t have to keep re-entering them
+        whenever you come back to the site or browse from one page to another.
+      </p>
+      <h2>What are the different types of cookies?</h2>
+      <p>A cookie can be classified by its lifespan and the domain to which it belongs.</p>
+      <p>By lifespan, a cookie is either a:</p>
+      <ol start={1}>
+        <li>session cookie which is erased when the user closes the browser; or</li>
+        <li>
+          persistent cookie which is saved to the hard drive and remains on the user&apos;s computer/device for a
+          pre-defined period of time. As for the domain to which it belongs, cookies are either:
+        </li>
+      </ol>
+      <ol start={1}>
+        <li>
+          first-party cookies which are set by the web server of the visited page and share the same domain (i.e. set by
+          us); or
+        </li>
+        <li>third-party cookies stored by a different domain to the visited page&apos;s domain.</li>
+      </ol>
+      <h2>What cookies do we use and why?</h2>
+      <p>We list all the cookies we use on this website in the APPENDIX below.</p>
+      <p>
+        We do not use cookies set by ourselves via our web developers (first-party cookies). We only have those set by
+        others (third-party cookies).
+      </p>
+      <p>
+        Cookies are also sometimes classified by reference to their purpose. We use the following cookies for the
+        following purposes:
+      </p>
+      <ol start={1}>
+        <li>
+          Analytical/performance cookies: They allow us to recognize and count the number of visitors and to see how
+          visitors move around our website when they are using it, as well as dates and times they visit. This helps us
+          to improve the way our website works, for example, by ensuring that users are finding what they are looking
+          for easily.
+        </li>
+        <li>
+          Targeting cookies: These cookies record your visit to our website, the pages you have visited and the links
+          you have followed, as well as time spent on our website, and the websites visited just before and just after
+          our website. We will use this information to make our website and the advertising displayed on it more
+          relevant to your interests. We may also share this information with third parties for this purpose.
+        </li>
+      </ol>
+      <p>
+        In general, we use cookies and other technologies (such as web server logs) on our website to enhance your
+        experience and to collect information about how our website is used.{' '}
+      </p>
+      <p>
+        We will retain and evaluate information on your recent visits to our website and how you move around different
+        sections of our website for analytics purposes to understand how people use our website so that we can make it
+        more intuitive. The information also helps us to understand which parts of this website are most popular and
+        generally to assess user behavior and characteristics to measure interest in and use of the various areas of our
+        website. This then allows us to improve our website and the way we market our business.
+      </p>
+      <p>
+        This information may also be used to help us to improve, administer and diagnose problems with our server and
+        website. The information also helps us monitor traffic on our website so that we can manage our website&apos;s
+        capacity and efficiency.
+      </p>
+      <h2>Other Technologies</h2>
+      <p>
+        We may allow others to provide analytics services and serve advertisements on our behalf. In addition to the
+        uses of cookies described above, these entities may use other methods, such as the technologies described below,
+        to collect information about your use of our website and other websites and online services.
+      </p>
+      <p>
+        Pixels tags. Pixel tags (which are also called clear GIFs, web beacons, or pixels), are small pieces of code
+        that can be embedded on websites and emails. Pixels tags may be used to learn how you interact with our website
+        pages and emails, and this information helps us, and our partners provide you with a more tailored experience.
+      </p>
+      <p>
+        Device Identifiers. A device identifier is a unique label that can be used to identify a mobile device. Device
+        identifiers may be used to track, analyze and improve the performance of the website and ads delivered.
+      </p>
+      <h2>What data is collected by cookies and other technologies on our website?</h2>
+      <h3>This information may include:</h3>
+      <ol start={1}>
+        <li>
+          the IP and logical address of the server you are using (but the last digits are anonymized so we cannot
+          identify you).
+        </li>
+        <li>the top level domain name from which you access the internet (for example .ie, .com, etc)</li>
+        <li>the type of browser you are using,</li>
+        <li>the date and time you access our website</li>
+        <li>the internet address linking to our website.</li>
+      </ol>
+      <h3>This website also uses cookies to:</h3>
+      <ol start={1}>
+        <li>remember you and your actions while navigating between pages;</li>
+        <li>remember if you have agreed (or not) to our use of cookies on our website;</li>
+        <li>ensure the security of the website;</li>
+        <li>monitor and improve the performance of servers hosting the site;</li>
+        <li>distinguish users and sessions;</li>
+        <li>Improving the speed of the site when you access content repeatedly;</li>
+        <li>determine new sessions and visits;</li>
+        <li>show the traffic source or campaign that explains how you may have reached our website; and</li>
+        <li>allow us to store any customization preferences where our website allows this</li>
+      </ol>
+      <p>
+        We may also use other services, such as{' '}
+        <Link href="https://www.google.com/intl/en/analytics/#?modal_active=none" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            Google Analytics
+          </MUILink>
+        </Link>
+        &nbsp;(described below) or other third-party cookies, to assist with analyzing performance on our website. As
+        part of providing these services, these service providers may use cookies and the technologies described below
+        to collect and store information about your device, such as time of visit, pages visited, time spent on each
+        page of our website, links clicked and conversion information, IP address, browser, mobile network information,
+        and type of operating system used.
+      </p>
+      <h2>Google Analytics Cookies</h2>
+      <p>
+        This website uses{' '}
+        <Link href="https://www.google.com/analytics/" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            Google Analytics
+          </MUILink>
+        </Link>
+        , a web analytics service provided by Google, Inc. (&quot;Google&quot;).
+      </p>
+      <p>
+        We use Google Analytics to track your preferences and also to identify popular sections of our website. Use of
+        Google Analytics in this way, enables us to adapt the content of our website more specifically to your needs and
+        thereby improve what we can offer to you.
+      </p>
+      <p>
+        Google will use this information for the purpose of evaluating your use of our website, compiling reports on
+        website activity for website operators and providing other services relating to website activity and internet
+        usage. Google may also transfer this information to third parties where required to do so by law, or where such
+        third parties process the information on Google&apos;s behalf. Google will not associate your IP address with
+        any other data held by Google.
+      </p>
+      <p>In particular Google Analytics tells us</p>
+      <ol start={1}>
+        <li>your IP address (last 3 digits are masked);</li>
+        <li>the number of pages visited;</li>
+        <li>the time and duration of the visit;</li>
+        <li>your location;</li>
+        <li>the website you came from (if any);</li>
+        <li>the type of hardware you use (i.e. whether you are browsing from a desktop or a mobile device);</li>
+        <li>the software used (type of browser); and</li>
+        <li>your general interaction with our website.</li>
+      </ol>
+      <p>
+        As stated above, cookie-related information is not used to identify you personally, and what is compiled is only
+        aggregate data that tells us, for example, what countries we are most popular in, but not that you live in a
+        particular country or your precise location when you visited our website (this is because we have only half the
+        information- we know the country the person is browsing from, but not the name of person who is browsing). In
+        such an example Google will analyze the number of users for us, but the relevant cookies do not reveal their
+        identities.
+      </p>
+      <p>
+        By using this website, you consent to the processing of data about you by Google in the manner and for the
+        purposes set out above. Google Analytics, its purpose and function is further explained on the{' '}
+        <Link href="https://www.google.com/analytics/" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            Google Analytics website
+          </MUILink>
+        </Link>
+        .
+      </p>
+      <p>
+        For more information about Google Analytics cookies, please see Google&apos;s help pages and privacy policy:{' '}
+        <Link href="https://www.google.com/intl/en/policies/privacy/" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            Google&apos;s Privacy Policy
+          </MUILink>
+        </Link>
+        &nbsp;and{' '}
+        <Link href="https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            Google Analytics Help pages
+          </MUILink>
+        </Link>
+        . For further information about the use of these cookies by Google{' '}
+        <Link href="https://support.google.com/analytics/answer/6004245" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            click here
+          </MUILink>
+        </Link>
+        .
+      </p>
+      <h2>
+        What if you don&rsquo;t agree with us monitoring your use of our website (even if we don&apos;t collect your
+        personal data)?
+      </h2>
+      <p>
+        Enabling these cookies is not strictly necessary for our website to work but it will provide you with a better
+        browsing experience. You can delete or block the cookies we set, but if you do that, some features of this
+        website may not work as intended.
+      </p>
+      <p>
+        Most browsers are initially set to accept cookies. If you prefer, you can set your browser to refuse cookies and
+        control and/or delete cookies as you wish &ndash; for details, see{' '}
+        <Link href="https://www.aboutcookies.org/" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            https://aboutcookies.org
+          </MUILink>
+        </Link>
+        . You can delete all cookies that are already on your device and you can set most browsers to prevent them from
+        being placed. You should be aware that if you do this, you may have to manually adjust some preferences every
+        time you visit an Internet site and some services and functionalities may not work if you do not accept the
+        cookies they send.
+      </p>
+      <p>
+        Advertisers and business partners that you access on or through our website may also send you cookies. We do not
+        control any cookies outside of our website.
+      </p>
+      <p>
+        If you have any further questions regarding disabling cookies you should consult with your preferred
+        browser&rsquo;s provider or manufacturer.
+      </p>
+      <p>
+        In order to implement your objection it may be necessary to install an opt-out cookie on your browser. This
+        cookie will only indicate that you have opted out. It is important to note, that for technical reasons, the
+        opt-out cookie will only affect the browser from which you actively object from. If you delete the cookies in
+        your browser or use a different end device or browser, you will need to opt out again.
+      </p>
+      <p>
+        To opt out of being tracked by Google Analytics across all websites, Google has developed Google Analytics
+        opt-out browser add-on. If you would like to opt out of Google Analytics, you have the option of downloading and
+        installing this browser add-on which can be found under the link:{' '}
+        <Link href="https://tools.google.com/dlpage/gaoptout" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            https://tools.google.com/dlpage/gaoptout
+          </MUILink>
+        </Link>
+        .
+      </p>
+      <h2>Revisions to this Cookie Policy</h2>
+      <p>
+        On this website, you can always view the latest version of our Privacy Policy and our Cookie Policy. We may
+        modify this Cookie Policy from time to time. If we make changes to this Cookie Policy, we will provide notice of
+        such changes, such as by sending an email notification, providing notice through our website or updating the
+        &lsquo;Last Updated&rsquo; date at the beginning of this Cookie Policy. The amended Cookie Policy will be
+        effective immediately after the date it is posted. By continuing to access or use our website after the
+        effective date, you confirm your acceptance of the revised Cookie Policy and all of the terms incorporated
+        therein by reference. We encourage you to review our Privacy Policy and our Cookie Policy whenever you access or
+        use our website to stay informed about our information practices and the choices available to you.
+      </p>
+      <p>
+        If you do not accept changes which are made to this Cookie Policy, or take any measures described above to
+        opt-out by removing or rejecting cookies, you may continue to use this website but accept that it may not
+        display and/or function as intended by us. Any social media channels connected to us and third party
+        applications will be subject to the privacy and cookie policies and practices of the relevant platform providers
+        which, unless otherwise indicated, are not affiliated or associated with us Your exercise of any rights to
+        opt-out may also impact how our information and content is displayed and/or accessible to you on this website
+        and on other websites.
+      </p>
+      <h2>APPENDIX</h2>
+      <p>Overview of cookies placed and the consequences if the cookies are not placed.</p>
+      <h3>First-party cookies</h3>
+      <table className={css.table}>
+        <tbody>
+          <tr>
+            <td colSpan={1} rowSpan={1}>
+              <p>#</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Name of cookie</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Domain</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Purpose(s) of cookie</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Storage period of cookie</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Consequences is cookie is not accepted</p>
+            </td>
+          </tr>
+          <tr>
+            <td colSpan={1} rowSpan={1}>
+              <p>1</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>_BEAMER_FILTER_BY_URL_{'{productID}'}</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>app.safe.global</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Stores whether to apply URL filtering on the feed.</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>20 minutes</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>User activity won&apos;t be tracked</p>
+            </td>
+          </tr>
+          <tr>
+            <td colSpan={1} rowSpan={1}>
+              <p>2</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>_BEAMER_DATE_{'{productID}'}</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>app.safe.global</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Stores the latest date in which the feed was opened.</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>300 days</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>User activity won&apos;t be tracked</p>
+            </td>
+          </tr>
+          <tr>
+            <td colSpan={1} rowSpan={1}>
+              <p>3</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>_BEAMER_LAST_POST_SHOWN_{'{productID}'}</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>app.safe.global</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Stores the ID of the last post shown as a teaser.</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Session</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>User activity won&apos;t be tracked</p>
+            </td>
+          </tr>
+          <tr>
+            <td colSpan={1} rowSpan={1}>
+              <p>4</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>_BEAMER_BOOSTED_ANNOUNCEMENT_DATE_{'{productID}'}</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>app.safe.global</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Stores the latest date in which a boosted announcement was displayed.</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>300 days</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>User activity won&apos;t be tracked</p>
+            </td>
+          </tr>
+          <tr>
+            <td colSpan={1} rowSpan={1}>
+              <p>5</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>_BEAMER_FIRST_VISIT_{'{productID}'}</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>app.safe.global</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Stores the date of this user&rsquo;s first visit to the site.</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>300 days</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>User activity won&apos;t be tracked</p>
+            </td>
+          </tr>
+          <tr>
+            <td colSpan={1} rowSpan={1}>
+              <p>6</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>_BEAMER_USER_ID_{'{productID}'}</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>app.safe.global</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Stores an internal ID for this user.</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>300 days</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>User activity won&apos;t be tracked</p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h3>Third-party cookies</h3>
+      <p>The cookies from this table can be set by third-party wallets.</p>
+      <table className={css.table}>
+        <tbody>
+          <tr>
+            <td colSpan={1} rowSpan={1}>
+              <p>#</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Name of cookie</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Domain</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Purpose(s) of cookie</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Storage period of cookie</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Consequences is cookie is not accepted</p>
+            </td>
+          </tr>
+          <tr>
+            <td colSpan={1} rowSpan={1}>
+              <p>1</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>_ga</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>safe.global</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Used to distinguish users</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>2 years from set/update</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>User activity won&apos;t be tracked</p>
+            </td>
+          </tr>
+          <tr>
+            <td colSpan={1} rowSpan={1}>
+              <p>2</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>_ga</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>getbeamer.com</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Used to distinguish users</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>2 years from set/update</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>User activity won&apos;t be tracked</p>
+            </td>
+          </tr>
+          <tr>
+            <td colSpan={1} rowSpan={1}>
+              <p>3</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>_gid</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>getbeamer.com</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Used to distinguish users</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>24 hours</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>User activity won&apos;t be tracked</p>
+            </td>
+          </tr>
+          <tr>
+            <td colSpan={1} rowSpan={1}>
+              <p>4</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>_BEAMER_USER_ID_{'{productID}'}</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>getbeamer.com</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Stores an internal ID for this user.</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>300 days</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>User activity won&apos;t be tracked</p>
+            </td>
+          </tr>
+          <tr>
+            <td colSpan={1} rowSpan={1}>
+              <p>5</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>JSESSIONID</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>app.getbeamer.com</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Stores an internal ID for this user.</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>Session</p>
+            </td>
+            <td colSpan={1} rowSpan={1}>
+              <p>User activity won&apos;t be tracked</p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default SafeCookiePolicy

--- a/src/components/cookie-policy/index.tsx
+++ b/src/components/cookie-policy/index.tsx
@@ -20,7 +20,10 @@ const SafeCookiePolicy = () => {
         process your personal data in pseudonymised form.
       </p>
       <p>
-        This Cookie Policy applies to our website at <a href="https://app.safe.global">https://app.safe.global</a>
+        This Cookie Policy applies to our website at{' '}
+        <Link href="https://app.safe.global" passHref>
+          <MUILink>https://app.safe.global</MUILink>
+        </Link>
         &nbsp;and sets out some further detail on how and why we use these technologies on our website.{' '}
       </p>
       <p>

--- a/src/components/cookie-policy/styles.module.css
+++ b/src/components/cookie-policy/styles.module.css
@@ -1,0 +1,15 @@
+.table {
+  width: 100%;
+  border-spacing: 0;
+  border: 0;
+  border-collapse: collapse;
+}
+
+.table td {
+  border: 1px solid;
+  padding: 0 8px;
+}
+
+.table tr:first-child td {
+  font-weight: bold;
+}

--- a/src/components/imprint/index.tsx
+++ b/src/components/imprint/index.tsx
@@ -1,0 +1,69 @@
+import { Typography } from '@mui/material'
+import Link from 'next/link'
+import MUILink from '@mui/material/Link'
+
+const SafeImprint = () => {
+  return (
+    <div>
+      <Typography variant="h1" mb={2}>
+        Imprint & Disclaimer
+      </Typography>
+      <Typography variant="h3" mb={2}>
+        Information in accordance with section 5 of the Telemedia Act (TMG, Germany):
+      </Typography>
+      <Typography mb={2}>
+        Core Contributors GmbH
+        <br />
+        ℅ Full Node
+        <br />
+        Skalitzer Str. 85-86
+        <br />
+        10997 Berlin Germany
+      </Typography>
+      <Typography mb={4}>
+        Managing directors: Richard Meißner, Tobias Schubotz
+        <br />
+        Contact: info@cc0x.dev
+        <br />
+        District Court: Berlin Charlottenburg
+        <br />
+        Register Number: HRB 240421 B
+      </Typography>
+      <Typography variant="h3" mb={2}>
+        Disclaimer
+      </Typography>
+      <Typography mb={1}>
+        <strong>Accountability for content</strong>
+      </Typography>
+      <Typography mb={2}>
+        The contents of our pages have been created with the utmost care. However, we cannot guarantee the contents’
+        accuracy, completeness or topicality. According to statutory provisions, we are furthermore responsible for our
+        own content on these web pages. In this context, please note that we are accordingly not obliged to monitor
+        merely the transmitted or saved information of third parties, or investigate circumstances pointing to illegal
+        activity. Our obligations to remove or block the use of information under generally applicable laws remain
+        unaffected by this as per §§ 8 to 10 of the Telemedia Act (TMG).
+      </Typography>
+      <Typography mb={1}>
+        <strong>Accountability for links</strong>
+      </Typography>
+      <Typography mb={2}>
+        Responsibility for the content of external links (to web pages of third parties) lies solely with the operators
+        of the linked pages. No violations were evident to us at the time of linking. Should any legal infringement
+        become known to us, we will remove the respective link immediately.
+      </Typography>
+      <Typography mb={1}>
+        <strong>Copyright</strong>
+      </Typography>
+      <Typography>
+        This website and their contents are subject to copyright laws.{' '}
+        <Link href="https://github.com/safe-global/web-core/blob/dev/LICENSE" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            The code is open-source, released under GPL-3.0.
+          </MUILink>
+        </Link>
+      </Typography>
+    </div>
+  )
+}
+
+export default SafeImprint

--- a/src/components/imprint/index.tsx
+++ b/src/components/imprint/index.tsx
@@ -23,7 +23,7 @@ const SafeImprint = () => {
       <Typography mb={4}>
         Managing directors: Richard Meißner, Tobias Schubotz
         <br />
-        Contact: info@cc0x.dev
+        Contact: <a href="mailto:info@cc0x.dev">info@cc0x.dev</a>
         <br />
         District Court: Berlin Charlottenburg
         <br />

--- a/src/components/imprint/index.tsx
+++ b/src/components/imprint/index.tsx
@@ -23,7 +23,10 @@ const SafeImprint = () => {
       <Typography mb={4}>
         Managing directors: Richard Meißner, Tobias Schubotz
         <br />
-        Contact: <a href="mailto:info@cc0x.dev">info@cc0x.dev</a>
+        Contact:{' '}
+        <Link href="mailto:info@cc0x.dev" passHref>
+          <MUILink>info@cc0x.dev</MUILink>
+        </Link>
         <br />
         District Court: Berlin Charlottenburg
         <br />

--- a/src/components/new-safe/create/steps/SetNameStep/index.tsx
+++ b/src/components/new-safe/create/steps/SetNameStep/index.tsx
@@ -16,7 +16,6 @@ import { CREATE_SAFE_EVENTS, trackEvent } from '@/services/analytics'
 import { AppRoutes } from '@/config/routes'
 import MUILink from '@mui/material/Link'
 import Link from 'next/link'
-import React from 'react'
 
 type SetNameStepForm = {
   name: string

--- a/src/components/new-safe/create/steps/SetNameStep/index.tsx
+++ b/src/components/new-safe/create/steps/SetNameStep/index.tsx
@@ -13,7 +13,10 @@ import useIsWrongChain from '@/hooks/useIsWrongChain'
 import NetworkWarning from '@/components/new-safe/create/NetworkWarning'
 import NameInput from '@/components/common/NameInput'
 import { CREATE_SAFE_EVENTS, trackEvent } from '@/services/analytics'
-import ExternalLink from '@/components/common/ExternalLink'
+import { AppRoutes } from '@/config/routes'
+import MUILink from '@mui/material/Link'
+import Link from 'next/link'
+import React from 'react'
 
 type SetNameStepForm = {
   name: string
@@ -93,13 +96,13 @@ function SetNameStep({
           </Grid>
           <Typography variant="body2" mt={2}>
             By continuing, you agree to our{' '}
-            <ExternalLink href="https://safe.global/terms" fontWeight={700}>
-              terms of use
-            </ExternalLink>{' '}
+            <Link href={AppRoutes.terms} passHref>
+              <MUILink>terms of use</MUILink>
+            </Link>{' '}
             and{' '}
-            <ExternalLink href="https://safe.global/privacy" fontWeight={700}>
-              privacy policy
-            </ExternalLink>
+            <Link href={AppRoutes.privacy} passHref>
+              <MUILink>privacy policy</MUILink>
+            </Link>
             .
           </Typography>
 

--- a/src/components/new-safe/load/steps/SetAddressStep/index.tsx
+++ b/src/components/new-safe/load/steps/SetAddressStep/index.tsx
@@ -27,7 +27,9 @@ import useChainId from '@/hooks/useChainId'
 import { useAppSelector } from '@/store'
 import { selectAddedSafes } from '@/store/addedSafesSlice'
 import { LOAD_SAFE_EVENTS, trackEvent } from '@/services/analytics'
-import ExternalLink from '@/components/common/ExternalLink'
+import { AppRoutes } from '@/config/routes'
+import MUILink from '@mui/material/Link'
+import Link from 'next/link'
 
 enum Field {
   name = 'name',
@@ -136,8 +138,15 @@ const SetAddressStep = ({ data, onSubmit, onBack }: StepRenderProps<LoadSafeForm
           <AddressInput label="Safe" validate={validateSafeAddress} name={Field.address} />
 
           <Typography mt={4}>
-            By continuing you consent to the <ExternalLink href="https://safe.global/terms">terms of use</ExternalLink>{' '}
-            and <ExternalLink href="https://safe.global/privacy">privacy policy</ExternalLink>.
+            By continuing you consent to the{' '}
+            <Link href={AppRoutes.terms} passHref>
+              <MUILink>terms of use</MUILink>
+            </Link>{' '}
+            and{' '}
+            <Link href={AppRoutes.privacy} passHref>
+              <MUILink>privacy policy</MUILink>
+            </Link>
+            .
           </Typography>
         </Box>
 

--- a/src/components/privacy/index.tsx
+++ b/src/components/privacy/index.tsx
@@ -10,7 +10,9 @@ const SafePrivacyPolicy = () => {
       <p>
         Your privacy is important to us. It is our policy to respect your privacy and comply with any applicable law and
         regulation regarding any personal information we may collect about you, including across our website,{' '}
-        <a href="https://app.safe.global">https://app.safe.global</a>
+        <Link href="https://app.safe.global" passHref>
+          <MUILink>https://app.safe.global</MUILink>
+        </Link>
         ,&nbsp;and other sites we own and operate as well as mobile applications we offer. Wherever possible, we have
         designed our website so that you may navigate and use our website without having to provide Personal Data.
       </p>
@@ -42,40 +44,64 @@ const SafePrivacyPolicy = () => {
       <p>If you are viewing this policy online, you can click on the below links to jump to the relevant section:</p>
       <ol start={2}>
         <li>
-          <a href="#2">Glossary</a>
+          <Link href="#2" passHref>
+            <MUILink>Glossary</MUILink>
+          </Link>
         </li>
         <li>
-          <a href="#3">Your information and the Blockchain</a>
+          <Link href="#3" passHref>
+            <MUILink>Your information and the Blockchain</MUILink>
+          </Link>
         </li>
         <li>
-          <a href="#4">How We Use Personal Data</a>
+          <Link href="#4" passHref>
+            <MUILink>How We Use Personal Data</MUILink>
+          </Link>
         </li>
         <li>
-          <a href="#5">Use of Third Party Applications</a>
+          <Link href="#5" passHref>
+            <MUILink>Use of Third Party Applications</MUILink>
+          </Link>
         </li>
         <li>
-          <a href="#6">Sharing Your Personal Data</a>
+          <Link href="#6" passHref>
+            <MUILink>Sharing Your Personal Data</MUILink>
+          </Link>
         </li>
         <li>
-          <a href="#7">Transferring Your data outside of the EU</a>
+          <Link href="#7" passHref>
+            <MUILink>Transferring Your data outside of the EU</MUILink>
+          </Link>
         </li>
         <li>
-          <a href="#8">Existence of Automated Decision-making</a>
+          <Link href="#8" passHref>
+            <MUILink>Existence of Automated Decision-making</MUILink>
+          </Link>
         </li>
         <li>
-          <a href="#9">Data Security</a>
+          <Link href="#9" passHref>
+            <MUILink>Data Security</MUILink>
+          </Link>
         </li>
         <li>
-          <a href="#10">Your Rights as a Data Subject</a>
+          <Link href="#10" passHref>
+            <MUILink>Your Rights as a Data Subject</MUILink>
+          </Link>
         </li>
         <li>
-          <a href="#11">Storing Personal Data</a>
+          <Link href="#11" passHref>
+            <MUILink>Storing Personal Data</MUILink>
+          </Link>
         </li>
         <li>
-          <a href="#12">Changes to this Privacy Policy</a>
+          <Link href="#12" passHref>
+            <MUILink>Changes to this Privacy Policy</MUILink>
+          </Link>
         </li>
         <li>
-          <a href="#13">Contacts us</a>
+          <Link href="#13" passHref>
+            <MUILink>Contacts us</MUILink>
+          </Link>
         </li>
       </ol>
       <h3 id="2">2. Glossary</h3>
@@ -818,10 +844,7 @@ const SafePrivacyPolicy = () => {
         Phone: 030/138 89-0
       </p>
       <p>
-        <Link
-          href="https://www.google.com/url?q=https://www.datenschutz-berlin.de&amp;sa=D&amp;source=editors&amp;ust=1677670462021305&amp;usg=AOvVaw1sgbmKiiYL0n7tPM5It81-"
-          passHref
-        >
+        <Link href="https://www.datenschutz-berlin.de" passHref>
           <MUILink target="_blank" rel="noreferrer">
             https://www.datenschutz-berlin.de
           </MUILink>
@@ -877,7 +900,9 @@ const SafePrivacyPolicy = () => {
         Germany
       </p>
       <p>
-        <a href="mailto:corecontributors.dpo@techgdpr.com">corecontributors.dpo@techgdpr.com</a>&nbsp;
+        <Link href="mailto:corecontributors.dpo@techgdpr.com" passHref>
+          <MUILink>corecontributors.dpo@techgdpr.com</MUILink>
+        </Link>
       </p>
     </div>
   )

--- a/src/components/privacy/index.tsx
+++ b/src/components/privacy/index.tsx
@@ -10,9 +10,7 @@ const SafePrivacyPolicy = () => {
       <p>
         Your privacy is important to us. It is our policy to respect your privacy and comply with any applicable law and
         regulation regarding any personal information we may collect about you, including across our website,{' '}
-        <a href="https://www.google.com/url?q=https://app.safe.global&amp;sa=D&amp;source=editors&amp;ust=1677670461968387&amp;usg=AOvVaw3V2Kc3KgyuW6TqsMfGAs15">
-          https://app.safe.global
-        </a>
+        <a href="https://app.safe.global">https://app.safe.global</a>
         ,&nbsp;and other sites we own and operate as well as mobile applications we offer. Wherever possible, we have
         designed our website so that you may navigate and use our website without having to provide Personal Data.
       </p>
@@ -117,9 +115,11 @@ const SafePrivacyPolicy = () => {
         <li>
           &ldquo;Safe&rdquo; is a modular, self-custodial (i.e. not supervised by us) smart contract-based
           multi-signature Wallet. Safe is{' '}
-          <a href="https://www.google.com/url?q=https://github.com/safe-global/safe-contracts/&amp;sa=D&amp;source=editors&amp;ust=1677670461974783&amp;usg=AOvVaw0VU7ej4w-4PKSYww4aFXyt">
-            open-source
-          </a>
+          <Link href="https://github.com/safe-global/safe-contracts/" passHref>
+            <MUILink target="_blank" rel="noreferrer">
+              open-source
+            </MUILink>
+          </Link>
           &nbsp;released under LGPL-3.0.
         </li>
         <li>
@@ -444,29 +444,37 @@ const SafePrivacyPolicy = () => {
       <h4>5.2. Amazon Web Services</h4>
       <p>
         We use{' '}
-        <a href="https://www.google.com/url?q=https://aws.amazon.com/&amp;sa=D&amp;source=editors&amp;ust=1677670461998336&amp;usg=AOvVaw0klUOiMtFQiqXOnVo-NxtZ">
-          Amazon Web Services (AWS)
-        </a>
+        <Link href="https://aws.amazon.com/" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            Amazon Web Services (AWS)
+          </MUILink>
+        </Link>
         &nbsp;to store log and database data as described in section 4.1.
       </p>
       <h4>5.3. Datadog</h4>
       <p>
         We use{' '}
-        <a href="https://www.google.com/url?q=https://www.datadoghq.com/&amp;sa=D&amp;source=editors&amp;ust=1677670461999033&amp;usg=AOvVaw3rYJZBo6VNH8rKYtFyQeRD">
-          Datadog
-        </a>
+        <Link href="https://www.datadoghq.com/" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            Datadog
+          </MUILink>
+        </Link>
         &nbsp;to store log data as described in section 4.1.
       </p>
       <h4>5.4. Mobile app stores</h4>
       <p>
         Safe mobile apps are distributed via{' '}
-        <a href="https://www.google.com/url?q=https://www.apple.com/app-store/&amp;sa=D&amp;source=editors&amp;ust=1677670461999703&amp;usg=AOvVaw0FQLE9DGc__i48SYxTwCzJ">
-          Apple AppStore
-        </a>
+        <Link href="https://www.apple.com/app-store/" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            Apple AppStore
+          </MUILink>
+        </Link>
         &nbsp;and{' '}
-        <a href="https://www.google.com/url?q=https://play.google.com/&amp;sa=D&amp;source=editors&amp;ust=1677670462000051&amp;usg=AOvVaw0xdj_3JNm_HHuv6tClADLo">
-          Google Play Store
-        </a>
+        <Link href="https://play.google.com/" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            Google Play Store
+          </MUILink>
+        </Link>
         . They most likely track user behavior when downloading apps from their stores as well as when using apps. We
         only have very limited access to that data. We can view aggregated statistics on installs and uninstalls.
         Grouping by device type, app version, language, carrier and country is possible.
@@ -481,9 +489,11 @@ const SafePrivacyPolicy = () => {
       <h4>5.6. Google Firebase</h4>
       <p>
         We use the following{' '}
-        <a href="https://www.google.com/url?q=https://firebase.google.com/&amp;sa=D&amp;source=editors&amp;ust=1677670462001228&amp;usg=AOvVaw0PvjHiv6LzUshRGaz9KwDc">
-          Google Firebase
-        </a>
+        <Link href="https://firebase.google.com/" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            Google Firebase
+          </MUILink>
+        </Link>
         &nbsp;services:
       </p>
       <ul>
@@ -499,44 +509,56 @@ const SafePrivacyPolicy = () => {
       </ul>
       <h4>5.7. WalletConnect</h4>
       <p>
-        <a href="https://www.google.com/url?q=https://walletconnect.com/&amp;sa=D&amp;source=editors&amp;ust=1677670462002729&amp;usg=AOvVaw3fns2anVcEVZjXS6gxfger">
-          WalletConnect
-        </a>
+        <Link href="https://walletconnect.com/" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            WalletConnect
+          </MUILink>
+        </Link>
         &nbsp;is used to connect wallets to dapps using end-to-end encryption by scanning a QR code. We do not store any
         information collected by WalletConnect.{' '}
       </p>
       <h4>5.8. Sentry</h4>
       <p>
         We use{' '}
-        <a href="https://www.google.com/url?q=https://sentry.io/&amp;sa=D&amp;source=editors&amp;ust=1677670462003432&amp;usg=AOvVaw0awYpXXYSCHZcWOeIr7IXY">
-          Sentry
-        </a>
+        <Link href="https://sentry.io/" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            Sentry
+          </MUILink>
+        </Link>
         &nbsp;to collect error reports and crashes to improve product and user experience.{' '}
       </p>
       <h4>5.9. Beamer</h4>
       <p>
         We use{' '}
-        <a href="https://www.google.com/url?q=https://www.getbeamer.com/&amp;sa=D&amp;source=editors&amp;ust=1677670462004085&amp;usg=AOvVaw3mKE7fFDU9R9XnTtgrSkwz">
-          Beamer
-        </a>
+        <Link href="https://www.getbeamer.com/" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            Beamer
+          </MUILink>
+        </Link>
         &nbsp;providing updates to the user about changes in the app. Beamer&apos;s purpose and function are further
         explained under the following link{' '}
-        <a href="https://www.google.com/url?q=https://www.getbeamer.com/showcase/notification-center&amp;sa=D&amp;source=editors&amp;ust=1677670462004398&amp;usg=AOvVaw1TTpszDU9wZy4QP-SU-Mz2">
-          https://www.getbeamer.com/showcase/notification-center
-        </a>
+        <Link href="https://www.getbeamer.com/showcase/notification-center" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            https://www.getbeamer.com/showcase/notification-center
+          </MUILink>
+        </Link>
         .
       </p>
       <p>We do not store any information collected by Beamer.</p>
       <h4>5.10. Node providers</h4>
       <p>
         We use{' '}
-        <a href="https://www.google.com/url?q=https://www.infura.io/&amp;sa=D&amp;source=editors&amp;ust=1677670462005213&amp;usg=AOvVaw3Z7giCkorlD4Jsvrh_si8a">
-          Infura
-        </a>
+        <Link href="https://www.infura.io/" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            Infura
+          </MUILink>
+        </Link>
         &nbsp;and{' '}
-        <a href="https://www.google.com/url?q=https://nodereal.io/&amp;sa=D&amp;source=editors&amp;ust=1677670462005507&amp;usg=AOvVaw2MaUVqR0xB4JDnSBMH5IS4">
-          Nodereal
-        </a>
+        <Link href="https://nodereal.io/" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            Nodereal
+          </MUILink>
+        </Link>
         &nbsp;to query public blockchain data from our backend services. All Safes are monitored, no personalization is
         happening and no user IP addresses are forwarded. Personal data processed are:
       </p>
@@ -548,9 +570,11 @@ const SafePrivacyPolicy = () => {
       <h4>5.11. Tenderly</h4>
       <p>
         We use{' '}
-        <a href="https://www.google.com/url?q=https://tenderly.co/&amp;sa=D&amp;source=editors&amp;ust=1677670462006850&amp;usg=AOvVaw35y42G_oU-fWhcI_iNwfBg">
-          Tenderly
-        </a>
+        <Link href="https://tenderly.co/" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            Tenderly
+          </MUILink>
+        </Link>
         &nbsp;to simulate blockchain transactions before they are executed. For that we send your smart contract address
         of your Safe and transaction data to Tenderly.
       </p>
@@ -558,19 +582,25 @@ const SafePrivacyPolicy = () => {
       <p>We use the following tools for internal communication. </p>
       <ul>
         <li>
-          <a href="https://www.google.com/url?q=https://slack.com/&amp;sa=D&amp;source=editors&amp;ust=1677670462007752&amp;usg=AOvVaw0LysMSW4tdq8cG4KbCOzaa">
-            Slack
-          </a>
+          <Link href="https://slack.com/" passHref>
+            <MUILink target="_blank" rel="noreferrer">
+              Slack
+            </MUILink>
+          </Link>
         </li>
         <li>
-          <a href="https://www.google.com/url?q=https://workspace.google.com/&amp;sa=D&amp;source=editors&amp;ust=1677670462008110&amp;usg=AOvVaw0eNEELfZnd0R91E3J2XnB5">
-            Google Workspace
-          </a>
+          <Link href="https://workspace.google.com/" passHref>
+            <MUILink target="_blank" rel="noreferrer">
+              Google Workspace
+            </MUILink>
+          </Link>
         </li>
         <li>
-          <a href="https://www.google.com/url?q=https://notion.so&amp;sa=D&amp;source=editors&amp;ust=1677670462008559&amp;usg=AOvVaw0LlPhL5VvrcNajC6vp7ou5">
-            Notion
-          </a>
+          <Link href="https://notion.so" passHref>
+            <MUILink target="_blank" rel="noreferrer">
+              Notion
+            </MUILink>
+          </Link>
         </li>
       </ul>
       <h3 id="6">6. Sharing Your Personal Data</h3>
@@ -633,9 +663,11 @@ const SafePrivacyPolicy = () => {
         You have certain rights under applicable legislation, and in particular under Regulation EU 2016/679 (General
         Data Protection Regulation or &lsquo;GDPR&rsquo;). We explain these below. You can find out more about the GDPR
         and your rights by accessing the{' '}
-        <a href="https://www.google.com/url?q=https://ec.europa.eu/info/law/law-topic/data-protection_en&amp;sa=D&amp;source=editors&amp;ust=1677670462013109&amp;usg=AOvVaw130yoKbfsfpLG6xbgjr5oB">
-          European Commission&rsquo;s website
-        </a>
+        <Link href="https://ec.europa.eu/info/law/law-topic/data-protection_en" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            European Commission&rsquo;s website
+          </MUILink>
+        </Link>
         . If you wish to exercise your data subject rights, please contact us by post or at privacy@cc0x.dev.
       </p>
       <h5>Right Information and access</h5>

--- a/src/components/privacy/index.tsx
+++ b/src/components/privacy/index.tsx
@@ -1,0 +1,854 @@
+import Link from 'next/link'
+import MUILink from '@mui/material/Link'
+import css from './styles.module.css'
+
+const SafePrivacyPolicy = () => {
+  return (
+    <div>
+      <h1>Privacy Policy</h1>
+      <p>Last updated on March&nbsp;2023.</p>
+      <p>
+        Your privacy is important to us. It is our policy to respect your privacy and comply with any applicable law and
+        regulation regarding any personal information we may collect about you, including across our website,{' '}
+        <a href="https://www.google.com/url?q=https://app.safe.global&amp;sa=D&amp;source=editors&amp;ust=1677670461968387&amp;usg=AOvVaw3V2Kc3KgyuW6TqsMfGAs15">
+          https://app.safe.global
+        </a>
+        ,&nbsp;and other sites we own and operate as well as mobile applications we offer. Wherever possible, we have
+        designed our website so that you may navigate and use our website without having to provide Personal Data.
+      </p>
+      <p>
+        This Privacy Policy describes how we, as a controller, collect, use and share your personal data. It applies to
+        personal data you voluntarily provide to us, or is automatically collected by us.{' '}
+      </p>
+      <p>
+        In this policy, &quot;we&quot;, &quot;us&quot; and &quot;our&quot; refers to Core Contributors GmbH a company
+        incorporated in Germany with its registered address at Skalitzer Str. 85-86, ℅ Full Node, 10997 Berlin,
+        Germany.&nbsp;Any data protection related questions you might have about how we handle your personal data or if
+        you wish to exercise your data subject rights, please contact us by post or at privacy@cc0x.dev.{' '}
+      </p>
+      <p>
+        In this Policy, &ldquo;personal data&rdquo; means any information relating to you as an identified or
+        identifiable natural person (&ldquo;Data Subject&rdquo;); an identifiable natural person is one who can be
+        identified, directly or indirectly, in particular by reference to an identifier such as a name, an online
+        identifier or to one or more factors specific to your physical, physiological, genetic, mental, economic,
+        cultural or social identity.
+      </p>
+      <p>
+        In this Policy, &ldquo;processing&rdquo; means any operation or set of operations which is performed on personal
+        data (as defined in this Privacy Policy) or on sets of personal data, whether or not by automated means, such as
+        collection, recording, organization, structuring, storage, adaptation or alteration, retrieval, consultation,
+        use, disclosure by transmission, dissemination or otherwise making available, alignment or combination,
+        restriction, erasure or destruction.
+      </p>
+      <h3>1. Navigating this Policy</h3>
+      <p>If you are viewing this policy online, you can click on the below links to jump to the relevant section:</p>
+      <ol start={2}>
+        <li>
+          <a href="#2">Glossary</a>
+        </li>
+        <li>
+          <a href="#3">Your information and the Blockchain</a>
+        </li>
+        <li>
+          <a href="#4">How We Use Personal Data</a>
+        </li>
+        <li>
+          <a href="#5">Use of Third Party Applications</a>
+        </li>
+        <li>
+          <a href="#6">Sharing Your Personal Data</a>
+        </li>
+        <li>
+          <a href="#7">Transferring Your data outside of the EU</a>
+        </li>
+        <li>
+          <a href="#8">Existence of Automated Decision-making</a>
+        </li>
+        <li>
+          <a href="#9">Data Security</a>
+        </li>
+        <li>
+          <a href="#10">Your Rights as a Data Subject</a>
+        </li>
+        <li>
+          <a href="#11">Storing Personal Data</a>
+        </li>
+        <li>
+          <a href="#12">Changes to this Privacy Policy</a>
+        </li>
+        <li>
+          <a href="#13">Contacts us</a>
+        </li>
+      </ol>
+      <h3 id="2">2. Glossary</h3>
+      <p>What do some of the capitalized terms mean in this policy?</p>
+      <ol start={1}>
+        <li>
+          &ldquo;Blockchain&rdquo; means a mathematically secured consensus ledger such as the Ethereum Virtual Machine,
+          an Ethereum Virtual Machine compatible validation mechanism, or other decentralized validation mechanisms.
+        </li>
+        <li>
+          &ldquo;Transaction&rdquo; means a change to the data set through a new entry in the continuous Blockchain.
+        </li>
+        <li>
+          &ldquo;Smart Contract&rdquo; is a piece of source code deployed as an application on the Blockchain which can
+          be executed, including self-execution of Transactions as well as execution triggered by 3rd parties.
+        </li>
+        <li>
+          &ldquo;Token&rdquo; is a digital asset transferred in a Transaction, including ETH, ERC20, ERC721 and ERC1155
+          tokens.
+        </li>
+        <li>
+          &ldquo;Wallet&rdquo; is a cryptographic storage solution permitting you to store cryptographic assets by
+          correlation of a (i) Public Key and (ii) a Private Key or a Smart Contract to receive, manage and send Tokens.
+        </li>
+        <li>
+          &ldquo;Recovery Phrase&rdquo; is a series of secret words used to generate one or more Private Keys and
+          derived Public Keys.
+        </li>
+        <li>
+          &ldquo;Public Key&rdquo; is a unique sequence of numbers and letters within the Blockchain to distinguish the
+          network participants from each other.
+        </li>
+        <li>
+          &ldquo;Private Key&rdquo; is a unique sequence of numbers and/or letters required to initiate a Blockchain
+          Transaction and should only be known by the legal owner of the Wallet.
+        </li>
+        <li>
+          &ldquo;Safe&rdquo; is a modular, self-custodial (i.e. not supervised by us) smart contract-based
+          multi-signature Wallet. Safe is{' '}
+          <a href="https://www.google.com/url?q=https://github.com/safe-global/safe-contracts/&amp;sa=D&amp;source=editors&amp;ust=1677670461974783&amp;usg=AOvVaw0VU7ej4w-4PKSYww4aFXyt">
+            open-source
+          </a>
+          &nbsp;released under LGPL-3.0.
+        </li>
+        <li>
+          &ldquo;Safe Interfaces&rdquo; refers to a web-based graphical user interface for the Safe as well as a mobile
+          application on Android and iOS.
+        </li>
+        <li>
+          &ldquo;Safe Transaction&rdquo; is a Transaction of a Safe, authorized by a user, typically via their Wallet.{' '}
+        </li>
+        <li>
+          &ldquo;Profile&rdquo; means the Public Key and user provided, human readable label stored locally on the
+          user&apos;s device.
+        </li>
+      </ol>
+      <h3 id="3">3. Your information and the Blockchain</h3>
+      <p>
+        Blockchains, also known as distributed ledger technology (or simply &lsquo;DLT&rsquo;), are made up of digitally
+        recorded data in a chain of packages called &lsquo;blocks&rsquo;. The manner in which these blocks are linked is
+        chronological, meaning that the data is very difficult to alter once recorded. Since the ledger may be
+        distributed all over the world (across several &lsquo;nodes&rsquo; which usually replicate the ledger) this
+        means there is no single person making decisions or otherwise administering the system (such as an operator of a
+        cloud computing system), and that there is no centralized place where it is located either.
+      </p>
+      <p>
+        Accordingly, by design, records of a Blockchain cannot be changed or deleted and are said to be
+        &lsquo;immutable&rsquo;. This may affect your ability to exercise your rights such as your right to erasure
+        (&lsquo;right to be forgotten&rsquo;), or your rights to object or restrict processing of your personal data.
+        Data on the Blockchain cannot be erased and cannot be changed. Although smart contracts may be used to revoke
+        certain access rights, and some content may be made invisible to others, it is not deleted.
+      </p>
+      <p>
+        In certain circumstances, in order to comply with our contractual obligations to you (such as delivery of
+        Tokens) it will be necessary to write certain personal data, such as your Wallet address, onto the Blockchain;
+        this is done through a smart contract and requires you to execute such transactions using your Wallet&rsquo;s
+        Private Key.
+      </p>
+      <p>
+        In most cases ultimate decisions to (i) transact on the Blockchain using your Wallet, as well as (ii) share the
+        Public Key relating to your Wallet with anyone (including us) rests with you.
+      </p>
+      <p>
+        IF YOU WANT TO ENSURE YOUR PRIVACY RIGHTS ARE NOT AFFECTED IN ANY WAY, YOU SHOULD NOT TRANSACT ON BLOCKCHAINS AS
+        CERTAIN RIGHTS MAY NOT BE FULLY AVAILABLE OR EXERCISABLE BY YOU OR US DUE TO THE TECHNOLOGICAL INFRASTRUCTURE OF
+        THE BLOCKCHAIN. IN PARTICULAR THE BLOCKCHAIN IS AVAILABLE TO THE PUBLIC AND ANY PERSONAL DATA SHARED ON THE
+        BLOCKCHAIN WILL BECOME PUBLICLY AVAILABLE
+      </p>
+      <h3 id="4">4. How We Use Personal Data</h3>
+      <h4>4.1. When visiting our website and using Safe Interfaces</h4>
+      <p>
+        When visiting our website or using Safe Interfaces, we may collect and process personal data. The data will be
+        stored in different instances
+      </p>
+      <ol start={1} className={css.alphaList}>
+        <li>
+          We connect the Wallet&nbsp;to the web app to identify the user via their public Wallet address. For this
+          purpose we process:
+          <ol start={1} className={css.romanList}>
+            <li>public Wallet address and</li>
+            <li>WalletConnect connection data</li>
+          </ol>
+        </li>
+      </ol>
+      <ol start={2} className={css.alphaList}>
+        <li>
+          When you create a new Safe we process the following data to compose a Transaction based on your entered data
+          to be approved by your Wallet:
+          <ol start={1} className={css.romanList}>
+            <li>your public Wallet address, </li>
+            <li>account balance, </li>
+            <li>smart contract address of the Safe,</li>
+            <li>addresses of externally owned accounts&nbsp;and </li>
+            <li>user activity</li>
+          </ol>
+        </li>
+      </ol>
+      <ol start={3} className={css.alphaList}>
+        <li>
+          When you create a Profile for a new Safe we process the following data for the purpose of enabling you to view
+          your Safe after creation as well as enabling you to view all co-owned Safes:
+          <ol start={1} className={css.romanList}>
+            <li>your public Wallet address and </li>
+            <li>account balance</li>
+          </ol>
+        </li>
+      </ol>
+      <ol start={4} className={css.alphaList}>
+        <li>
+          When you create a Profile for an existing Safe for the purpose of allowing you to view and use them in the
+          Safe Interface, we process your
+          <ol start={1} className={css.romanList}>
+            <li>public Wallet address, </li>
+            <li>Safe balance, </li>
+            <li>smart contract address of the Safe and</li>
+            <li>Safe owner&apos;s public Wallet addresses</li>
+          </ol>
+        </li>
+      </ol>
+      <ol start={5} className={css.alphaList}>
+        <li>
+          When you initiate a Safe Transaction&nbsp;we process the following data to compose the Transaction for you
+          based on your entered data:{' '}
+          <ol start={1} className={css.romanList}>
+            <li>your public Wallet address and </li>
+            <li>smart contract address of the Safe</li>
+          </ol>
+        </li>
+      </ol>
+      <ol start={6} className={css.alphaList}>
+        <li>
+          When you sign a Safe Transaction&nbsp;we process the following data to enable you to sign the Transaction
+          using your Wallet:
+          <ol start={1} className={css.romanList}>
+            <li>Safe balance, </li>
+            <li>smart contract address of Safe and</li>
+            <li>Safe owner&apos;s public Wallet addresses</li>
+          </ol>
+        </li>
+      </ol>
+      <ol start={7} className={css.alphaList}>
+        <li>
+          To enable you to execute The transaction on the Blockchain we process:
+          <ol start={1} className={css.romanList}>
+            <li>your public Wallet address, </li>
+            <li>Safe balance, </li>
+            <li>smart contract address of the Safe, </li>
+            <li>Safe owner&apos;s public Wallet addresses and </li>
+            <li>Transactions signed by all Safe owners</li>
+          </ol>
+        </li>
+      </ol>
+      <ol start={8} className={css.alphaList}>
+        <li>
+          When we collect relevant&nbsp;data&nbsp;from the Blockchain to display context information in the Safe
+          Interface we process:
+          <ol start={1} className={css.romanList}>
+            <li>your public Wallet address, </li>
+            <li>account balance,</li>
+            <li>account activity and</li>
+            <li>Safe owner&apos;s Public wallet addresses</li>
+          </ol>
+        </li>
+      </ol>
+      <ol start={9} className={css.alphaList}>
+        <li>
+          When we decode Transactions from the Blockchain for the purpose of providing Transaction information in a
+          conveniently readable format, we process:
+          <ol start={1} className={css.romanList}>
+            <li>your public Wallet address </li>
+            <li>account balance and </li>
+            <li>account activity</li>
+          </ol>
+        </li>
+      </ol>
+      <ol start={10} className={css.alphaList}>
+        <li>
+          When we maintain a user profile&nbsp;to provide you with a good user experience through Profiles and an
+          address book we process:
+          <ol start={1} className={css.romanList}>
+            <li>your public Wallet address, </li>
+            <li>label, </li>
+            <li>smart contract address of the Safe, </li>
+            <li>Safe owner&apos;s public wallet addresses, </li>
+            <li>last used Wallet (for automatic reconnect), </li>
+            <li>last used chain id, </li>
+            <li>selected currency, </li>
+            <li>theme and </li>
+            <li>address format</li>
+          </ol>
+        </li>
+      </ol>
+      <p>
+        The legal base for all these activities is the performance of the contract we have with you (GDPR Art.6.1b).
+      </p>
+      <p>
+        THE DATA WILL BE STORED ON THE BLOCKCHAIN. GIVEN THE TECHNOLOGICAL DESIGN OF THE BLOCKCHAIN, AS EXPLAINED IN
+        SECTION 2, THIS DATA WILL BECOME PUBLIC AND IT WILL NOT LIKELY BE POSSIBLE TO DELETE OR CHANGE THE DATA AT ANY
+        GIVEN TIME.
+      </p>
+      <h4>4.2. Tracking</h4>
+      <p>4.2.1 We may store the following personal data to analyze your behavior:</p>
+      <ol start={1} className={css.romanList}>
+        <li>IP Address, </li>
+        <li>session tracking, </li>
+        <li>user behavior, </li>
+        <li>wallet type, </li>
+        <li>device and browser user agent,</li>
+        <li>user consent, </li>
+        <li>operating system, </li>
+        <li>referrers, </li>
+        <li>user behavior: subpage, duration, and revisit, the date and time of access,</li>
+      </ol>
+      <p>This data may be processed in order to improve the product and user experience.</p>
+      <p>The lawful basis for this processing is your consent (GDPR Art.6.1a) when agreeing to accept cookies.</p>
+      <p>
+        4.2.2 We conduct technical monitoring of your activity on the platform in order to ensure availability,
+        integrity and robustness of the service. For this purpose we process your:
+      </p>
+      <ol start={1} className={css.romanList}>
+        <li>IP addresses, </li>
+        <li>meta and communication data, </li>
+        <li>website access and </li>
+        <li>log data</li>
+      </ol>
+      <p>
+        The lawful basis for this processing is our legitimate interest (GDPR Art.6.1f) in ensuring the correctness of
+        the service.
+      </p>
+      <h4>4.3. When Participating in User Experience Research (UXR)</h4>
+      <p>
+        When you participate in our user experience research we may collect and process some personal data. This data
+        may include:
+      </p>
+      <ol start={1} className={css.romanList}>
+        <li>your name</li>
+        <li>your email</li>
+        <li>your phone type</li>
+        <li>your occupation</li>
+        <li>range of managed funds</li>
+      </ol>
+      <p>
+        In addition, we may take a recording of you while testing the Safe for internal and external use. The basis for
+        this collection and processing is our legitimate business interest in monitoring and improving our services.
+      </p>
+      <p>
+        The lawful basis for this processing is your consent as provided before participating in user experience
+        research.
+      </p>
+      <h4>4.4. Publishing the app</h4>
+      <p>4.4.1 Publishing the app on Google Play Store.</p>
+      <p>We process the following information to enable you to download the app on smartphones running Android:</p>
+      <ol start={1} className={css.alphaList}>
+        <li>google account and </li>
+        <li>e-mail address</li>
+      </ol>
+      <p>4.4.2 Publishing the app on Apple App Store</p>
+      <p>We process the following information to enable you to download the app on smartphones running iOS:</p>
+      <ol start={1}>
+        <li>apple account and </li>
+        <li>e-mail address</li>
+      </ol>
+      <p>
+        The lawful basis for these two processing activities is the performance of the contract we have with you (GDPR
+        Art.6.1b).{' '}
+      </p>
+      <h4>4.5. Use of the app</h4>
+      <p>4.5.1 We provide the app to you to enable you to use it. For this purpose we process your:</p>
+      <ol start={1} className={css.alphaList}>
+        <li>mobile device information, </li>
+        <li>http request caches and </li>
+        <li>http request cookies</li>
+      </ol>
+      <p>
+        4.5.2 In order to update you about changes in the app, we need to send you push notifications. For this purpose
+        we process your:
+      </p>
+      <ol start={1} className={css.alphaList}>
+        <li>Transactions executed and failed, </li>
+        <li>assets sent, </li>
+        <li>assets received </li>
+      </ol>
+      <p>
+        4.5.3 To provide support to you and notify you about outage resulting in unavailability of the service, we
+        process your:
+      </p>
+      <ol start={1} className={css.alphaList}>
+        <li>pseudonymized user identifier</li>
+      </ol>
+      <p>
+        4.5.4 In order to provide remote client configuration and control whether to inform about, recommend or force
+        you to update your app or enable/disable certain app features we process your:
+      </p>
+      <ol start={1} className={css.alphaList}>
+        <li>User agent, </li>
+        <li>app information (version, build number etc.), </li>
+        <li>language, </li>
+        <li>Country,</li>
+        <li>Platform</li>
+        <li>operating system</li>
+        <li>Browser</li>
+        <li>Device category</li>
+        <li>User audience</li>
+        <li>User property</li>
+        <li>User in random percentage</li>
+        <li>Imported segment</li>
+        <li>date/time</li>
+        <li>first open </li>
+        <li>installation ID</li>
+      </ol>
+      <p>
+        For all these activities (4.5.1-4.54) we rely on the legal base of performance of a contract (GDPR Art.6.1b)
+        with you.{' '}
+      </p>
+      <p>4.5.5 Finally, to report errors and improve user experience we process your:</p>
+      <ol start={1}>
+        <li>User agent info (Browser, OS, device), </li>
+        <li>URL that you were on (Can contain Safe address) and </li>
+        <li>Error info: Time, stacktrace</li>
+      </ol>
+      <p>We rely on our legitimate interest (GDPR Art.6.1f) of ensuring product quality. </p>
+      <h4>4.6 Other uses of your Personal Data</h4>
+      <p>
+        We may process any of your Personal Data where it is necessary to establish, exercise, or defend legal claims.
+        The legal basis for this is our legitimate interests, namely the protection and assertion of our legal rights,
+        your legal rights and the legal rights of others.
+      </p>
+      <p>
+        Further, we may process your Personal data where such processing is necessary in order for us to comply with a
+        legal obligation to which we are subject. The legal basis for this processing is our legitimate interests,
+        namely the protection and assertion of our legal rights.
+      </p>
+      <h3 id="5">5. Use of Third Party Applications</h3>
+      <h4>5.1. Blockchain</h4>
+      <p>
+        When using the Safe your smart contract address, Safe Transactions, addresses of signer accounts and ETH
+        balances and token balances will be stored on the Blockchain. See section 2 of this Policy
+      </p>
+      <p>
+        THE INFORMATION WILL BE DISPLAYED PERMANENTLY AND PUBLIC, THIS IS PART OF THE NATURE OF THE BLOCKCHAIN. IF YOU
+        ARE NEW TO THIS FIELD, WE HIGHLY RECOMMEND INFORMING YOURSELF ABOUT THE BLOCKCHAIN TECHNOLOGY BEFORE USING OUR
+        SERVICES.
+      </p>
+      <h4>5.2. Amazon Web Services</h4>
+      <p>
+        We use{' '}
+        <a href="https://www.google.com/url?q=https://aws.amazon.com/&amp;sa=D&amp;source=editors&amp;ust=1677670461998336&amp;usg=AOvVaw0klUOiMtFQiqXOnVo-NxtZ">
+          Amazon Web Services (AWS)
+        </a>
+        &nbsp;to store log and database data as described in section 4.1.
+      </p>
+      <h4>5.3. Datadog</h4>
+      <p>
+        We use{' '}
+        <a href="https://www.google.com/url?q=https://www.datadoghq.com/&amp;sa=D&amp;source=editors&amp;ust=1677670461999033&amp;usg=AOvVaw3rYJZBo6VNH8rKYtFyQeRD">
+          Datadog
+        </a>
+        &nbsp;to store log data as described in section 4.1.
+      </p>
+      <h4>5.4. Mobile app stores</h4>
+      <p>
+        Safe mobile apps are distributed via{' '}
+        <a href="https://www.google.com/url?q=https://www.apple.com/app-store/&amp;sa=D&amp;source=editors&amp;ust=1677670461999703&amp;usg=AOvVaw0FQLE9DGc__i48SYxTwCzJ">
+          Apple AppStore
+        </a>
+        &nbsp;and{' '}
+        <a href="https://www.google.com/url?q=https://play.google.com/&amp;sa=D&amp;source=editors&amp;ust=1677670462000051&amp;usg=AOvVaw0xdj_3JNm_HHuv6tClADLo">
+          Google Play Store
+        </a>
+        . They most likely track user behavior when downloading apps from their stores as well as when using apps. We
+        only have very limited access to that data. We can view aggregated statistics on installs and uninstalls.
+        Grouping by device type, app version, language, carrier and country is possible.
+      </p>
+      <h4>5.5. Fingerprint/Touch ID/ Face ID</h4>
+      <p>
+        We enable the user to unlock the Safe mobile app via biometrics information (touch ID or face ID). This is a
+        feature of the operating system. We do not store any of this data. Instead, the API of the operating system is
+        used to validate the user input. If you have any further questions you should consult with your preferred mobile
+        device provider or manufacturer.
+      </p>
+      <h4>5.6. Google Firebase</h4>
+      <p>
+        We use the following{' '}
+        <a href="https://www.google.com/url?q=https://firebase.google.com/&amp;sa=D&amp;source=editors&amp;ust=1677670462001228&amp;usg=AOvVaw0PvjHiv6LzUshRGaz9KwDc">
+          Google Firebase
+        </a>
+        &nbsp;services:
+      </p>
+      <ul>
+        <li>
+          Firebase Cloud Messaging: Provide updates to the user about changes in the mobile apps via push notifications.
+        </li>
+        <li>
+          Firebase remote config: Inform users about, recommend or force user to update their mobile app or
+          enabling/disabling certain app features. These settings are global for all users, no personalization is
+          happening.
+        </li>
+        <li>Firebase crash reporting: Report errors and crashes to improve product and user experience.</li>
+      </ul>
+      <h4>5.7. WalletConnect</h4>
+      <p>
+        <a href="https://www.google.com/url?q=https://walletconnect.com/&amp;sa=D&amp;source=editors&amp;ust=1677670462002729&amp;usg=AOvVaw3fns2anVcEVZjXS6gxfger">
+          WalletConnect
+        </a>
+        &nbsp;is used to connect wallets to dapps using end-to-end encryption by scanning a QR code. We do not store any
+        information collected by WalletConnect.{' '}
+      </p>
+      <h4>5.8. Sentry</h4>
+      <p>
+        We use{' '}
+        <a href="https://www.google.com/url?q=https://sentry.io/&amp;sa=D&amp;source=editors&amp;ust=1677670462003432&amp;usg=AOvVaw0awYpXXYSCHZcWOeIr7IXY">
+          Sentry
+        </a>
+        &nbsp;to collect error reports and crashes to improve product and user experience.{' '}
+      </p>
+      <h4>5.9. Beamer</h4>
+      <p>
+        We use{' '}
+        <a href="https://www.google.com/url?q=https://www.getbeamer.com/&amp;sa=D&amp;source=editors&amp;ust=1677670462004085&amp;usg=AOvVaw3mKE7fFDU9R9XnTtgrSkwz">
+          Beamer
+        </a>
+        &nbsp;providing updates to the user about changes in the app. Beamer&apos;s purpose and function are further
+        explained under the following link{' '}
+        <a href="https://www.google.com/url?q=https://www.getbeamer.com/showcase/notification-center&amp;sa=D&amp;source=editors&amp;ust=1677670462004398&amp;usg=AOvVaw1TTpszDU9wZy4QP-SU-Mz2">
+          https://www.getbeamer.com/showcase/notification-center
+        </a>
+        .
+      </p>
+      <p>We do not store any information collected by Beamer.</p>
+      <h4>5.10. Node providers</h4>
+      <p>
+        We use{' '}
+        <a href="https://www.google.com/url?q=https://www.infura.io/&amp;sa=D&amp;source=editors&amp;ust=1677670462005213&amp;usg=AOvVaw3Z7giCkorlD4Jsvrh_si8a">
+          Infura
+        </a>
+        &nbsp;and{' '}
+        <a href="https://www.google.com/url?q=https://nodereal.io/&amp;sa=D&amp;source=editors&amp;ust=1677670462005507&amp;usg=AOvVaw2MaUVqR0xB4JDnSBMH5IS4">
+          Nodereal
+        </a>
+        &nbsp;to query public blockchain data from our backend services. All Safes are monitored, no personalization is
+        happening and no user IP addresses are forwarded. Personal data processed are:
+      </p>
+      <ul>
+        <li>Your smart contract address of the Safe;</li>
+        <li>Transaction id/hash</li>
+        <li>Transaction data</li>
+      </ul>
+      <h4>5.11. Tenderly</h4>
+      <p>
+        We use{' '}
+        <a href="https://www.google.com/url?q=https://tenderly.co/&amp;sa=D&amp;source=editors&amp;ust=1677670462006850&amp;usg=AOvVaw35y42G_oU-fWhcI_iNwfBg">
+          Tenderly
+        </a>
+        &nbsp;to simulate blockchain transactions before they are executed. For that we send your smart contract address
+        of your Safe and transaction data to Tenderly.
+      </p>
+      <h4>5.12. Internal communication</h4>
+      <p>We use the following tools for internal communication. </p>
+      <ul>
+        <li>
+          <a href="https://www.google.com/url?q=https://slack.com/&amp;sa=D&amp;source=editors&amp;ust=1677670462007752&amp;usg=AOvVaw0LysMSW4tdq8cG4KbCOzaa">
+            Slack
+          </a>
+        </li>
+        <li>
+          <a href="https://www.google.com/url?q=https://workspace.google.com/&amp;sa=D&amp;source=editors&amp;ust=1677670462008110&amp;usg=AOvVaw0eNEELfZnd0R91E3J2XnB5">
+            Google Workspace
+          </a>
+        </li>
+        <li>
+          <a href="https://www.google.com/url?q=https://notion.so&amp;sa=D&amp;source=editors&amp;ust=1677670462008559&amp;usg=AOvVaw0LlPhL5VvrcNajC6vp7ou5">
+            Notion
+          </a>
+        </li>
+      </ul>
+      <h3 id="6">6. Sharing Your Personal Data</h3>
+      <p>
+        We may pass your information to our Business Partners, administration centers, third party service providers,
+        agents, subcontractors and other associated organizations for the purposes of completing tasks and providing our
+        services to you.
+      </p>
+      <p>
+        In addition, when we use any other third-party service providers, we will disclose only the personal information
+        that is necessary to deliver the service required and we will ensure that they keep your information secure and
+        not use it for their own direct marketing purposes. In addition, we may transfer your personal information to a
+        third party as part of a sale of some, or all, of our business and assets or as part of any business
+        restructuring or reorganization, or if we are under a duty to disclose or share your personal data in order to
+        comply with any legal obligation. However, we will take steps to ensure that your privacy rights continue to be
+        protected.
+      </p>
+      <h3 id="7">7. Transferring Your data outside of the EU</h3>
+      <p>
+        Wherever possible we will choose service providers based in the EU. For those outside the EU, wherever possible
+        we will configure data to be inside the EU. We concluded the new version of the Standard Contractual Clauses
+        with these service providers (2021/914).
+      </p>
+      <p>Service providers in the US:</p>
+      <ul>
+        <li>Amazon Web Service Inc.</li>
+        <li>Google LLC</li>
+        <li>Data Dog Inc.</li>
+        <li>Slack Technologies LLC</li>
+        <li>Joincube Inc. (Beamer)</li>
+        <li>Functional software Inc. (Sentry) </li>
+        <li>Notion Labs Inc.</li>
+        <li>ConsenSys Software Inc.</li>
+      </ul>
+      <p>Service providers in other countries outside of the EU:</p>
+      <ul>
+        <li>Tenderly d.o.o. is based in Serbia.</li>
+        <li>Node Real PTE Ltd. is based in Singapore.</li>
+      </ul>
+      <p>
+        HOWEVER, WHEN INTERACTING WITH THE BLOCKCHAIN, AS EXPLAINED ABOVE IN THIS POLICY, THE BLOCKCHAIN IS A GLOBAL
+        DECENTRALIZED PUBLIC NETWORK AND ACCORDINGLY ANY PERSONAL DATA WRITTEN ONTO THE BLOCKCHAIN MAY BE TRANSFERRED
+        AND STORED ACROSS THE GLOBE.
+      </p>
+      <h3 id="8">8. Existence of Automated Decision-making</h3>
+      <p>We do not use automatic decision-making or profiling when processing Personal Data.</p>
+      <h3 id="9">9. Data Security</h3>
+      <p>
+        We have put in place appropriate security measures to prevent your personal data from being accidentally lost,
+        used or accessed in an unauthorized way, altered or disclosed. In addition, we limit access to your personal
+        data to those employees, agents, contractors and other third parties who have a business need to know. They will
+        only process your personal data on our instructions and they are subject to a duty of confidentiality.
+      </p>
+      <p>
+        We have put in place procedures to deal with any suspected personal data breach and will notify you and any
+        applicable regulator of a breach where we are legally required to do so.
+      </p>
+      <h3 id="10">10. Your Rights as a Data Subject</h3>
+      <p>
+        You have certain rights under applicable legislation, and in particular under Regulation EU 2016/679 (General
+        Data Protection Regulation or &lsquo;GDPR&rsquo;). We explain these below. You can find out more about the GDPR
+        and your rights by accessing the{' '}
+        <a href="https://www.google.com/url?q=https://ec.europa.eu/info/law/law-topic/data-protection_en&amp;sa=D&amp;source=editors&amp;ust=1677670462013109&amp;usg=AOvVaw130yoKbfsfpLG6xbgjr5oB">
+          European Commission&rsquo;s website
+        </a>
+        . If you wish to exercise your data subject rights, please contact us by post or at privacy@cc0x.dev.
+      </p>
+      <h5>Right Information and access</h5>
+      <p>
+        You have a right to be informed about the processing of your personal data (and if you did not give it to us,
+        information as to the source) and this Privacy Policy intends to provide the information. Of course, if you have
+        any further questions you can contact us on the above details.
+      </p>
+      <h5>Right to rectification</h5>
+      <p>
+        You have the right to have any inaccurate personal information about you rectified and to have any incomplete
+        personal information about you completed. You may also request that we restrict the processing of that
+        information. The accuracy of your information is important to us. If you do not want us to use your Personal
+        Information in the manner set out in this Privacy Policy, or need to advise us of any changes to your personal
+        information, or would like any more information about the way in which we collect and use your Personal
+        Information, please contact us at the above details.
+      </p>
+      <h5>Right to erasure (right to be &lsquo;forgotten&rsquo;)</h5>
+      <p>
+        You have the general right to request the erasure of your personal information in the following circumstances:
+      </p>
+      <ul>
+        <li>the personal information is no longer necessary for the purpose for which it was collected;</li>
+        <li>
+          you withdraw your consent to consent based processing and no other legal justification for processing applies;
+        </li>
+        <li>you object to processing for direct marketing purposes;</li>
+        <li>we unlawfully processed your personal information; and</li>
+        <li>erasure is required to comply with a legal obligation that applies to us.</li>
+      </ul>
+      <p>
+        HOWEVER, WHEN INTERACTING WITH THE BLOCKCHAIN WE MAY NOT BE ABLE TO ENSURE THAT YOUR PERSONAL DATA IS DELETED.
+        THIS IS BECAUSE THE BLOCKCHAIN IS A PUBLIC DECENTRALIZED NETWORK AND BLOCKCHAIN TECHNOLOGY DOES NOT GENERALLY
+        ALLOW FOR DATA TO BE DELETED AND YOUR RIGHT TO ERASURE MAY NOT BE ABLE TO BE FULLY ENFORCED. IN THESE
+        CIRCUMSTANCES WE WILL ONLY BE ABLE TO ENSURE THAT ALL PERSONAL DATA THAT IS HELD BY US IS PERMANENTLY DELETED.
+      </p>
+      <p>
+        We will proceed to comply with an erasure request without delay unless continued retention is necessary for:
+      </p>
+      <ul>
+        <li>Exercising the right of freedom of expression and information;</li>
+        <li>Complying with a legal obligation under EU or other applicable law;</li>
+        <li>The performance of a task carried out in the public interest;</li>
+        <li>
+          Archiving purposes in the public interest, scientific or historical research purposes, or statistical
+          purposes, under certain circumstances; and/or
+        </li>
+        <li>The establishment, exercise, or defense of legal claims.</li>
+      </ul>
+      <h5>Right to restrict processing and right to object to processing</h5>
+      <p>You have a right to restrict processing of your personal information, such as where:</p>
+      <ol start={1}>
+        <li>you contest the accuracy of the personal information;</li>
+        <li>
+          where processing is unlawful you may request, instead of requesting erasure, that we restrict the use of the
+          unlawfully processed personal information;
+        </li>
+        <li>
+          we no longer need to process your personal information but need to retain your information for the
+          establishment, exercise, or defense of legal claims.
+        </li>
+      </ol>
+      <p>
+        You also have the right to object to processing of your personal information under certain circumstances, such
+        as where the processing is based on your consent and you withdraw that consent. This may impact the services we
+        can provide and we will explain this to you if you decide to exercise this right.
+      </p>
+      <p>
+        HOWEVER, WHEN INTERACTING WITH THE BLOCKCHAIN, AS IT IS A PUBLIC DECENTRALIZED NETWORK, WE WILL LIKELY NOT BE
+        ABLE TO PREVENT EXTERNAL PARTIES FROM PROCESSING ANY PERSONAL DATA WHICH HAS BEEN WRITTEN ONTO THE BLOCKCHAIN.
+        IN THESE CIRCUMSTANCES WE WILL USE OUR REASONABLE ENDEAVORS TO ENSURE THAT ALL PROCESSING OF PERSONAL DATA HELD
+        BY US IS RESTRICTED, NOTWITHSTANDING THIS, YOUR RIGHT TO RESTRICT TO PROCESSING MAY NOT BE ABLE TO BE FULLY
+        ENFORCED.
+      </p>
+      <h5>Right to data portability</h5>
+      <p>
+        Where the legal basis for our processing is your consent or the processing is necessary for the performance of a
+        contract to which you are party or in order to take steps at your request prior to entering into a contract, you
+        have a right to receive the personal information you provided to us in a structured, commonly used and
+        machine-readable format, or ask us to send it to another person.
+      </p>
+      <h5>Right to freedom from automated decision-making</h5>
+      <p>
+        As explained above, we do not use automated decision-making, but where any automated decision-making takes
+        place, you have the right in this case to express your point of view and to contest the decision, as well as
+        request that decisions based on automated processing concerning you or significantly affecting you and based on
+        your personal data are made by natural persons, not only by computers.
+      </p>
+      <h5>Right to object to direct marketing (&lsquo;opting out&rsquo;)</h5>
+      <p>
+        You have a choice about whether or not you wish to receive information from us. We will not contact you for
+        marketing purposes unless:
+      </p>
+      <ul>
+        <li>
+          you have a business relationship with us, and we rely on our legitimate interests as the lawful basis for
+          processing (as described above)
+        </li>
+        <li>you have otherwise given your prior consent (such as when you download one of our guides)</li>
+      </ul>
+      <p>
+        You can change your marketing preferences at any time by contacting us on the above details. On each and every
+        marketing communication, we will always provide the option for you to exercise your right to object to the
+        processing of your personal data for marketing purposes (known as &lsquo;opting-out&rsquo;) by clicking on the
+        &lsquo;unsubscribe&rsquo; button on our marketing emails or choosing a similar opt-out option on any forms we
+        use to collect your data. You may also opt-out at any time by contacting us on the below details.
+      </p>
+      <p>
+        Please note that any administrative or service-related communications (to offer our services, or notify you of
+        an update to this Privacy Policy or applicable terms of business, etc.) will solely be directed at our clients
+        or business partners, and such communications generally do not offer an option to unsubscribe as they are
+        necessary to provide the services requested. Therefore, please be aware that your ability to opt-out from
+        receiving marketing and promotional materials does not change our right to contact you regarding your use of our
+        website or as part of a contractual relationship we may have with you.
+      </p>
+      <h5>Right to request access</h5>
+      <p>
+        You also have a right to access information we hold about you. We are happy to provide you with details of your
+        Personal Information that we hold or process. To protect your personal information, we follow set storage and
+        disclosure procedures, which mean that we will require proof of identity from you prior to disclosing such
+        information. You can exercise this right at any time by contacting us on the above details.
+      </p>
+      <h5>Right to withdraw consent</h5>
+      <p>
+        Where the legal basis for processing your personal information is your consent, you have the right to withdraw
+        that consent at any time by contacting us on the above details.
+      </p>
+      <h5>Raising a complaint about how we have handled your personal data</h5>
+      <p>
+        If you wish to raise a complaint on how we have handled your personal data, you can contact us as set out above
+        and we will then investigate the matter.
+      </p>
+      <h5>Right to lodge a complaint with a relevant supervisory authority</h5>
+      <p>
+        We encourage you to contact us at privacy@cc0de.dev if you have any privacy related concerns. Should you
+        disapprove of the response we have provided you, you have the right to lodge a complaint with our supervisory
+        authority, or with the data protection authority of the European member state you live or work in. The details
+        of the supervisory authority responsible for Berlin, Germany, are:
+      </p>
+      <p>Berliner Beauftragte f&uuml;r Datenschutz und Informationsfreiheit</p>
+      <p>
+        Alt-Moabit 59-61
+        <br />
+        10555 Berlin
+        <br />
+        Germany
+        <br />
+        Phone: 030/138 89-0
+      </p>
+      <p>
+        <Link
+          href="https://www.google.com/url?q=https://www.datenschutz-berlin.de&amp;sa=D&amp;source=editors&amp;ust=1677670462021305&amp;usg=AOvVaw1sgbmKiiYL0n7tPM5It81-"
+          passHref
+        >
+          <MUILink target="_blank" rel="noreferrer">
+            https://www.datenschutz-berlin.de
+          </MUILink>
+        </Link>
+        &nbsp;
+      </p>
+      <p>
+        You also have the right to lodge a complaint with the supervisory authority in the country of your habitual
+        residence, place of work, or the place where you allege an infringement of one or more of our rights has taken
+        place, if that is based in the EEA.
+      </p>
+      <h3 id="11">11. Storing Personal Data</h3>
+      <p>
+        We retain your information only for as long as is necessary for the purposes for which we process the
+        information as set out in this policy.
+      </p>
+      <p>
+        However, we may retain your Personal Data for a longer period of time where such retention is necessary for
+        compliance with a legal obligation to which we are subject, or in order to protect your vital interests or the
+        vital interests of another natural person.
+      </p>
+      <h3 id="12">12. Changes to this Privacy Policy</h3>
+      <p>
+        We may modify this privacy policy at any time to comply with legal requirements as well as developments within
+        our organization. When we do, we will revise the date at the top of this page. Each visit or interaction with
+        our services will be subject to the new privacy policy. We encourage you to regularly review our privacy policy
+        to stay informed about our data protection policy. Unless, we implement profound changes that we proactively
+        notify you about, you acknowledge that it is your responsibility to review our privacy policy to be aware of
+        modifications. If you do not agree to the revised policy, you should discontinue your use of this website.
+      </p>
+      <h3 id="13">13. Contact Us</h3>
+      <h5>Contact us by post or email at:</h5>
+      <p>
+        Core Contributors GmbH
+        <br />℅ Full Node
+        <br />
+        Skalitzer Str. 85-86
+        <br />
+        10997 Berlin
+        <br />
+        Germany
+        <br />
+        privacy@cc0x.dev
+      </p>
+      <h5>Contact our Data Protection Officer by post or email at:</h5>
+      <p>
+        TechGDPR DPC GmbH
+        <br />
+        Heinrich-Roller Str. 15
+        <br />
+        10405 Berlin
+        <br />
+        Germany
+      </p>
+      <p>
+        <a href="mailto:corecontributors.dpo@techgdpr.com">corecontributors.dpo@techgdpr.com</a>&nbsp;
+      </p>
+    </div>
+  )
+}
+
+export default SafePrivacyPolicy

--- a/src/components/privacy/styles.module.css
+++ b/src/components/privacy/styles.module.css
@@ -1,0 +1,7 @@
+.alphaList {
+  list-style: lower-alpha;
+}
+
+.romanList {
+  list-style: lower-roman;
+}

--- a/src/components/terms/index.tsx
+++ b/src/components/terms/index.tsx
@@ -1,11 +1,572 @@
 import { Typography } from '@mui/material'
+import Link from 'next/link'
+import MUILink from '@mui/material/Link'
+import { AppRoutes } from '@/config/routes'
 
 const SafeTerms = () => {
   return (
     <div>
       <Typography variant="h1" mb={2}>
-        Terms
+        Terms and Conditions
       </Typography>
+      <p>Last updated: March, 2023</p>
+      <h3>1. What is the scope of the Terms?</h3>
+      <ol start={1}>
+        <li>
+          These Terms and Conditions (&ldquo;Terms&rdquo;) become part of any contract (&ldquo;Agreement&rdquo;) between
+          you (&ldquo;you&rdquo;, &ldquo;yours&rdquo; or &ldquo;User&rdquo;) and Core Contributors GmbH
+          (&ldquo;CC&rdquo;, &ldquo;we&rdquo;, &ldquo;our&rdquo; or &ldquo;us&rdquo;) provided we made these Terms
+          accessible to you prior to entering into the Agreement and you consent to these Terms. We are a limited
+          liability company registered with the commercial register of Berlin Charlottenburg under company number HRB
+          24041&nbsp;B, with its registered office at the ℅ Full Node, Skalitzer Str. 85-86, 10997 Berlin, Germany. You
+          can contact us by writing to info@cc0x.dev.
+        </li>
+        <li>
+          The Agreement is concluded by using the Mobile App, Web App and/or Browser Extension&nbsp;subject to these
+          Terms.&nbsp;The use of our Services is only permitted to legal entities, partnerships and natural persons with
+          unlimited legal capacity. In particular, minors are prohibited from using our Services.
+        </li>
+        <li>
+          The application of your general terms and conditions is excluded. Your deviating, conflicting or supplementary
+          general terms and conditions shall only become part of the Agreement if and to the extent that CC has
+          expressly agreed to their application in writing. This consent requirement shall apply in any case, even if
+          for example CC, being aware of your general terms and conditions, accepts payments by the contractual partner
+          without reservations.
+        </li>
+        <li>
+          We reserve the right to change these Terms at any time and without giving reasons, while considering and
+          weighing your interests. The new Terms will be communicated to you in advance. They are considered as agreed
+          upon if you do not object to their validity within 14 days after receipt of the notification. We will
+          separately inform you about the essential changes, the possibility to object, the deadline and the
+          consequences of inactivity. If you object, the current version of the Terms remains applicable. Our right to
+          terminate the contract according to Clause 8 remains unaffected.
+        </li>
+      </ol>
+      <h3>2. What do some of the capitalized terms mean in the Agreement?</h3>
+      <ol start={1}>
+        <li>
+          &ldquo;Blockchain&rdquo; means a mathematically secured consensus ledger such as the Ethereum Virtual Machine,
+          an Ethereum Virtual Machine compatible validation mechanism, or other decentralized validation mechanisms.
+        </li>
+        <li>
+          &ldquo;Transaction&rdquo; means a change to the data set through a new entry in the continuous Blockchain.
+        </li>
+        <li>
+          &ldquo;Smart Contract&rdquo; means a piece of source code deployed as an application on the Blockchain which
+          can be executed, including self-execution of Transactions as well as execution triggered by 3rd parties.
+        </li>
+        <li>
+          &ldquo;Token&rdquo; means a digital asset transferred in a Transaction, including ETH, ERC20, ERC721 and
+          ERC1155 tokens.
+        </li>
+        <li>
+          &ldquo;Wallet&rdquo; means a cryptographic storage solution permitting you to store cryptographic assets by
+          correlation of a (i) Public Key and (ii) a Private Key, or a Smart Contract to receive, manage and send
+          Tokens.
+        </li>
+        <li>
+          &ldquo;Recovery Phrase&rdquo; means a series of secret words used to generate one or more Private Keys and
+          derived Public Keys.
+        </li>
+        <li>
+          &ldquo;Public Key&rdquo; means a unique sequence of numbers and letters within the Blockchain to distinguish
+          the network participants from each other.
+        </li>
+        <li>
+          &ldquo;Private Key&rdquo; means a unique sequence of numbers and/or letters required to initiate a Blockchain
+          Transaction and should only be known by the legal owner of the Wallet.
+        </li>
+      </ol>
+      <h3>3. What are the Services offered?</h3>
+      <p>
+        Our services (&ldquo;Services&rdquo;) primarily consist of enabling users to create their Safes and ongoing
+        interaction with it on the Blockchain.
+      </p>
+      <ol start={1}>
+        <li>&ldquo;Safe&rdquo; </li>
+      </ol>
+      <p>
+        The Safe (&ldquo;Safe&rdquo;) is a modular, self-custodial (i.e. not supervised by us) smart contract-based
+        wallet not provided by CC. Safe is{' '}
+        <Link href="https://github.com/safe-global/safe-contracts/" passHref>
+          <MUILink target="_blank" rel="noreferrer">
+            open-source
+          </MUILink>
+        </Link>
+        &nbsp;released under LGPL-3.0.
+      </p>
+      <p>
+        Smart contract wallet means, unlike a standard private key Wallet, that access control for authorizing any
+        Transaction is defined in code. An example are multi-signature wallets which require that any Transaction must
+        be signed by a minimum number of signing wallets whereby the specifics of the requirements to authorize a
+        Transaction can be configured in code.{' '}
+      </p>
+      <p>
+        Owners need to connect a signing wallet with the Safe.&nbsp;Safe is compatible inter alia with standard private
+        key Wallets such as hardware wallets, browser extension wallets and mobile wallets that support WalletConnect.
+      </p>
+      <ol start={2}>
+        <li>&ldquo;Safe&nbsp;App&rdquo;</li>
+      </ol>
+      <p>
+        You may access the Safe using the Safe web app, mobile app for iOS and android, or the browser
+        extension&nbsp;(each a &ldquo;Safe&nbsp;App&rdquo;). The Safe&nbsp;App may be used to manage your personal
+        digital assets on Ethereum and other common EVM chains when you connect the Safe with third-party&nbsp;services
+        (as defined below). The Safe&nbsp;App provides certain features that may be amended from time to time.{' '}
+      </p>
+      <ol start={3}>
+        <li>&ldquo;Third-Party&nbsp;Apps&rdquo;</li>
+      </ol>
+      <p>
+        The Safe&nbsp;App allows you to connect the Safe to third-party decentralized applications
+        (&ldquo;Third-Party&nbsp;Apps&rdquo;) and use third-party&nbsp;services such as from the decentralized finance
+        sector, DAO Tools or services related to NFTs (&ldquo;Third-Party&nbsp;Services&quot;). The
+        Third-Party&nbsp;Apps are integrated in the user interface of the Safe&nbsp;App via inline framing. The provider
+        of the Third-Party&nbsp;App and related Third-Party Service is responsible for the operation of the service and
+        the correctness, completeness and actuality of any information provided therein. We make a pre-selection of
+        Third-Party&nbsp;Apps that we show in the Safe&nbsp;App. However, we only perform a rough triage in advance for
+        obvious problems and functionality in terms of loading time and resolution capability of the transactions.
+        Accordingly, in the event of any (technical) issues concerning the Third-Party Services, the user must only
+        contact the respective service provider directly. The terms of service, if any, shall be governed by the
+        applicable contractual provisions between the User and the respective provider of the Third-Party&nbsp;Service.
+        Accordingly, we are not liable in the event of a breach of contract, damage or loss related to the use of such
+        Third-Party Service.
+      </p>
+      <h3>4. What do the Services not consist of?</h3>
+      <p>Our Services do not&nbsp;consist of:</p>
+      <ol start={1}>
+        <li>
+          activity regulated by the Federal Financial Supervisory Authority (BaFin) or any other regulatory agency in
+          any jurisdiction;
+        </li>
+        <li>coverage underwritten by any regulatory agency&rsquo;s compensation scheme;</li>
+        <li>
+          custody of your Recovery Phrase, Private Keys, Tokens or the ability to remove or freeze your Tokens, i.e.
+          Safe is a self-custodial wallet;
+        </li>
+        <li>the storage or transmission of fiat currencies;</li>
+        <li>
+          back-up services to recover your Recovery Phrase or Private Keys, for whose safekeeping you are solely
+          responsible; CC has no means to recover your access to your Tokens, when you lose access to your Safe;
+        </li>
+        <li>
+          any form of legal, financial, investment, accounting, tax or other professional advice regarding Transactions
+          and their suitability to you;{' '}
+        </li>
+        <li>
+          the responsibility to monitor authorized Transactions or to check the correctness or completeness of
+          Transactions before you are authorizing them.
+        </li>
+      </ol>
+      <h3>5. What do you need to know about Third-Party Services?</h3>
+      <ol start={1}>
+        <li>
+          We provide you the possibility to interact with your Safe through&nbsp;Third-Party Services. Any activities
+          you engage in with, or services you receive from a third party is between you and that third party directly.
+          The conditions of service provisions, if any, shall be governed by the applicable contractual provisions
+          between you and the respective provider of the Third-Party Service.{' '}
+        </li>
+        <li>
+          The Services rely in part on third-party and open-source software, including the Blockchain, and the continued
+          development and support by third parties. There is no assurance or guarantee that those third parties will
+          maintain their support of their software or that open-source software will continue to be maintained. This may
+          have a material adverse effect on the Services.
+        </li>
+        <li>This means specifically:</li>
+      </ol>
+      <ul>
+        <li>
+          We do not have any oversight over your activities with Third-Party&nbsp;Services especially by using
+          Third-Party&nbsp;Apps, and therefore we do not and cannot make any representation regarding their
+          appropriateness and suitability for you.
+        </li>
+        <li>
+          Third-Party&nbsp;Services are not hosted, owned, controlled or maintained by us. We also do not participate in
+          the Transaction and will not and cannot monitor, verify, censor or edit the functioning or content of any
+          Third-Party Service.
+        </li>
+        <li>
+          We have not conducted any security audit, bug bounty or formal verification (whether internal or external) of
+          the Third-Party Services.
+        </li>
+        <li>
+          We have no control over, do not recommend, endorse, or otherwise take a position on the integrity, functioning
+          of, content and your use of Third-Party&nbsp;Services, whose sole responsibility lies with the person from
+          whom such services or content originated.
+        </li>
+        <li>
+          When you access or use Third-Party&nbsp;Services you accept that there are risks in doing so and that you
+          alone assume any such risks when choosing to interact with them. We are not liable for any errors or omissions
+          or for any damages or loss you might suffer through interacting with those Third-Party&nbsp;Services, such as
+          Third-Party&nbsp;Apps.
+        </li>
+        <li>
+          You know of the inherent risks of cryptographic and Blockchain-based systems and the high volatility of Token
+          markets. Transactions undertaken in the Blockchain are irrevocable and irreversible and there is no
+          possibility to refund Token that have been deployed.
+        </li>
+        <li>
+          You should read the license requirements, terms and conditions as well as privacy policy of each
+          Third-Party&nbsp;Service that you access or use. Certain Third-Party&nbsp;Services may involve complex
+          Transactions that entail a high degree of risk.
+        </li>
+        <li>
+          If you contribute integrations to Third-Party&nbsp;Services, you are responsible for all content you
+          contribute, in any manner, and you must have all rights necessary to do so, in the manner in which you
+          contribute it. You are responsible for all your activity in connection with any such Third-Party&nbsp;Service.{' '}
+        </li>
+        <li>
+          Your interactions with persons found on or through the Third-Party&nbsp;Service, including payment and
+          delivery of goods and services, financial transactions, and any other terms associated with such dealings, are
+          solely between you and such persons. You agree that we shall not be responsible or liable for any loss or
+          damage of any sort incurred as the result of any such dealings.
+        </li>
+        <li>
+          If there is a dispute between you and the Third-Party&nbsp;Service provider or/and other users of the
+          Third-Party&nbsp;Service, you agree that we are under no obligation to become involved. In the event that you
+          have a dispute with one or more other users, you release us, our officers, employees, agents, contractors and
+          successors from claims, demands, and damages of every kind or nature, known or unknown, suspected or
+          unsuspected, disclosed or undisclosed, arising out of or in any way related to such disputes and/or our
+          Services.
+        </li>
+      </ul>
+      <h3>6. What are the fees for the Services?</h3>
+      <ol start={1}>
+        <li>
+          The use of the Safe App or Third-Party&nbsp;Apps may cause fees, including network fees, as indicated in the
+          respective app. CC has no control over the fees charged by the Third-Party Services. CC may change its own
+          fees at any time. Price changes will be communicated to the User in due time before taking effect.
+        </li>
+        <li>
+          The User is only entitled to offset and/or assert rights of retention if his counterclaims are legally
+          established, undisputed or recognized by CC.
+        </li>
+      </ol>
+      <h3>7. Are we responsible for the security of your Private Keys, Recovery Phrase or other credentials?</h3>
+      <ol start={1}>
+        <li>
+          We shall not be responsible&nbsp;to secure your Private Keys, Recovery Phrase, credentials or other means of
+          authorization of your wallet(s).
+        </li>
+        <li>
+          You must own and control any wallet you use in connection with our Services. You are responsible for
+          implementing all appropriate measures for securing any wallet you use, including any Private Key(s), Recovery
+          Phrase, credentials or other means of authorization necessary to access such storage mechanism(s).
+        </li>
+        <li>
+          We exclude any and all liability for any security breaches or other acts or omissions, which result in your
+          loss of access or custody of any cryptographic assets stored thereon.
+        </li>
+      </ol>
+      <h3>8. Can we terminate or limit your right to use our Services?</h3>
+      <ol start={1}>
+        <li>
+          We may terminate the Agreement and refuse access to the Safe&nbsp;Apps at any time giving 30 days&rsquo; prior
+          notice. The right of the parties to terminate the Agreement for cause remains unaffected. In case of our
+          termination of the Agreement, you may no longer access your Safe via our Services. However, you may continue
+          to access your Safe and any Tokens via a third-party wallet provider using your Recovery Phrase and Private
+          Keys.
+        </li>
+        <li>
+          We reserve the right to limit the use of the Safe&nbsp;Apps to a specified number of Users if necessary to
+          protect or ensure the stability and integrity of the Services. We will only be able to limit access to the
+          Services. At no time will we be able to limit or block access to or transfer your funds without your consent.
+        </li>
+      </ol>
+      <h3>9. Can you terminate your Agreement with us?</h3>
+      <p>You may terminate the Agreement at any time without notice.</p>
+      <h3>10. What licenses and access do we grant to you?</h3>
+      <ol start={1}>
+        <li>
+          All intellectual property rights in the Safe and the Services throughout the world belong to us as owner or
+          our licensors. Nothing in these Terms gives you any rights in respect of any intellectual property owned by us
+          or our licensors and you acknowledge that you do not acquire any ownership rights by downloading the Safe App
+          or any content from the Safe App.
+        </li>
+        <li>
+          If you are a consumer we grant you a simple, limited license, but do not sell, to you the Services you
+          download solely for your own personal, non-commercial use.{' '}
+        </li>
+      </ol>
+      <h3>11. What can you expect from the Services and can we make changes to them?</h3>
+      <ol start={1}>
+        <li>
+          Without limiting your mandatory warranties, we provide the Services to you &ldquo;as is&rdquo; and &ldquo;as
+          available&rdquo; in relation to merchantability, fitness for a particular purpose, availability, security,
+          title or non-infringement.{' '}
+        </li>
+        <li>
+          If you use the Safe App via web browser, the strict liability of CC for damages (sec. 536a German Civil Code)
+          for defects existing at the time of conclusion of the contract is precluded.{' '}
+        </li>
+        <li>The foregoing provisions will not limit CC&rsquo;s liability as defined in Clause 13. </li>
+        <li>
+          We reserve the right to change the format and features of the Services by making any updates to Services
+          available for you to download or, where your device settings permit it, by automatic delivery of updates.
+        </li>
+        <li>
+          You are not obliged to download the updated Services, but we may cease to provide and/or update prior versions
+          of the Services and, depending on the nature of the update, in some circumstances you may not be able to
+          continue using the Services until you have downloaded the updated version.
+        </li>
+        <li>
+          We may cease to provide and/or update content to the Services, with or without notice to you, if it improves
+          the Services we provide to you, or we need to do so for security, legal or any other reasons.
+        </li>
+      </ol>
+      <h3>12. What do you agree, warrant and represent?</h3>
+      <p>By using our Services you hereby agree, represent and warrant that:</p>
+      <ol start={1}>
+        <li>
+          You are not a citizen, resident, or member of any jurisdiction or group that is subject to economic sanctions
+          by the European Union or the United States or any other relevant jurisdiction.
+        </li>
+        <li>
+          You do not appear on HMT Sanctions List, the U.S. Treasury Department&rsquo;s Office of Foreign Asset
+          Control&rsquo;s sanctions lists, the U.S. commerce department&apos;s consolidated screening list, the EU
+          consolidated list of persons, groups or entities subject to EU Financial Sanctions, nor do you act on behalf
+          of a person sanctioned thereunder.
+        </li>
+        <li>You have read and understood these Terms and agree to be bound by its terms.</li>
+        <li>
+          Your usage of our Services is legal under the laws of your jurisdiction or under the laws of any other
+          jurisdiction to which you may be subject.
+        </li>
+        <li>
+          You won&rsquo;t use the Services or interact with the Services in a manner that violates any law or
+          regulation, including, without limitation, any applicable export control laws.
+        </li>
+        <li>
+          You understand the functionality, usage, storage, transmission mechanisms and intricacies associated with
+          Tokens as well as wallet (including Safe) and Blockchains.
+        </li>
+        <li>
+          You understand that Transactions on the Blockchain are irreversible and may not be erased and that your Safe
+          address and Transactions are displayed permanently and publicly.
+        </li>
+        <li>
+          You will comply with any applicable tax obligations in your jurisdiction arising from your use of the
+          Services.
+        </li>
+        <li>
+          You will not misuse or gain unauthorized access to our Services by knowingly introducing viruses, cross-site
+          scripting, Trojan horses, worms, time-bombs, keystroke loggers, spyware, adware or any other harmful programs
+          or similar computer code designed to adversely affect our Services and that in the event you do so or
+          otherwise attack our Services, we reserve the right to report any such activity to the relevant law
+          enforcement authorities and we will cooperate with those authorities as required.
+        </li>
+        <li>
+          You won&rsquo;t access without authority, interfere with, damage or disrupt any part of our Services, any
+          equipment or network on which our Services is stored, any software used in the provision of our Services or
+          any equipment or network or software owned or used by any third party.
+        </li>
+        <li>
+          You won&rsquo;t use our Services for activities that are unlawful or fraudulent or have such purpose or effect
+          or otherwise support any activities that breach applicable local, national or international law or
+          regulations.
+        </li>
+        <li>
+          You won&rsquo;t use our Services to store, trade or transmit Tokens that are proceeds of criminal or
+          fraudulent activity.
+        </li>
+        <li>
+          You understand that the Services and the underlying Blockchain are in an early development stage and we
+          accordingly do not guarantee an error-free process and give no price or liquidity guarantee.
+        </li>
+        <li>You are using the Services at your own risk.</li>
+      </ol>
+      <h3>13. What about our liability to you?</h3>
+      <p>We are liable to you only as follows:</p>
+      <ol start={1}>
+        <li>We are liable for damages, in any case of negligence, resulting from injury to life, body or health.</li>
+        <li>
+          We are liable for damages &ndash; regardless of the legal grounds &ndash; in the event of intent and gross
+          negligence on our part, our legal representatives, our executive employees or other vicarious agents.
+        </li>
+        <li>
+          If we do not provide the Safe App or Services to you free of charge, we are liable in case of simple
+          negligence for damages resulting from the breach of an essential contractual duty (e.g. a duty, the
+          performance of which enables the proper execution of the contract in the first place and on the compliance of
+          which the contractual partner regularly relies and may rely), whereby in the latter case of breach of an
+          essential contractual duty, our liability shall be limited to compensation of the foreseeable, typically
+          occurring damage.
+        </li>
+        <li>
+          The limitations of liability according to Clause 13.2 do not apply as far as we have assumed a guarantee or we
+          have fraudulently concealed a defect in the Services. These limitations of liability also do not apply to your
+          claims according to the Product Liability Act (&rdquo;Produkthaftungsgesetz&rdquo;) and any applicable data
+          privacy laws.
+        </li>
+        <li>
+          If you suffer damages from the loss of data, we are not liable for this, as far as the damages would have been
+          avoided by your regular and complete backup of all relevant data.
+        </li>
+        <li>
+          We take all possible measures to enable you to access our Services. In the event of disruptions to the
+          technical infrastructure, the internet connection or a relevant blockchain, we shall be exempt from our
+          obligation to perform. This also applies if we are prevented from performing due to force majeure or other
+          circumstances, the elimination of which is not possible or cannot be economically expected of CC.
+        </li>
+      </ol>
+      <h3>14. What about viruses, bugs and security vulnerabilities?</h3>
+      <ol start={1}>
+        <li>We endeavor to provide our Service free from material bugs, security vulnerabilities or viruses.</li>
+        <li>
+          You are responsible for configuring your information technology and computer programmes to access our Services
+          and to use your own virus protection software.
+        </li>
+        <li>If you become aware of any exploits, bugs or vulnerabilities, please inform bounty@safe.global.</li>
+        <li>
+          You must not misuse our Services by knowingly introducing material that is malicious or technologically
+          harmful. If you do, your right to use our Services will cease immediately.
+        </li>
+      </ol>
+      <h3>15. What if an event outside our control happens that affects our Services?</h3>
+      <ol start={1}>
+        <li>
+          We may update and change our Services from time to time. We may suspend or withdraw or restrict the
+          availability of all or any part of our Services for business, operational or regulatory reasons or because of
+          a Force Majeure Event at no notice.
+        </li>
+        <li>
+          A &ldquo;Force Majeure Event&rdquo; shall mean any event, circumstance or cause beyond our reasonable control,
+          which prevents, hinders or delays the provision of our Services or makes their provision impossible or
+          onerous, including, without limitation:
+        </li>
+      </ol>
+      <ul>
+        <li>acts of God, flood, storm, drought, earthquake or other natural disaster;</li>
+        <li>epidemic or pandemic (for the avoidance of doubt, including the 2020 Coronavirus Pandemic);</li>
+        <li>
+          terrorist attack, hacking or cyber threats, civil war, civil commotion or riots, war, threat of or preparation
+          for war, armed conflict, imposition of sanctions, embargo, or breaking off of diplomatic relations;
+        </li>
+        <li>
+          equipment or software malfunction or bugs including network splits or forks or unexpected changes in the
+          Blockchain, as well as hacks, phishing attacks, distributed denials of service or any other security attacks;
+        </li>
+        <li>nuclear, chemical or biological contamination;</li>
+        <li>
+          any law statutes, ordinances, rules, regulations, judgments, injunctions, orders and decrees or any action
+          taken by a government or public authority, including without limitation imposing a prohibition, or failing to
+          grant a necessary license or consent;
+        </li>
+        <li>collapse of buildings, breakdown of plant or machinery, fire, explosion or accident; and</li>
+        <li>strike, industrial action or lockout.</li>
+      </ul>
+      <ol start={3}>
+        <li>
+          We shall not be liable or responsible to you, or be deemed to have defaulted under or breached this Agreement,
+          for any failure or delay in the provision of the Services or the performance of this Agreement, if and to the
+          extent such failure or delay is caused by or results from or is connected to acts beyond our reasonable
+          control, including the occurrence of a Force Majeure Event.
+        </li>
+      </ol>
+      <h3>16. Who is responsible for your tax liabilities?</h3>
+      <p>
+        You are solely responsible to determine if your use of the Services have tax implications, in particular income
+        tax and capital gains tax relating to the purchase or sale of Tokens, for you. By using the Services you agree
+        not to hold us liable for any tax liability associated with or arising from the operation of the Services or any
+        other action or transaction related thereto.
+      </p>
+      <h3>17. What if a court disagrees with part of this Agreement?</h3>
+      <p>
+        Should individual provisions of these Terms be or become invalid or unenforceable in whole or in part, this
+        shall not affect the validity of the remaining provisions. The invalid or unenforceable provision shall be
+        replaced by the statutory provision. If there is no statutory provision or if the statutory provision would lead
+        to an unacceptable result, the parties shall enter negotiations to replace the invalid or unenforceable
+        provision with a valid provision that comes as close as possible to the economic purpose of the invalid or
+        unenforceable provision.
+      </p>
+      <h3>18. What if we do not enforce certain rights under this Agreement?</h3>
+      <p>
+        Our failure to exercise or enforce any right or remedy provided under this Agreement or by law shall not
+        constitute a waiver of that or any other right or remedy, nor shall it prevent or restrict any further exercise
+        of that or any other right or remedy.
+      </p>
+      <h3>19. Do third parties have rights?</h3>
+      <p>
+        Unless it expressly states otherwise, this Agreement does not give rise to any third-party rights, which may be
+        enforced against us.
+      </p>
+      <h3>20. Can this Agreement be assigned?</h3>
+      <ol start={1}>
+        <li>
+          We are entitled to transfer our rights and obligations under the Agreement in whole or in part to third
+          parties with a notice period of four weeks. In this case, you have the right to terminate the Agreement
+          without notice.
+        </li>
+        <li>
+          You shall not be entitled to assign this Agreement to any third party without our express prior written
+          consent.
+        </li>
+      </ol>
+      <h3>21. Which Clauses of this Agreement survive termination?</h3>
+      <p>
+        All covenants, agreements, representations and warranties made in this Agreement shall survive your acceptance
+        of this Agreement and its termination.
+      </p>
+      <h3>22. Data Protection</h3>
+      <p>
+        We inform you about our processing of personal data, including the disclosure to third parties and your rights
+        as an affected party, in the{' '}
+        <Link href={AppRoutes.privacy} passHref>
+          <MUILink>Privacy Policy</MUILink>
+        </Link>
+        .
+      </p>
+      <h3>23. Which laws apply to the Agreement?</h3>
+      <p>
+        The Agreement including these Terms shall be governed by German law. The application of the UN Convention on
+        Contracts for the International Sale of Goods is excluded. For consumers domiciled in another European country
+        but Germany, the mandatory provisions of the consumer protection laws of the member state in which the consumer
+        is domiciled shall also apply, provided that these are more advantageous for the consumer than the provisions of
+        the German law.
+      </p>
+      <h3>24. How can you get support for the Safe and tell us about any problems?</h3>
+      <p>
+        If you want to learn more about the Safe or the Service or have any problems using them or have any complaints
+        please get in touch via any of the following channels:
+      </p>
+      <ol start={1}>
+        <li>
+          Intercom:{' '}
+          <Link href="https://help.safe.global" passHref>
+            <MUILink target="_blank" rel="noreferrer">
+              https://help.safe.global
+            </MUILink>
+          </Link>
+        </li>
+        <li>
+          Discord:{' '}
+          <Link href="https://chat.safe.global/" passHref>
+            <MUILink target="_blank" rel="noreferrer">
+              https://chat.safe.global
+            </MUILink>
+          </Link>
+        </li>
+        <li>
+          Twitter:{' '}
+          <Link href="https://twitter.com/safe" passHref>
+            <MUILink target="_blank" rel="noreferrer">
+              https://twitter.com/safe
+            </MUILink>
+          </Link>
+        </li>
+      </ol>
+      <h3>25. Where is the place of legal proceedings?</h3>
+      <p>
+        For users who are merchants within the meaning of the German Commercial Code (Handelsgesetzbuch), a special fund
+        (Sonderverm&ouml;gen) under public law or a legal person under public law, Berlin shall be the exclusive place
+        of jurisdiction for all disputes arising from the contractual relationship.
+      </p>
+      <h3>26. Is this all?</h3>
+      <p>
+        These Terms constitute the entire agreement between you and us in relation to the Agreement&rsquo;s subject
+        matter. It replaces and extinguishes any and all prior agreements, draft agreements, arrangements, warranties,
+        statements, assurances, representations and undertakings of any nature made by, or on behalf of either of us,
+        whether oral or written, public or private, in relation to that subject matter.
+      </p>
     </div>
   )
 }

--- a/src/components/terms/index.tsx
+++ b/src/components/terms/index.tsx
@@ -1,0 +1,13 @@
+import { Typography } from '@mui/material'
+
+const SafeTerms = () => {
+  return (
+    <div>
+      <Typography variant="h1" mb={2}>
+        Terms
+      </Typography>
+    </div>
+  )
+}
+
+export default SafeTerms

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -1,6 +1,7 @@
 export const AppRoutes = {
   '404': '/404',
   welcome: '/welcome',
+  privacy: '/privacy',
   index: '/',
   imprint: '/imprint',
   import: '/import',

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -1,6 +1,7 @@
 export const AppRoutes = {
   '404': '/404',
   welcome: '/welcome',
+  terms: '/terms',
   privacy: '/privacy',
   index: '/',
   imprint: '/imprint',

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -7,6 +7,7 @@ export const AppRoutes = {
   import: '/import',
   home: '/home',
   environmentVariables: '/environment-variables',
+  cookie: '/cookie',
   addressBook: '/address-book',
   _offline: '/_offline',
   apps: {

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -2,6 +2,7 @@ export const AppRoutes = {
   '404': '/404',
   welcome: '/welcome',
   index: '/',
+  imprint: '/imprint',
   import: '/import',
   home: '/home',
   environmentVariables: '/environment-variables',

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -33,6 +33,7 @@ import ErrorBoundary from '@/components/common/ErrorBoundary'
 import createEmotionCache from '@/utils/createEmotionCache'
 import MetaTags from '@/components/common/MetaTags'
 import useAdjustUrl from '@/hooks/useAdjustUrl'
+import TermsBanner from '@/components/common/TermsBanner'
 
 const GATEWAY_URL = IS_PRODUCTION || cgwDebugStorage.get() ? GATEWAY_URL_PRODUCTION : GATEWAY_URL_STAGING
 
@@ -103,6 +104,7 @@ const WebCoreApp = ({
           </PageLayout>
 
           <CookieBanner />
+          <TermsBanner />
 
           <Notifications />
         </AppProviders>

--- a/src/pages/cookie.tsx
+++ b/src/pages/cookie.tsx
@@ -1,0 +1,19 @@
+import type { NextPage } from 'next'
+import Head from 'next/head'
+import SafeCookiePolicy from '@/components/cookie-policy'
+
+const CookiePolicy: NextPage = () => {
+  return (
+    <>
+      <Head>
+        <title>Safe – Cookie policy</title>
+      </Head>
+
+      <main>
+        <SafeCookiePolicy />
+      </main>
+    </>
+  )
+}
+
+export default CookiePolicy

--- a/src/pages/imprint.tsx
+++ b/src/pages/imprint.tsx
@@ -1,0 +1,19 @@
+import type { NextPage } from 'next'
+import Head from 'next/head'
+import SafeImprint from '@/components/imprint'
+
+const Imprint: NextPage = () => {
+  return (
+    <>
+      <Head>
+        <title>Safe – Imprint</title>
+      </Head>
+
+      <main>
+        <SafeImprint />
+      </main>
+    </>
+  )
+}
+
+export default Imprint

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -1,0 +1,19 @@
+import type { NextPage } from 'next'
+import Head from 'next/head'
+import SafePrivacyPolicy from '@/components/privacy'
+
+const Privacy: NextPage = () => {
+  return (
+    <>
+      <Head>
+        <title>Safe – Imprint</title>
+      </Head>
+
+      <main>
+        <SafePrivacyPolicy />
+      </main>
+    </>
+  )
+}
+
+export default Privacy

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -2,11 +2,11 @@ import type { NextPage } from 'next'
 import Head from 'next/head'
 import SafePrivacyPolicy from '@/components/privacy'
 
-const Privacy: NextPage = () => {
+const PrivacyPolicy: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe – Imprint</title>
+        <title>Safe – Privacy policy</title>
       </Head>
 
       <main>
@@ -16,4 +16,4 @@ const Privacy: NextPage = () => {
   )
 }
 
-export default Privacy
+export default PrivacyPolicy

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -1,0 +1,19 @@
+import type { NextPage } from 'next'
+import Head from 'next/head'
+import SafeTerms from '@/components/terms'
+
+const Imprint: NextPage = () => {
+  return (
+    <>
+      <Head>
+        <title>Safe – Terms</title>
+      </Head>
+
+      <main>
+        <SafeTerms />
+      </main>
+    </>
+  )
+}
+
+export default Imprint


### PR DESCRIPTION
## What it solves

Resolves #1722 

## How this PR fixes it

- Adds a new page for Privacy policy, Cookie policy, Terms and Imprint
- Links those pages in the footer
- Displays the footer on those pages
- Hides the sidebar on those pages

## How to test it

1. Open the Safe
2. Go to Settings to see the Footer
3. Click on any of the three links to see the page
4. Compare to https://www.notion.so/gnosis-safe/Terms-policy-update-f3827a6f724340deae9554d24afe8c29
6. Create or Load a new safe and click on terms of use or privacy policy and observe seeing the new pages

## Screenshots

<img width="502" alt="Screenshot 2023-03-03 at 11 06 23" src="https://user-images.githubusercontent.com/5880855/222692334-b3f264a3-f512-41d5-bda5-85b2bb7de2cd.png">

