### PR TITLE
Fix: tx-summary word-break only on mobile

### DIFF
--- a/src/components/transactions/TxSummary/styles.module.css
+++ b/src/components/transactions/TxSummary/styles.module.css
@@ -32,10 +32,13 @@
 
 .columnWrap {
   white-space: normal;
-  word-break: break-word;
 }
 
 @media (max-width: 600px) {
+  .columnWrap {
+    word-break: break-word;
+  }
+
   .gridContainer {
     gap: var(--space-1);
   }


### PR DESCRIPTION
## What it solves
Randomly noticed this on prod:
<img width="1111" alt="Screenshot 2023-03-14 at 12 41 10" src="https://user-images.githubusercontent.com/381895/224990490-97371331-2a88-4054-b9fa-460e415c91b7.png">

Breaking words like this seems to be unnecessary on desktop (and even on mobile, because we break the summary into several lines).

After the fix:
<img width="1202" alt="Screenshot 2023-03-14 at 12 39 01" src="https://user-images.githubusercontent.com/381895/224990626-a62417ca-afe6-49bd-aa9b-7365a33f06b4.png">
<img width="549" alt="Screenshot 2023-03-14 at 12 39 08" src="https://user-images.githubusercontent.com/381895/224990629-db3f20ea-5785-41dc-9f10-fe83bf105902.png">
<img width="838" alt="Screenshot 2023-03-14 at 12 39 34" src="https://user-images.githubusercontent.com/381895/224990633-5489273a-4bb1-40fb-b780-5cc384634070.png">

