### PR TITLE
feat: Relay dashboard widget

### DIFF
--- a/src/components/dashboard/Relaying/index.tsx
+++ b/src/components/dashboard/Relaying/index.tsx
@@ -1,0 +1,98 @@
+import { WidgetBody, WidgetContainer } from '@/components/dashboard/styled'
+import { Box, Card, Divider, Grid, Link, Skeleton, SvgIcon, Typography } from '@mui/material'
+import RelayerIcon from '@/public/images/common/relayer.svg'
+import css from './styles.module.css'
+import useRemainingRelays from '@/hooks/useRemainingRelays'
+import useChains from '@/hooks/useChains'
+import { FEATURES, hasFeature } from '@/utils/chains'
+import ImageFallback from '@/components/common/ImageFallback'
+
+const FallbackChainIcon = ({ color }: { color: string }) => (
+  <div
+    style={{
+      width: '16px',
+      height: '16px',
+      backgroundColor: color,
+      borderRadius: '50%',
+    }}
+  />
+)
+
+const Relaying = () => {
+  const [remainingRelays] = useRemainingRelays()
+  const { configs } = useChains()
+
+  return (
+    <WidgetContainer>
+      <Typography component="h2" variant="subtitle1" fontWeight={700} mb={2}>
+        Gasless transactions
+      </Typography>
+
+      <WidgetBody>
+        <Card sx={{ padding: 3 }}>
+          <Grid container mb={3}>
+            <Grid item xs={12} sm={2}>
+              <SvgIcon component={RelayerIcon} sx={{ width: 'auto', height: '60px' }} inheritViewBox />
+            </Grid>
+            <Grid item xs={10}>
+              <Box display="flex" alignItems="center">
+                <Typography variant="h6" fontWeight={700}>
+                  Introducing Relayer
+                </Typography>
+                <Box className={css.inlineChip} sx={{ backgroundColor: 'secondary.light' }}>
+                  New
+                </Box>
+              </Box>
+              <Typography variant="body2" sx={{ display: 'inline' }}>
+                Benefit from gasless experience powered by Gelato and Safe.{' '}
+              </Typography>
+              <Link href="#" color="primary.main" fontWeight="bold">
+                Read about trial
+              </Link>
+            </Grid>
+          </Grid>
+          <Divider />
+          <Grid container mt={2} spacing={3}>
+            <Grid item xs={12} sm={4}>
+              <Typography variant="body1" color="primary.light">
+                Free transactions{' '}
+              </Typography>
+              {remainingRelays !== undefined ? (
+                <Typography fontWeight={700}>{remainingRelays} out of 5 remaining</Typography>
+              ) : (
+                <Skeleton className={css.chipSkeleton} variant="rounded" />
+              )}
+            </Grid>
+            <Grid item xs={12} sm={8}>
+              <Box display="flex" alignItems="center" justifyContent="space-between">
+                <Typography variant="body1" color="primary.light">
+                  Supported on{' '}
+                </Typography>
+                <Box className={css.inlineChip} sx={{ backgroundColor: 'border.light' }}>
+                  More coming soon
+                </Box>
+              </Box>
+              {/* Chains that have relaying feature enabled */}
+              {configs
+                .filter((chain) => hasFeature(chain, FEATURES.RELAYING))
+                .map((chain) => (
+                  <Box display="flex" alignItems="center" gap={1} key={chain.chainId}>
+                    <ImageFallback
+                      src={chain.nativeCurrency.logoUri}
+                      about={chain.chainName}
+                      fallbackSrc=""
+                      fallbackComponent={<FallbackChainIcon color={chain.theme.backgroundColor} />}
+                      height="16px"
+                    />
+                    <Typography key={chain.chainId}>{chain.chainName}</Typography>
+                  </Box>
+                ))}
+            </Grid>
+          </Grid>
+        </Card>
+      </WidgetBody>
+    </WidgetContainer>
+  )
+}
+
+export default Relaying

--- a/src/components/dashboard/Relaying/index.tsx
+++ b/src/components/dashboard/Relaying/index.tsx
@@ -3,7 +3,7 @@ import { Box, Card, Divider, Grid, Link, Skeleton, SvgIcon, Typography } from '@
 import RelayerIcon from '@/public/images/common/relayer.svg'
 import css from './styles.module.css'
 import useRemainingRelays from '@/hooks/useRemainingRelays'
-import useChains from '@/hooks/useChains'
+import useChains, { useCurrentChain } from '@/hooks/useChains'
 import { FEATURES, hasFeature } from '@/utils/chains'
 import ImageFallback from '@/components/common/ImageFallback'
 
@@ -21,6 +21,7 @@ const FallbackChainIcon = ({ color }: { color: string }) => (
 const Relaying = () => {
   const [remainingRelays] = useRemainingRelays()
   const { configs } = useChains()
+  const currentChain = useCurrentChain()
 
   return (
     <WidgetContainer>
@@ -29,7 +30,7 @@ const Relaying = () => {
       </Typography>
 
       <WidgetBody>
-        <Card sx={{ padding: 3 }}>
+        <Card sx={{ padding: 3, height: 'inherit' }}>
           <Grid container mb={3}>
             <Grid item xs={12} sm={2}>
               <SvgIcon component={RelayerIcon} sx={{ width: 'auto', height: '60px' }} inheritViewBox />
@@ -53,16 +54,18 @@ const Relaying = () => {
           </Grid>
           <Divider />
           <Grid container mt={2} spacing={3}>
-            <Grid item xs={12} sm={4}>
-              <Typography variant="body1" color="primary.light">
-                Free transactions{' '}
-              </Typography>
-              {remainingRelays !== undefined ? (
-                <Typography fontWeight={700}>{remainingRelays} out of 5 remaining</Typography>
-              ) : (
-                <Skeleton className={css.chipSkeleton} variant="rounded" />
-              )}
-            </Grid>
+            {currentChain && hasFeature(currentChain, FEATURES.RELAYING) && (
+              <Grid item xs={12} sm={4}>
+                <Typography variant="body1" color="primary.light">
+                  Free transactions{' '}
+                </Typography>
+                {remainingRelays !== undefined ? (
+                  <Typography fontWeight={700}>{remainingRelays} out of 5 remaining</Typography>
+                ) : (
+                  <Skeleton className={css.chipSkeleton} variant="rounded" />
+                )}
+              </Grid>
+            )}
             <Grid item xs={12} sm={8}>
               <Box display="flex" alignItems="center" justifyContent="space-between">
                 <Typography variant="body1" color="primary.light">

--- a/src/components/dashboard/Relaying/styles.module.css
+++ b/src/components/dashboard/Relaying/styles.module.css
@@ -1,0 +1,15 @@
+.inlineChip {
+  margin-left: var(--space-1);
+  padding: 4px 12px;
+  border-radius: 6px;
+  height: 28px;
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.4px;
+  white-space: nowrap;
+}
+
+.chipSkeleton {
+  height: 30px;
+  width: 80px;
+}

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -7,6 +7,7 @@ import SafeAppsDashboardSection from '@/components/dashboard/SafeAppsDashboardSe
 import GovernanceSection from '@/components/dashboard/GovernanceSection/GovernanceSection'
 import CreationDialog from '@/components/dashboard/CreationDialog'
 import { useRouter } from 'next/router'
+import Relaying from '@/components/dashboard/Relaying'
 
 const Dashboard = (): ReactElement => {
   const router = useRouter()
@@ -23,8 +24,12 @@ const Dashboard = (): ReactElement => {
           <PendingTxsList size={4} />
         </Grid>
 
-        <Grid item xs={12}>
+        <Grid item xs={12} md={12} lg={6}>
           <FeaturedApps />
+        </Grid>
+
+        <Grid item xs={12} md={12} lg={6}>
+          <Relaying />
         </Grid>
 
         <Grid item xs={12}>


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/web-core/issues/1701

## How this PR fixes it
Implements the widget as per detailed in the original issue

## How to test it
1. Go to the Home page in Goerli
2. The widget should be next to the "Featured apps" as per designs and you can see the number of remaining relay transactions left.
3. Go to the Home page in a network that has no Relaying support (p.e Mainnet)
4. The widget should be present anyway but showing no information of remaining relay transactions

## Screenshots
_On Goerli_
<img width="1087" alt="Screenshot 2023-03-20 at 13 32 00" src="https://user-images.githubusercontent.com/32431609/226341063-89d18710-9aa4-4520-a6e5-2e08cf8fef68.png">
_On Polygon_
<img width="723" alt="Screenshot 2023-03-20 at 13 31 49" src="https://user-images.githubusercontent.com/32431609/226341056-12160efa-a075-4e30-aff2-69de67babecd.png">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
