### PR TITLE
apple-app-site-association file also needed in staging environment.

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,23 @@
+{
+    "applinks": {
+        "details": [
+            {
+                "appIDs": [
+                    "ZKG876RKJ8.io.gnosis.multisig.prod.mainnet",
+                    "ZKG876RKJ8.io.gnosis.multisig.prerelease",
+                    "ZKG876RKJ8.io.gnosis.multisig.dev.mainnet",
+                    "ZKG876RKJ8.io.gnosis.multisig.dev.rinkeby",
+                    "ZKG876RKJ8.io.gnosis.multisig.staging.mainnet",
+                    "ZKG876RKJ8.io.gnosis.multisig.staging.rinkeby"
+                ],
+                "components": [
+                    {
+                        "/": "*",
+                        "comment": "Matches all universal links"
+                    }
+                ]
+            }
+        ]
+    }
+}
+


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-ios/issues/2480

## How this PR fixes it
When this file is deployed and available at  https://safe-web-core.staging.5afe.dev/.well-known/apple-app-site-association the ios mobile app will be able to open staging deep link

## How to test it
- Deploy to staging
- Create ios app with matching applink entitlements

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
