### PR TITLE
test: e2e manually hide tokens

### DIFF
--- a/cypress/e2e/smoke/balances.cy.js
+++ b/cypress/e2e/smoke/balances.cy.js
@@ -175,6 +175,24 @@ describe('Assets > Coins', () => {
     })
   })
 
+  describe('tokens can be manually hidden', () => {
+    it('hide single token', () => {
+      // Click hide Dai
+      cy.contains('Dai').parents('tr').find('button[aria-label="Hide asset"]').click()
+      // time to hide the asset
+      cy.wait(350)
+      cy.contains('Dai').should('not.exist')
+    })
+
+    it('unhide hidden token', () => {
+      cy.contains('1 hidden token').click()
+      cy.contains('Dai').parents('tr').find('input[type="checkbox"]').click()
+      cy.contains('Save').click()
+      cy.contains('Dai')
+      cy.contains('Hide tokens')
+    })
+  })
+
   describe.skip('pagination should work', () => {
     before(() => {
       // Open the Safe used for testing pagination

--- a/cypress/e2e/smoke/balances.cy.js
+++ b/cypress/e2e/smoke/balances.cy.js
@@ -185,10 +185,15 @@ describe('Assets > Coins', () => {
     })
 
     it('unhide hidden token', () => {
+      // Open hide token menu
       cy.contains('1 hidden token').click()
+      // uncheck dai token
       cy.contains('Dai').parents('tr').find('input[type="checkbox"]').click()
+      // apply changes
       cy.contains('Save').click()
+      // Dai token is visible again
       cy.contains('Dai')
+      // The menu button shows "Hide tokens" label again
       cy.contains('Hide tokens')
     })
   })


### PR DESCRIPTION
## What it solves
Adds E2E test for manually hiding tokens

## How to test it
Run cypress

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
