### PR TITLE
[Experiment] sign on any chain

### DIFF
--- a/src/components/common/CheckWallet/index.test.tsx
+++ b/src/components/common/CheckWallet/index.test.tsx
@@ -65,16 +65,12 @@ describe('CheckWallet', () => {
     expect(container.querySelector('span[aria-label]')).toHaveAttribute('aria-label', 'Please connect your wallet')
   })
 
-  it('should disable the button when the wallet is connected to the wrong chain', () => {
+  it('should not disable the button when the wallet is connected to the wrong chain', () => {
     ;(useIsWrongChain as jest.MockedFunction<typeof useIsWrongChain>).mockReturnValueOnce(true)
 
     const { container } = renderButton()
 
-    expect(container.querySelector('button')).toBeDisabled()
-    expect(container.querySelector('span[aria-label]')).toHaveAttribute(
-      'aria-label',
-      'Please connect your wallet to Optimism',
-    )
+    expect(container.querySelector('button')).not.toBeDisabled()
   })
 
   it('should disable the button when the wallet is connected to the right chain but is not an owner', () => {

--- a/src/components/common/CheckWallet/index.tsx
+++ b/src/components/common/CheckWallet/index.tsx
@@ -30,8 +30,6 @@ const CheckWallet = ({ children, allowSpendingLimit, allowNonOwner }: CheckWalle
 
   const message = !wallet
     ? Message.WalletNotConnected
-    : isWrongChain
-    ? Message.WrongNetwork + (currentChain?.chainName || '')
     : !isSafeOwner && !isSpendingLimit && !allowNonOwner
     ? Message.NotSafeOwner
     : isSpendingLimit && !allowSpendingLimit

--- a/src/components/common/CheckWallet/index.tsx
+++ b/src/components/common/CheckWallet/index.tsx
@@ -4,8 +4,6 @@ import useIsOnlySpendingLimitBeneficiary from '@/hooks/useIsOnlySpendingLimitBen
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import useWallet from '@/hooks/wallets/useWallet'
 import useConnectWallet from '../ConnectWallet/useConnectWallet'
-import useIsWrongChain from '@/hooks/useIsWrongChain'
-import { useCurrentChain } from '@/hooks/useChains'
 
 type CheckWalletProps = {
   children: (ok: boolean) => ReactElement
@@ -22,11 +20,9 @@ enum Message {
 
 const CheckWallet = ({ children, allowSpendingLimit, allowNonOwner }: CheckWalletProps): ReactElement => {
   const wallet = useWallet()
-  const isWrongChain = useIsWrongChain()
   const isSafeOwner = useIsSafeOwner()
   const isSpendingLimit = useIsOnlySpendingLimitBeneficiary()
   const connectWallet = useConnectWallet()
-  const currentChain = useCurrentChain()
 
   const message = !wallet
     ? Message.WalletNotConnected

--- a/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.test.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.test.tsx
@@ -165,6 +165,10 @@ describe('SignOrExecuteForm', () => {
       const mockTx = createSafeTx()
       const result = render(<SignOrExecuteForm isExecutable={true} onSubmit={jest.fn} safeTx={mockTx} />)
 
+      act(() => {
+        fireEvent.click(result.getByText('Execute transaction'))
+      })
+
       expect(
         result.getByText('This transaction will most likely fail. To save gas costs, reject this transaction.'),
       ).toBeInTheDocument()
@@ -187,6 +191,10 @@ describe('SignOrExecuteForm', () => {
 
       const mockTx = createSafeTx()
       const result = render(<SignOrExecuteForm isExecutable={true} onSubmit={jest.fn} safeTx={mockTx} />)
+
+      act(() => {
+        fireEvent.click(result.getByText('Execute transaction'))
+      })
 
       expect(
         result.getByText('This transaction will most likely fail. To save gas costs, reject this transaction.'),
@@ -319,7 +327,7 @@ describe('SignOrExecuteForm', () => {
     jest.spyOn(wrongChain, 'default').mockReturnValue(true)
 
     const mockTx = createSafeTx()
-    const result = render(<SignOrExecuteForm isExecutable={true} onSubmit={jest.fn} safeTx={mockTx} />)
+    const result = render(<SignOrExecuteForm isExecutable={true} onlyExecute onSubmit={jest.fn} safeTx={mockTx} />)
 
     expect(result.getByText('Please connect your wallet to')).toBeInTheDocument()
     expect(result.getByText('Submit')).toBeDisabled()
@@ -382,8 +390,10 @@ describe('SignOrExecuteForm', () => {
     const result = render(<SignOrExecuteForm isExecutable={true} onSubmit={jest.fn} safeTx={mockTx} />)
 
     const submitButton = result.getByText('Submit')
+    const executeCheckbox = result.getByText('Execute transaction')
 
     act(() => {
+      fireEvent.click(executeCheckbox)
       fireEvent.click(submitButton)
     })
 

--- a/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.test.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.test.tsx
@@ -315,7 +315,7 @@ describe('SignOrExecuteForm', () => {
     expect(result.getByText('Submit')).not.toBeDisabled()
   })
 
-  it('displays an error and disables the submit button if connected wallet is on a different chain', async () => {
+  it('displays an error and disables the submit button if connected wallet is on a different chain', () => {
     jest.spyOn(wrongChain, 'default').mockReturnValue(true)
 
     const mockTx = createSafeTx()

--- a/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.test.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.test.tsx
@@ -114,13 +114,13 @@ describe('SignOrExecuteForm', () => {
     expect(result.getByText('Execute transaction')).toBeInTheDocument()
   })
 
-  it('the execute checkbox is disabled if execution is the only option', () => {
+  it('the execute checkbox is not shown if execution is the only option', () => {
     const mockTx = createSafeTx()
     const result = render(
       <SignOrExecuteForm isExecutable={true} onSubmit={jest.fn} safeTx={mockTx} onlyExecute={true} />,
     )
 
-    expect((result.getByRole('checkbox') as HTMLInputElement).disabled).toBe(true)
+    expect(result.queryByText('Execute transaction')).not.toBeInTheDocument()
   })
 
   it("doesn't display an execute checkbox if nonce is incorrect", () => {

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -24,6 +24,7 @@ import { sameString } from '@safe-global/safe-core-sdk/dist/src/utils'
 import useIsValidExecution from '@/hooks/useIsValidExecution'
 import { useHasPendingTxs } from '@/hooks/usePendingTxs'
 import CheckWallet from '@/components/common/CheckWallet'
+import ChainSwitcher from '@/components/common/ChainSwitcher'
 
 type SignOrExecuteProps = {
   safeTx?: SafeTransaction
@@ -243,8 +244,14 @@ const SignOrExecuteForm = ({
         />
 
         {/* Error messages */}
-        {(willExecute && isWrongChain) ? (
-          <ErrorMessage>Please connect your wallet to {currentChain?.chainName}</ErrorMessage>
+        {willExecute && isWrongChain ? (
+          <>
+            <ErrorMessage>Please connect your wallet to {currentChain?.chainName}</ErrorMessage>
+
+            <center>
+              <ChainSwitcher />
+            </center>
+          </>
         ) : cannotPropose ? (
           <ErrorMessage>
             You are currently not an owner of this Safe and won&apos;t be able to submit this transaction.

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -224,7 +224,7 @@ const SignOrExecuteForm = ({
 
         <DecodedTx tx={tx} txId={txId} />
 
-        {canExecute && <ExecuteCheckbox checked={shouldExecute} onChange={setShouldExecute} disabled={onlyExecute} />}
+        {canExecute && !onlyExecute && <ExecuteCheckbox checked={shouldExecute} onChange={setShouldExecute} />}
 
         <AdvancedParams
           params={advancedParams}

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -61,7 +61,7 @@ const SignOrExecuteForm = ({
   const { createTx, dispatchTxProposal, dispatchOnChainSigning, dispatchTxSigning, dispatchTxExecution } = useTxSender()
 
   // Internal state
-  const [shouldExecute, setShouldExecute] = useState<boolean>(true)
+  const [shouldExecute, setShouldExecute] = useState<boolean>(onlyExecute)
   const [isSubmittable, setIsSubmittable] = useState<boolean>(true)
   const [tx, setTx] = useState<SafeTransaction | undefined>(safeTx)
   const [submitError, setSubmitError] = useState<Error | undefined>()
@@ -209,6 +209,7 @@ const SignOrExecuteForm = ({
     isEstimating ||
     !tx ||
     disableSubmit ||
+    (willExecute && isWrongChain) ||
     cannotPropose ||
     isExecutionLoop ||
     isValidExecutionLoading
@@ -242,7 +243,7 @@ const SignOrExecuteForm = ({
         />
 
         {/* Error messages */}
-        {isWrongChain ? (
+        {(willExecute && isWrongChain) ? (
           <ErrorMessage>Please connect your wallet to {currentChain?.chainName}</ErrorMessage>
         ) : cannotPropose ? (
           <ErrorMessage>

--- a/src/hooks/coreSDK/__tests__/useInitSafeCoreSDK.test.ts
+++ b/src/hooks/coreSDK/__tests__/useInitSafeCoreSDK.test.ts
@@ -9,6 +9,15 @@ import type { EIP1193Provider, OnboardAPI } from '@web3-onboard/core'
 import { act } from '@testing-library/react'
 import type Safe from '@safe-global/safe-core-sdk'
 
+// mock useCurrentChain
+jest.mock('@/hooks/useChains', () => ({
+  __esModule: true,
+  useCurrentChain: jest.fn(() => ({
+    chainName: 'Goerli',
+    chainId: '5',
+  })),
+}))
+
 describe('useInitSafeCoreSDK hook', () => {
   const mockSafeInfo = {
     safe: {
@@ -56,7 +65,7 @@ describe('useInitSafeCoreSDK hook', () => {
 
     renderHook(() => useInitSafeCoreSDK())
 
-    expect(initMock).toHaveBeenCalledWith({}, '5', '0x1', '1.3.0')
+    expect(initMock).toHaveBeenCalledWith({}, '5', '0x1', '1.3.0', { chainId: '5', chainName: 'Goerli' }, '5')
 
     await act(() => Promise.resolve())
 
@@ -68,46 +77,6 @@ describe('useInitSafeCoreSDK hook', () => {
     const setSDKMock = jest.spyOn(coreSDK, 'setSafeSDK')
 
     jest.spyOn(useWallet, 'default').mockReturnValue({ ...mockWallet, provider: {} as EIP1193Provider })
-
-    renderHook(() => useInitSafeCoreSDK())
-
-    expect(initMock).not.toHaveBeenCalled()
-    expect(setSDKMock).toHaveBeenCalledWith(undefined)
-  })
-
-  it('does not initialize a Core SDK instance if there is no safe chainId', () => {
-    const initMock = jest.spyOn(coreSDK, 'initSafeSDK')
-    const setSDKMock = jest.spyOn(coreSDK, 'setSafeSDK')
-
-    jest.spyOn(useWallet, 'default').mockReturnValue({ ...mockWallet, provider: {} as EIP1193Provider, chainId: '5' })
-    jest.spyOn(useSafeInfo, 'default').mockReturnValueOnce({
-      ...mockSafeInfo,
-      safe: {
-        ...mockSafeInfo.safe,
-        chainId: '',
-      } as SafeInfo,
-      safeLoaded: true,
-    })
-
-    renderHook(() => useInitSafeCoreSDK())
-
-    expect(initMock).not.toHaveBeenCalled()
-    expect(setSDKMock).toHaveBeenCalledWith(undefined)
-  })
-
-  it('does not initialize a Core SDK instance if the safe chainId and wallet chainId are different', () => {
-    const initMock = jest.spyOn(coreSDK, 'initSafeSDK')
-    const setSDKMock = jest.spyOn(coreSDK, 'setSafeSDK')
-
-    jest.spyOn(useWallet, 'default').mockReturnValue({ ...mockWallet, provider: {} as EIP1193Provider, chainId: '1' })
-    jest.spyOn(useSafeInfo, 'default').mockReturnValueOnce({
-      ...mockSafeInfo,
-      safe: {
-        ...mockSafeInfo.safe,
-        chainId: '5',
-      } as SafeInfo,
-      safeLoaded: true,
-    })
 
     renderHook(() => useInitSafeCoreSDK())
 

--- a/src/hooks/coreSDK/__tests__/useInitSafeCoreSDK.test.ts
+++ b/src/hooks/coreSDK/__tests__/useInitSafeCoreSDK.test.ts
@@ -4,8 +4,10 @@ import * as useSafeInfo from '@/hooks/useSafeInfo'
 import * as coreSDK from '@/hooks/coreSDK/safeCoreSDK'
 import * as useWallet from '@/hooks/wallets/useWallet'
 import * as useOnboard from '@/hooks/wallets/useOnboard'
+import * as web3 from '../../wallets/web3'
 import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import type { EIP1193Provider, OnboardAPI } from '@web3-onboard/core'
+import type { JsonRpcProvider } from '@ethersproject/providers'
 import { act } from '@testing-library/react'
 import type Safe from '@safe-global/safe-core-sdk'
 
@@ -15,6 +17,7 @@ jest.mock('@/hooks/useChains', () => ({
   useCurrentChain: jest.fn(() => ({
     chainName: 'Goerli',
     chainId: '5',
+    rpcUri: { value: 'https://goerli.infura.io/v3/123', authentification: 'none' },
   })),
 }))
 
@@ -57,6 +60,7 @@ describe('useInitSafeCoreSDK hook', () => {
     const initMock = jest.spyOn(coreSDK, 'initSafeSDK').mockReturnValue(Promise.resolve(mockSafe))
     const setSDKMock = jest.spyOn(coreSDK, 'setSafeSDK')
 
+    jest.spyOn(web3, 'createWeb3ReadOnly').mockReturnValue({} as unknown as JsonRpcProvider)
     jest.spyOn(useWallet, 'default').mockReturnValue({ ...mockWallet, provider: {} as EIP1193Provider })
     jest.spyOn(useSafeInfo, 'default').mockReturnValueOnce({
       ...mockSafeInfo,
@@ -65,7 +69,7 @@ describe('useInitSafeCoreSDK hook', () => {
 
     renderHook(() => useInitSafeCoreSDK())
 
-    expect(initMock).toHaveBeenCalledWith({}, '5', '0x1', '1.3.0', { chainId: '5', chainName: 'Goerli' }, '5')
+    expect(initMock).toHaveBeenCalledWith({}, {}, '5', '5', '0x1', '1.3.0')
 
     await act(() => Promise.resolve())
 

--- a/src/hooks/coreSDK/useInitSafeCoreSDK.ts
+++ b/src/hooks/coreSDK/useInitSafeCoreSDK.ts
@@ -4,17 +4,20 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import { initSafeSDK, setSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import { trackError } from '@/services/exceptions'
 import ErrorCodes from '@/services/exceptions/ErrorCodes'
-import { useAppDispatch } from '@/store'
+import { useAppDispatch, useAppSelector } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
 import useOnboard from '@/hooks/wallets/useOnboard'
 import { useCurrentChain } from '../useChains'
+import { selectRpc } from '@/store/settingsSlice'
+import { createWeb3ReadOnly } from '../wallets/web3'
 
 export const useInitSafeCoreSDK = () => {
   const wallet = useWallet()
   const onboard = useOnboard()
-  const { safe, safeLoaded } = useSafeInfo()
+  const { safe, safeAddress, safeLoaded } = useSafeInfo()
   const dispatch = useAppDispatch()
   const chainInfo = useCurrentChain()
+  const customRpc = useAppSelector(selectRpc)
 
   useEffect(() => {
     if (!onboard || !wallet?.provider || !safeLoaded || !safe.version || !chainInfo) {
@@ -23,7 +26,9 @@ export const useInitSafeCoreSDK = () => {
       return
     }
 
-    initSafeSDK(wallet.provider, safe.chainId, safe.address.value, safe.version, chainInfo, wallet.chainId)
+    const readonlyProvider = createWeb3ReadOnly(chainInfo.rpcUri, customRpc?.[safe.chainId])
+
+    initSafeSDK(readonlyProvider, wallet.provider, wallet.chainId, safe.chainId, safeAddress, safe.version)
       .then(setSafeSDK)
       .catch((e) => {
         dispatch(
@@ -39,5 +44,5 @@ export const useInitSafeCoreSDK = () => {
         // Disconnect the wallet
         onboard.disconnectWallet({ label: wallet.label })
       })
-  }, [onboard, wallet, safe.chainId, safe.address.value, safe.version, safeLoaded, dispatch, chainInfo])
+  }, [onboard, wallet, safe.chainId, safeAddress, safe.version, safeLoaded, dispatch, chainInfo, customRpc])
 }

--- a/src/hooks/coreSDK/useInitSafeCoreSDK.ts
+++ b/src/hooks/coreSDK/useInitSafeCoreSDK.ts
@@ -7,21 +7,23 @@ import ErrorCodes from '@/services/exceptions/ErrorCodes'
 import { useAppDispatch } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
 import useOnboard from '@/hooks/wallets/useOnboard'
+import { useCurrentChain } from '../useChains'
 
 export const useInitSafeCoreSDK = () => {
   const wallet = useWallet()
   const onboard = useOnboard()
   const { safe, safeLoaded } = useSafeInfo()
   const dispatch = useAppDispatch()
+  const chainInfo = useCurrentChain()
 
   useEffect(() => {
-    if (!onboard || !wallet?.provider || !safeLoaded || safe.chainId !== wallet.chainId || !safe.version) {
+    if (!onboard || !wallet?.provider || !safeLoaded || !safe.version) {
       // If we don't reset the SDK, a previous Safe could remain in the store
       setSafeSDK(undefined)
       return
     }
 
-    initSafeSDK(wallet.provider, safe.chainId, safe.address.value, safe.version)
+    initSafeSDK(wallet.provider, safe.chainId, safe.address.value, safe.version, chainInfo)
       .then(setSafeSDK)
       .catch((e) => {
         dispatch(

--- a/src/hooks/coreSDK/useInitSafeCoreSDK.ts
+++ b/src/hooks/coreSDK/useInitSafeCoreSDK.ts
@@ -17,13 +17,13 @@ export const useInitSafeCoreSDK = () => {
   const chainInfo = useCurrentChain()
 
   useEffect(() => {
-    if (!onboard || !wallet?.provider || !safeLoaded || !safe.version) {
+    if (!onboard || !wallet?.provider || !safeLoaded || !safe.version || !chainInfo) {
       // If we don't reset the SDK, a previous Safe could remain in the store
       setSafeSDK(undefined)
       return
     }
 
-    initSafeSDK(wallet.provider, safe.chainId, safe.address.value, safe.version, chainInfo)
+    initSafeSDK(wallet.provider, safe.chainId, safe.address.value, safe.version, chainInfo, wallet.chainId)
       .then(setSafeSDK)
       .catch((e) => {
         dispatch(
@@ -39,5 +39,5 @@ export const useInitSafeCoreSDK = () => {
         // Disconnect the wallet
         onboard.disconnectWallet({ label: wallet.label })
       })
-  }, [onboard, wallet, safe.chainId, safe.address.value, safe.version, safeLoaded, dispatch])
+  }, [onboard, wallet, safe.chainId, safe.address.value, safe.version, safeLoaded, dispatch, chainInfo])
 }

--- a/src/hooks/wallets/useInitWeb3.ts
+++ b/src/hooks/wallets/useInitWeb3.ts
@@ -12,7 +12,7 @@ export const useInitWeb3 = () => {
   const customRpc = useAppSelector(selectRpc)
 
   useEffect(() => {
-    if (!chain || !wallet || chain.chainId !== wallet.chainId) {
+    if (!chain || !wallet) {
       return
     }
     const web3 = createWeb3(wallet.provider)


### PR DESCRIPTION
## What it solves

This PR allows signing Safe transaction while the signer wallet is connected to any chain.

We use a hybrid provider based on the wallet provider with the "read only" JSON RCP provider mixed in for any calls other than signing and executing.

<img width="1061" alt="Screenshot 2023-03-02 at 17 14 32" src="https://user-images.githubusercontent.com/381895/222486380-e586a047-bfb7-4e73-951a-5668fe063d8c.png">
