### PR TITLE
Fix: revert regression in useSafeAppFromManifest

### DIFF
--- a/src/hooks/safe-apps/useSafeAppFromManifest.ts
+++ b/src/hooks/safe-apps/useSafeAppFromManifest.ts
@@ -11,7 +11,7 @@ type UseSafeAppFromManifestReturnType = {
 }
 
 const useSafeAppFromManifest = (appUrl: string, chainId: string): UseSafeAppFromManifestReturnType => {
-  const [data, error, loading] = useAsync<SafeAppDataWithPermissions>(() => {
+  const [data, error, isLoading] = useAsync<SafeAppDataWithPermissions>(() => {
     if (appUrl && chainId) return fetchSafeAppFromManifest(appUrl, chainId)
   }, [appUrl, chainId])
 
@@ -22,10 +22,7 @@ const useSafeAppFromManifest = (appUrl: string, chainId: string): UseSafeAppFrom
     logError(Errors._903, `${appUrl}, ${(error as Error).message}`)
   }, [appUrl, error])
 
-  return {
-    safeApp: data || emptyApp,
-    isLoading: loading || (!!appUrl && !data),
-  }
+  return { safeApp: data || emptyApp, isLoading }
 }
 
 export { useSafeAppFromManifest }

--- a/src/pages/apps/open.tsx
+++ b/src/pages/apps/open.tsx
@@ -50,7 +50,7 @@ const SafeApps: NextPage = () => {
   }, [router])
 
   // appUrl is required to be present
-  if (!appUrl) return null
+  if (!appUrl || !router.isReady) return null
 
   if (isModalVisible) {
     return (


### PR DESCRIPTION
## What it solves

Reverts a change from #1674

## How this PR fixes it

A regression was introduced in #1674 which prevented Safe Apps with an unreachable manifest.json from being loaded.

## How to test it
Load the InsurAce app, it should load w/o problem, but on prod it won't.