### PR TITLE
Fix: strip query params from Sentry events

### DIFF
--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -12,9 +12,15 @@ Sentry.init({
   ignoreErrors: ['Internal JSON-RPC error', 'JsonRpcEngine', 'Non-Error promise rejection captured with keys: code'],
 
   beforeSend: (event) => {
-    // Remove URL query params
-    if (event.request?.query_string) {
-      delete event.request?.query_string
+    // Remove sensitive URL query params
+    const query = event.request?.query_string
+    if (event.request && query) {
+      const appUrl = typeof query !== 'string' && !Array.isArray(query) ? query.appUrl : ''
+      if (appUrl) {
+        event.request.query_string = { appUrl }
+      } else {
+        delete event.request.query_string
+      }
     }
     return event
   },

--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -10,6 +10,14 @@ Sentry.init({
   sampleRate: 0.1,
   // ignore MetaMask errors we don't control
   ignoreErrors: ['Internal JSON-RPC error', 'JsonRpcEngine', 'Non-Error promise rejection captured with keys: code'],
+
+  beforeSend: (event) => {
+    // Remove URL query params
+    if (event.request?.query_string) {
+      delete event.request?.query_string
+    }
+    return event
+  },
 })
 
 export default Sentry


### PR DESCRIPTION
## What it solves

Removes sensitive data such as the Safe address and tx ids from Sentry events.
So far they haven't been needed for debugging anyway.