### PR TITLE
fix: pending skeletons + indexing statuses

### DIFF
--- a/src/components/common/PaginatedTxns/index.tsx
+++ b/src/components/common/PaginatedTxns/index.tsx
@@ -53,7 +53,8 @@ const TxPage = ({
 
       {error && <ErrorMessage>Error loading transactions</ErrorMessage>}
 
-      {loading && <SkeletonTxList />}
+      {/* No skeletons for pending as they are shown above the queue which has them */}
+      {loading && !hasPending && <SkeletonTxList />}
 
       {page?.next && onNextPage && (
         <Box my={4} textAlign="center">


### PR DESCRIPTION
## What it solves

Resolves (1) duplicate skeletons on queue and (2) hidden "Execute transaction" checkbox.

## How this PR fixes it

1. The pending transactions `TxPage` does no longer skeletons. There are two network requests on the page ([for pending and queued transactions](https://github.com/safe-global/web-core/blob/dev/src/pages/transactions/queue.tsx#L34-L37)) which otherwise show their own skeletons.
2. Transactions are no longer marked as pending if they are indexed. ([This needs to be refactored](https://github.com/safe-global/web-core/issues/1754)). We did not previously encounter this bug as [we weren't checking the presence of pending transactions](https://github.com/safe-global/web-core/pull/1676/files#diff-70addbd231a36637989f9e3732bed07149598277eee9498f69fb69dc12463ffcR71).

## How to test it

1. Queue a transaction and switch back and forth between the History and Queue. Observe no duplicate skeleton above the queued transaction.
2. Create and execute a transaction on a 1/n Safe. Create a new transaction and observe the "Execute transaction" checkbox on the review step.

## Screenshots

![skeleton](https://user-images.githubusercontent.com/20442784/224063689-9232d148-f7ae-46e0-af77-a77a6c0cd7fe.gif)

![execution checkbox](https://user-images.githubusercontent.com/20442784/224063708-a1b97c48-6fdc-46c0-a485-ac7e3b804459.gif)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
