### PR TITLE
fix: Typo in terms page

### DIFF
--- a/src/components/terms/index.tsx
+++ b/src/components/terms/index.tsx
@@ -18,7 +18,7 @@ const SafeTerms = () => {
           (&ldquo;CC&rdquo;, &ldquo;we&rdquo;, &ldquo;our&rdquo; or &ldquo;us&rdquo;) provided we made these Terms
           accessible to you prior to entering into the Agreement and you consent to these Terms. We are a limited
           liability company registered with the commercial register of Berlin Charlottenburg under company number HRB
-          24041&nbsp;B, with its registered office at the ℅ Full Node, Skalitzer Str. 85-86, 10997 Berlin, Germany. You
+          240421&nbsp;B, with its registered office at the ℅ Full Node, Skalitzer Str. 85-86, 10997 Berlin, Germany. You
           can contact us by writing to info@cc0x.dev.
         </li>
         <li>


### PR DESCRIPTION
## What it solves

Fixes a typo on the Terms page. The company number should now match the number on the imprint page as discussed here: https://5afe.slack.com/archives/C04MQSC3R7Y/p1678198438134889?thread_ts=1677598167.668529&cid=C04MQSC3R7Y

## How to test it

1. Open the Terms page
2. Observe the correct company number (240421 B)

## Screenshots

<img width="597" alt="Screenshot 2023-03-07 at 15 26 10" src="https://user-images.githubusercontent.com/5880855/223450997-1172084d-df8f-4c71-bbf0-9ecd272af080.png">
