### PR TITLE
fix: Only store owned safes for their given chainId

### DIFF
--- a/src/hooks/useOwnedSafes.ts
+++ b/src/hooks/useOwnedSafes.ts
@@ -1,11 +1,11 @@
 import { useEffect } from 'react'
 import { getOwnedSafes, type OwnedSafes } from '@safe-global/safe-gateway-typescript-sdk'
 
-import useChainId from '@/hooks/useChainId'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import useWallet from '@/hooks/wallets/useWallet'
 import useAsync from './useAsync'
 import { Errors, logError } from '@/services/exceptions'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 const CACHE_KEY = 'ownedSafes'
 
@@ -16,26 +16,26 @@ type OwnedSafesCache = {
 }
 
 const useOwnedSafes = (): OwnedSafesCache['walletAddress'] => {
-  const chainId = useChainId()
+  const { safe } = useSafeInfo()
   const { address: walletAddress } = useWallet() || {}
   const [ownedSafesCache, setOwnedSafesCache] = useLocalStorage<OwnedSafesCache>(CACHE_KEY)
 
   const [ownedSafes, error] = useAsync<OwnedSafes>(() => {
-    if (!chainId || !walletAddress) return
-    return getOwnedSafes(chainId, walletAddress)
-  }, [chainId, walletAddress])
+    if (!safe.chainId || !walletAddress) return
+    return getOwnedSafes(safe.chainId, walletAddress)
+  }, [safe.chainId, walletAddress])
 
   useEffect(() => {
-    if (!ownedSafes || !walletAddress || !chainId) return
+    if (!ownedSafes || !walletAddress || !safe.chainId) return
 
     setOwnedSafesCache((prev) => ({
       ...prev,
       [walletAddress]: {
         ...(prev?.[walletAddress] || {}),
-        [chainId]: ownedSafes.safes,
+        [safe.chainId]: ownedSafes.safes,
       },
     }))
-  }, [ownedSafes, setOwnedSafesCache, walletAddress, chainId])
+  }, [ownedSafes, setOwnedSafesCache, walletAddress, safe.chainId])
 
   useEffect(() => {
     if (error) {


### PR DESCRIPTION
## What it solves

Resolves #1759 

## How this PR fixes it

- Awaits the fetch of owned safes before setting the cache to avoid setting it for a stale state

## How to test it

1. Go to Safe
2. Clear the ownedSafes local storage
3. Connect a wallet that owns safes on different networks
4. Open the safe list sidebar
5. Observe owned safes are fetched and saved in the local storage
6. Switch to a safe on a different network
7. Observe the safe list sidebar closes
8. Observe the `ownedSafes` local storage doesn't update
9. Open the safe list sidebar again
10. Observe that the `ownedSafes` local storage gets overriden with the correct entries

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
