### PR TITLE
fix: add link to messages placeholder

### DIFF
--- a/src/components/safe-messages/PaginatedMsgs/index.tsx
+++ b/src/components/safe-messages/PaginatedMsgs/index.tsx
@@ -11,6 +11,7 @@ import InfiniteScroll from '@/components/common/InfiniteScroll'
 import PagePlaceholder from '@/components/common/PagePlaceholder'
 import MsgList from '@/components/safe-messages/MsgList'
 import SkeletonTxList from '@/components/common/PaginatedTxns/SkeletonTxList'
+import { SIGNED_MESSAFES_HELP_LINK } from '@/components/transactions/SignedMessagesHelpLink'
 
 const NoMessages = (): ReactElement => {
   return (
@@ -23,8 +24,7 @@ const NoMessages = (): ReactElement => {
         </Typography>
       }
     >
-      {/* TODO: Add link to help article */}
-      <Link rel="noopener noreferrer" target="_blank" href="#" fontWeight={700}>
+      <Link rel="noopener noreferrer" target="_blank" href={SIGNED_MESSAFES_HELP_LINK} fontWeight={700}>
         Learn more about off-chain messages{' '}
         <SvgIcon component={LinkIcon} inheritViewBox fontSize="small" sx={{ verticalAlign: 'middle', ml: 0.5 }} />
       </Link>

--- a/src/components/transactions/SignedMessagesHelpLink/index.tsx
+++ b/src/components/transactions/SignedMessagesHelpLink/index.tsx
@@ -4,6 +4,8 @@ import ExternalLink from '@/components/common/ExternalLink'
 import { useAppSelector } from '@/store'
 import { selectSafeMessages } from '@/store/safeMessagesSlice'
 
+export const SIGNED_MESSAFES_HELP_LINK = 'https://help.safe.global/en/articles/7021891-what-are-signed-messages'
+
 const SignedMessagesHelpLink = () => {
   const safeMessages = useAppSelector(selectSafeMessages)
   const safeMessagesCount = safeMessages.data?.results.length ?? 0
@@ -15,7 +17,7 @@ const SignedMessagesHelpLink = () => {
   return (
     <Box display="flex" alignItems="center" gap={1}>
       <SvgIcon component={InfoIcon} inheritViewBox color="border" fontSize="small" />
-      <ExternalLink noIcon href="https://help.safe.global/en/articles/7021891-what-are-signed-messages">
+      <ExternalLink noIcon href={SIGNED_MESSAFES_HELP_LINK}>
         <Typography variant="body2" fontWeight={700}>
           What are signed messages?
         </Typography>


### PR DESCRIPTION
## What it solves

Resolves missing help article link.

## How this PR fixes it

The placeholder help article link on an empty "Messages" list has been added.

## How to test it

Open a Safe with an empty "Messages" list and observe a functioning link.

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
