### PR TITLE
fix: filter governance app tag

### DIFF
--- a/src/components/safe-apps/utils.ts
+++ b/src/components/safe-apps/utils.ts
@@ -7,6 +7,7 @@ import type { BaseTransaction, ChainInfo } from '@gnosis.pm/safe-apps-sdk'
 import { formatVisualAmount } from '@/utils/formatters'
 import { validateAddress } from '@/utils/validation'
 import type { SafeAppDataWithPermissions } from './types'
+import { SafeAppsTag } from '@/config/constants'
 
 const validateTransaction = (t: BaseTransaction): boolean => {
   if (!['string', 'number'].includes(typeof t.value)) {
@@ -94,13 +95,8 @@ export const isOptimizedForBatchTransactions = (safeApp: SafeAppData) =>
 
 // some categories are used internally and we dont want to display them in the UI
 export const filterInternalCategories = (categories: string[]): string[] => {
+  // TODO: Remove safe-claiming-app when we remove the old claiming app
+  const internalCategories = ['safe-claiming-app', ...Object.values(SafeAppsTag)]
+
   return categories.filter((tag) => !internalCategories.some((internalCategory) => tag === internalCategory))
 }
-
-export const internalCategories = [
-  'dashboard-widgets',
-  'nft',
-  'safe-claiming-app',
-  'transaction-builder',
-  'wallet-connect',
-]

--- a/src/components/safe-apps/utils.ts
+++ b/src/components/safe-apps/utils.ts
@@ -95,8 +95,6 @@ export const isOptimizedForBatchTransactions = (safeApp: SafeAppData) =>
 
 // some categories are used internally and we dont want to display them in the UI
 export const filterInternalCategories = (categories: string[]): string[] => {
-  // TODO: Remove safe-claiming-app when we remove the old claiming app
-  const internalCategories = ['safe-claiming-app', ...Object.values(SafeAppsTag)]
-
+  const internalCategories = Object.values(SafeAppsTag)
   return categories.filter((tag) => !internalCategories.some((internalCategory) => tag === internalCategory))
 }

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -57,4 +57,6 @@ export enum SafeAppsTag {
   DASHBOARD_FEATURED = 'dashboard-widgets',
   SAFE_GOVERNANCE_APP = 'safe-governance-app',
   WALLET_CONNECT = 'wallet-connect',
+  // TODO: Remove safe-claiming-app when we remove the old claiming app
+  SAFE_CLAIMING_APP = 'safe-claiming-app',
 }


### PR DESCRIPTION
## What it solves

Hiding "safe-governance-app" tags from Safe App card.

## How this PR fixes it

The "safe-governance-app" tag is now filtered.

## How to test it

Open the Safe Apps list and observe no tag on the Governance App card.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/20442784/222383142-a72bff54-a662-49c0-8b55-0b4c6121d06b.png)

### After

![image](https://user-images.githubusercontent.com/20442784/222383433-8d6de7d6-bb0d-4aaa-becb-a59676fb0fa8.png)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻