### PR TITLE
fix(safe-apps): Add new Safe apps domain

### DIFF
--- a/src/components/safe-apps/AppFrame/useFromAppAnalytics.ts
+++ b/src/components/safe-apps/AppFrame/useFromAppAnalytics.ts
@@ -10,6 +10,7 @@ const ALLOWED_DOMAINS: RegExp[] = [
   /^http:\/\/localhost:[0-9]{4}$/,
   /^https:\/\/safe-apps\.dev\.5afe\.dev$/,
   /^https:\/\/apps\.gnosis-safe\.io$/,
+  /^https:\/\/apps-portal\.safe\.global$/,
 ]
 
 const useAnalyticsFromSafeApp = (iframeRef: MutableRefObject<HTMLIFrameElement | null>): void => {

--- a/src/components/safe-apps/AppFrame/useFromAppAnalytics.ts
+++ b/src/components/safe-apps/AppFrame/useFromAppAnalytics.ts
@@ -5,7 +5,7 @@ import type { AnalyticsEvent } from '@/services/analytics'
 import { EventType, trackSafeAppEvent } from '@/services/analytics'
 import { SAFE_APPS_ANALYTICS_CATEGORY } from '@/services/analytics/events/safeApps'
 
-//TODO: Update apps domain to the new one when decided
+//TODO: Remove Safe Apps old domain when all migrated to the new one
 const ALLOWED_DOMAINS: RegExp[] = [
   /^http:\/\/localhost:[0-9]{4}$/,
   /^https:\/\/safe-apps\.dev\.5afe\.dev$/,


### PR DESCRIPTION
## What it solves
This PR adds the new Safe Apps domain to the `useFromAppAnalytics()` hook.

You can send custom analytics from Safe Apps. As we are migrating the production address to `https://apps-portal.safe.global` it is necessary to allow the domain explicitly


## How to test it
Use the Wallet Connect with `https://safe-client.safe.global` for connect to any dApp.

Check the connection analytics are being sent

```
{
    "event": "safeApp",
    "chainId": "1",
    "eventCategory": "safe-apps-analytics",
    "eventAction": "New session",
    "safeAppName": "Walletconnect-v1",
    "safeAppEthMethod": "",
    "safeAppMethod": "",
    "safeAppSDKVersion": "",
    "eventLabel": "https://app.uniswap.org",
    "gtm.uniqueEventId": 15
}
```