### PR TITLE
fix: only show `safeTxGas` when present

### DIFF
--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -80,7 +80,7 @@ const GasParams = ({ params, isExecution, isEIP1559, onEdit, gasLimitError }: Ga
       <AccordionDetails>
         {nonce !== undefined && <GasDetail isLoading={false} name="Safe transaction nonce" value={nonce.toString()} />}
 
-        {safeTxGas !== undefined && <GasDetail isLoading={false} name="safeTxGas" value={safeTxGas.toString()} />}
+        {!!safeTxGas && <GasDetail isLoading={false} name="safeTxGas" value={safeTxGas.toString()} />}
 
         {isExecution && (
           <>


### PR DESCRIPTION
## What it solves

Resolves [regression](https://github.com/safe-global/web-core/pull/1744#issuecomment-1461047693).

## How this PR fixes it

The `safeTxGas` is only show if present, meaning that it won't display for 1.3.0 Safes.

## How to test it

Create a transaction on a 1.3.0 Safe and observe that the `safeTxGas` is not shown in the advanced gas parameters.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/223980800-f30a9470-fc24-4555-8d9e-b46e9fadfe1c.png)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
