### PR TITLE
feat: display Fallback Handler address

### DIFF
--- a/src/components/settings/FallbackHandler/__tests__/index.test.tsx
+++ b/src/components/settings/FallbackHandler/__tests__/index.test.tsx
@@ -1,0 +1,236 @@
+import { act, fireEvent, render, waitFor } from '@/tests/test-utils'
+
+import * as useSafeInfoHook from '@/hooks/useSafeInfo'
+import * as useTxBuilderHook from '@/hooks/safe-apps/useTxBuilderApp'
+import { FallbackHandler } from '..'
+
+const GOERLI_FALLBACK_HANDLER = '0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4'
+
+describe('FallbackHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    jest.spyOn(useTxBuilderHook, 'useTxBuilderApp').mockImplementation(() => ({
+      link: { href: 'https://mock.link/tx-builder' },
+    }))
+  })
+
+  it('should render the Fallback Handler when one is set', async () => {
+    jest.spyOn(useSafeInfoHook, 'default').mockImplementation(
+      () =>
+        ({
+          safe: {
+            version: '1.3.0',
+            chainId: '5',
+            fallbackHandler: {
+              value: GOERLI_FALLBACK_HANDLER,
+              name: 'FallbackHandlerName',
+            },
+          },
+        } as unknown as ReturnType<typeof useSafeInfoHook.default>),
+    )
+
+    const fbHandler = render(<FallbackHandler />)
+
+    await waitFor(() => {
+      expect(
+        fbHandler.queryByText(
+          'The fallback handler adds fallback logic for funtionality that may not be present in the Safe contract. Learn more about the fallback handler',
+        ),
+      ).toBeDefined()
+
+      expect(fbHandler.getByText(GOERLI_FALLBACK_HANDLER)).toBeDefined()
+
+      expect(fbHandler.getByText('FallbackHandlerName')).toBeDefined()
+    })
+  })
+
+  it('should use the official deployment name if the address is official but no known name is present', async () => {
+    jest.spyOn(useSafeInfoHook, 'default').mockImplementation(
+      () =>
+        ({
+          safe: {
+            version: '1.3.0',
+            chainId: '5',
+            fallbackHandler: {
+              value: GOERLI_FALLBACK_HANDLER,
+            },
+          },
+        } as unknown as ReturnType<typeof useSafeInfoHook.default>),
+    )
+
+    const fbHandler = render(<FallbackHandler />)
+
+    await waitFor(() => {
+      expect(fbHandler.getByText('CompatibilityFallbackHandler')).toBeDefined()
+    })
+  })
+
+  describe('No Fallback Handler', () => {
+    it('should render the Fallback Handler and warning tooltip when no Fallback Handler is set', async () => {
+      jest.spyOn(useSafeInfoHook, 'default').mockImplementation(
+        () =>
+          ({
+            safe: {
+              version: '1.3.0',
+              chainId: '5',
+            },
+          } as unknown as ReturnType<typeof useSafeInfoHook.default>),
+      )
+
+      const fbHandler = render(<FallbackHandler />)
+
+      await waitFor(() => {
+        expect(fbHandler.getByText('No fallback handler set')).toBeDefined()
+      })
+
+      const icon = fbHandler.getByTestId('fallback-handler-warning')
+
+      await act(() => {
+        fireEvent(
+          icon,
+          new MouseEvent('mouseover', {
+            bubbles: true,
+          }),
+        )
+      })
+
+      await waitFor(() => {
+        expect(
+          fbHandler.queryByText(new RegExp('The Safe may not work correctly as no fallback handler is currently set.')),
+        ).toBeInTheDocument()
+        expect(fbHandler.queryByText('Transaction Builder')).toBeInTheDocument()
+      })
+    })
+
+    it('should conditionally append the Transaction Builder link', async () => {
+      jest.spyOn(useTxBuilderHook, 'useTxBuilderApp').mockImplementation(() => undefined)
+
+      jest.spyOn(useSafeInfoHook, 'default').mockImplementation(
+        () =>
+          ({
+            safe: {
+              version: '1.3.0',
+              chainId: '5',
+            },
+          } as unknown as ReturnType<typeof useSafeInfoHook.default>),
+      )
+
+      const fbHandler = render(<FallbackHandler />)
+
+      const icon = fbHandler.getByTestId('fallback-handler-warning')
+
+      await act(() => {
+        fireEvent(
+          icon,
+          new MouseEvent('mouseover', {
+            bubbles: true,
+          }),
+        )
+      })
+
+      await waitFor(() => {
+        expect(
+          fbHandler.queryByText(new RegExp('The Safe may not work correctly as no fallback handler is currently set.')),
+        ).toBeInTheDocument()
+        expect(fbHandler.queryByText('Transaction Builder')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Unofficial Fallback Handler', () => {
+    it('should render placeholder and warning tooltip when an unofficial Fallback Handler is set', async () => {
+      jest.spyOn(useSafeInfoHook, 'default').mockImplementation(
+        () =>
+          ({
+            safe: {
+              version: '1.3.0',
+              chainId: '5',
+              fallbackHandler: {
+                value: '0x123',
+              },
+            },
+          } as unknown as ReturnType<typeof useSafeInfoHook.default>),
+      )
+
+      const fbHandler = render(<FallbackHandler />)
+
+      await waitFor(() => {
+        expect(
+          fbHandler.queryByText(
+            'The fallback handler adds fallback logic for funtionality that may not be present in the Safe contract. Learn more about the fallback handler',
+          ),
+        ).toBeDefined()
+
+        expect(fbHandler.getByText('0x123')).toBeDefined()
+      })
+
+      const icon = fbHandler.getByTestId('fallback-handler-warning')
+
+      await act(() => {
+        fireEvent(
+          icon,
+          new MouseEvent('mouseover', {
+            bubbles: true,
+          }),
+        )
+      })
+
+      await waitFor(() => {
+        expect(fbHandler.queryByText(new RegExp('An unofficial fallback handler is currently set.')))
+        expect(fbHandler.queryByText('Transaction Builder')).toBeInTheDocument()
+      })
+    })
+
+    it('should conditionally append the Transaction Builder link', async () => {
+      jest.spyOn(useTxBuilderHook, 'useTxBuilderApp').mockImplementation(() => undefined)
+
+      jest.spyOn(useSafeInfoHook, 'default').mockImplementation(
+        () =>
+          ({
+            safe: {
+              version: '1.3.0',
+              chainId: '5',
+              fallbackHandler: {
+                value: '0x123',
+              },
+            },
+          } as unknown as ReturnType<typeof useSafeInfoHook.default>),
+      )
+
+      const fbHandler = render(<FallbackHandler />)
+
+      const icon = fbHandler.getByTestId('fallback-handler-warning')
+
+      await act(() => {
+        fireEvent(
+          icon,
+          new MouseEvent('mouseover', {
+            bubbles: true,
+          }),
+        )
+      })
+
+      await waitFor(() => {
+        expect(fbHandler.queryByText(new RegExp('An unofficial fallback handler is currently set.')))
+        expect(fbHandler.queryByText('Transaction Builder')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  it('should render nothing if the Safe version does not support Fallback Handlers', () => {
+    jest.spyOn(useSafeInfoHook, 'default').mockImplementation(
+      () =>
+        ({
+          safe: {
+            version: '1.0.0',
+            chainId: '5',
+          },
+        } as unknown as ReturnType<typeof useSafeInfoHook.default>),
+    )
+
+    const fbHandler = render(<FallbackHandler />)
+
+    expect(fbHandler.container).toBeEmptyDOMElement()
+  })
+})

--- a/src/components/settings/FallbackHandler/index.tsx
+++ b/src/components/settings/FallbackHandler/index.tsx
@@ -1,0 +1,81 @@
+import { Typography, Box, SvgIcon, Tooltip, Grid, Paper } from '@mui/material'
+import semverSatisfies from 'semver/functions/satisfies'
+import { useMemo } from 'react'
+import type { ReactElement } from 'react'
+
+import EthHashInfo from '@/components/common/EthHashInfo'
+import AlertIcon from '@/public/images/common/alert.svg'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { getFallbackHandlerDeployment } from '@safe-global/safe-deployments'
+import { LATEST_SAFE_VERSION } from '@/config/constants'
+import ExternalLink from '@/components/common/ExternalLink'
+
+import css from '../SafeModules/styles.module.css'
+
+const FALLBACK_HANDLER_VERSION = '>=1.1.1'
+const FALLBACK_HANDLER_ARTICLE =
+  'https://help.gnosis-safe.io/en/articles/4738352-what-is-a-fallback-handler-and-how-does-it-relate-to-the-gnosis-safe'
+
+export const FallbackHandler = (): ReactElement | null => {
+  const { safe } = useSafeInfo()
+
+  const supportsFallbackHandler = !!safe.version && semverSatisfies(safe.version, FALLBACK_HANDLER_VERSION)
+
+  const fallbackHandler = safe.fallbackHandler?.value
+  const fallbackHandlerDeployment = useMemo(() => {
+    return getFallbackHandlerDeployment({
+      version: safe.version || LATEST_SAFE_VERSION,
+      network: safe.chainId,
+    })
+  }, [safe.version, safe.chainId])
+
+  if (!supportsFallbackHandler) {
+    return null
+  }
+
+  const shouldWarn = fallbackHandler ? fallbackHandler !== fallbackHandlerDeployment?.defaultAddress : false
+
+  return (
+    <Paper sx={{ padding: 4 }}>
+      <Grid container direction="row" justifyContent="space-between" spacing={3}>
+        <Grid item lg={4} xs={12}>
+          <Typography variant="h4" fontWeight={700}>
+            Fallback handler
+            {shouldWarn && (
+              <Tooltip placement="top" title="An unofficial fallback handler is currently set.">
+                <span>
+                  <SvgIcon
+                    component={AlertIcon}
+                    inheritViewBox
+                    fontSize="small"
+                    color="warning"
+                    sx={{ verticalAlign: 'middle', ml: 0.5 }}
+                  />
+                </span>
+              </Tooltip>
+            )}
+          </Typography>
+        </Grid>
+
+        <Grid item xs>
+          <Box>
+            <Typography>
+              The fallback handler adds fallback logic for funtionality that may not be present in the Safe contract.
+              Learn more about the fallback handler here{' '}
+              <ExternalLink href={FALLBACK_HANDLER_ARTICLE}>here</ExternalLink>
+            </Typography>
+            {fallbackHandler ? (
+              <Box className={css.container}>
+                <EthHashInfo shortAddress={false} address={fallbackHandler} showCopyButton hasExplorer />
+              </Box>
+            ) : (
+              <Typography mt={2} color={({ palette }) => palette.primary.light}>
+                No fallback handler set
+              </Typography>
+            )}
+          </Box>
+        </Grid>
+      </Grid>
+    </Paper>
+  )
+}

--- a/src/components/settings/FallbackHandler/index.tsx
+++ b/src/components/settings/FallbackHandler/index.tsx
@@ -37,8 +37,6 @@ export const FallbackHandler = (): ReactElement | null => {
 
   const isOfficial = !!safe.fallbackHandler && safe.fallbackHandler.value === fallbackHandlerDeployment?.defaultAddress
 
-  const fallbackHandlerName = safe.fallbackHandler?.name || fallbackHandlerDeployment?.contractName
-
   const tooltip = !safe.fallbackHandler ? (
     <>
       The Safe may not work correctly as no fallback handler is currently set.
@@ -102,8 +100,9 @@ export const FallbackHandler = (): ReactElement | null => {
               <Box className={css.container}>
                 <EthHashInfo
                   shortAddress={false}
-                  name={fallbackHandlerName}
+                  name={safe.fallbackHandler.name || fallbackHandlerDeployment?.contractName}
                   address={safe.fallbackHandler.value}
+                  customAvatar={safe.fallbackHandler.logoUri}
                   showCopyButton
                   hasExplorer
                 />

--- a/src/components/tx/modals/NewTxModal/CreationModal.tsx
+++ b/src/components/tx/modals/NewTxModal/CreationModal.tsx
@@ -1,29 +1,10 @@
 import { Box, DialogContent } from '@mui/material'
 import Link from 'next/link'
-import { useRouter } from 'next/router'
-import type { UrlObject } from 'url'
-import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
 
 import ModalDialog from '@/components/common/ModalDialog'
-import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
-import { AppRoutes } from '@/config/routes'
-import { SafeAppsTag } from '@/config/constants'
+import { useTxBuilderApp } from '@/hooks/safe-apps/useTxBuilderApp'
 import TxButton, { SendNFTsButton, SendTokensButton } from './TxButton'
 import useIsOnlySpendingLimitBeneficiary from '@/hooks/useIsOnlySpendingLimitBeneficiary'
-
-const useTxBuilderApp = (): { app?: SafeAppData; link: UrlObject } => {
-  const [matchingApps] = useRemoteSafeApps(SafeAppsTag.TX_BUILDER)
-  const router = useRouter()
-  const app = matchingApps?.[0]
-
-  return {
-    app,
-    link: {
-      pathname: AppRoutes.apps.open,
-      query: { safe: router.query.safe, appUrl: app?.url },
-    },
-  }
-}
 
 const CreationModal = ({
   open,
@@ -53,7 +34,7 @@ const CreationModal = ({
             <>
               {onNFTModalOpen && <SendNFTsButton onClick={onNFTModalOpen} />}
 
-              {txBuilder.app && shouldShowTxBuilder && (
+              {txBuilder && txBuilder.app && shouldShowTxBuilder && (
                 <Link href={txBuilder.link} passHref>
                   <a style={{ width: '100%' }}>
                     <TxButton

--- a/src/hooks/safe-apps/useTxBuilderApp.ts
+++ b/src/hooks/safe-apps/useTxBuilderApp.ts
@@ -1,0 +1,25 @@
+import { useRouter } from 'next/router'
+import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
+import type { UrlObject } from 'url'
+
+import { SafeAppsTag } from '@/config/constants'
+import { AppRoutes } from '@/config/routes'
+import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
+
+export const useTxBuilderApp = (): { app?: SafeAppData; link: UrlObject } | undefined => {
+  const [matchingApps] = useRemoteSafeApps(SafeAppsTag.TX_BUILDER)
+  const router = useRouter()
+  const app = matchingApps?.[0]
+
+  if (!app) {
+    return undefined
+  }
+
+  return {
+    app,
+    link: {
+      pathname: AppRoutes.apps.open,
+      query: { safe: router.query.safe, appUrl: app?.url },
+    },
+  }
+}

--- a/src/pages/settings/modules.tsx
+++ b/src/pages/settings/modules.tsx
@@ -4,6 +4,7 @@ import { Grid } from '@mui/material'
 import SafeModules from '@/components/settings/SafeModules'
 import TransactionGuards from '@/components/settings/TransactionGuards'
 import SettingsHeader from '@/components/settings/SettingsHeader'
+import { FallbackHandler } from '@/components/settings/FallbackHandler'
 
 const Modules: NextPage = () => {
   return (
@@ -22,6 +23,10 @@ const Modules: NextPage = () => {
 
           <Grid item>
             <TransactionGuards />
+          </Grid>
+
+          <Grid item>
+            <FallbackHandler />
           </Grid>
         </Grid>
       </main>


### PR DESCRIPTION
## What it solves

Resolves #1781

## How this PR fixes it

This adds a new block to the "Modules" settings pane that displays the currently set Fallback Handler (if present), as well as a warning if an unofficial one is set.

## How to test it

Open the "Modules" settings pane and observe the new block. It should display the according details as mentioned above.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/226337231-8be9fd64-a6d2-479e-93d5-2ed87fa1f547.png)

![image](https://user-images.githubusercontent.com/20442784/226337161-2c4f72dd-627c-40da-9d8a-3f3e06cf526e.png)

![image](https://user-images.githubusercontent.com/20442784/226337032-c6fdadb6-733d-4b25-bf25-b1bd3f76e09e.png)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
