### PR TITLE
Chore: replace deprecated set-output in the deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
         shell: bash
         ## Cut off "refs/heads/" and only allow alphanumeric characters,
         ## e.g. "refs/heads/features/hello-1.2.0" -> "features_hello_1_2_0"
-        run: echo "##[set-output name=branch;]$(echo $GITHUB_HEAD_REF | sed 's/refs\/heads\///' | sed 's/[^a-z0-9]/_/ig')"
+        run: echo "branch=$(echo $GITHUB_HEAD_REF | sed 's/refs\/heads\///' | sed 's/[^a-z0-9]/_/ig')" >> $GITHUB_OUTPUT
         id: extract_branch
 
       # Deploy to S3


### PR DESCRIPTION
## What it solves

`set-output` will be deprecated in May this year, so we need to migrate it as per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## How to test

If the PR deployment in this PR works, then it's all bueno.