### PR TITLE
feat: buttons to expand/collapse all actions

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -49,22 +49,22 @@ export const Multisend = ({
   variant = 'elevation',
   showDelegateCallWarning = true,
 }: MultisendProps): ReactElement | null => {
-  const [open, setOpen] = useState<Record<number, boolean>>()
+  const [openMap, setOpenMap] = useState<Record<number, boolean>>()
+  const isOpenMapUndefined = openMap == null
 
   // multiSend method receives one parameter `transactions`
   const multiSendTransactions = txData?.dataDecoded?.parameters?.[0].valueDecoded
 
   useEffect(() => {
     // Initialise whether each transaction should be expanded or not
-    const multiSendTransactions = txData?.dataDecoded?.parameters?.[0]?.valueDecoded
-    if (!open && multiSendTransactions) {
-      setOpen(
+    if (isOpenMapUndefined && multiSendTransactions) {
+      setOpenMap(
         multiSendTransactions.map(({ operation }) => {
           return showDelegateCallWarning ? operation === Operation.DELEGATE : false
         }),
       )
     }
-  }, [open, showDelegateCallWarning, txData?.dataDecoded?.parameters])
+  }, [multiSendTransactions, isOpenMapUndefined, showDelegateCallWarning])
 
   if (!txData) return null
 
@@ -82,10 +82,10 @@ export const Multisend = ({
 
   return (
     <>
-      <MultisendActionsHeader setOpen={setOpen} amount={multiSendTransactions.length} />
+      <MultisendActionsHeader setOpen={setOpenMap} amount={multiSendTransactions.length} />
       {multiSendTransactions.map(({ dataDecoded, data, value, to, operation }, index) => {
         const onChange: AccordionProps['onChange'] = (_, expanded) => {
-          setOpen((prev) => ({
+          setOpenMap((prev) => ({
             ...prev,
             [index]: expanded,
           }))
@@ -105,7 +105,7 @@ export const Multisend = ({
             showDelegateCallWarning={showDelegateCallWarning}
             actionTitle={`Action ${index + 1}`}
             variant={variant}
-            expanded={open?.[index] ?? false}
+            expanded={openMap?.[index] ?? false}
             onChange={onChange}
           />
         )

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -1,8 +1,11 @@
 import { HexEncodedData } from '@/components/transactions/HexEncodedData'
+import { Operation } from '@safe-global/safe-gateway-typescript-sdk'
 import type { TransactionData } from '@safe-global/safe-gateway-typescript-sdk'
-import type { ReactElement } from 'react'
+import { useState } from 'react'
+import type { Dispatch, ReactElement, SetStateAction } from 'react'
 import type { AccordionProps } from '@mui/material/Accordion/Accordion'
 import SingleTxDecoded from '@/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded'
+import { AccordionSummary, Button, Divider } from '@mui/material'
 
 type MultisendProps = {
   txData?: TransactionData
@@ -10,11 +13,44 @@ type MultisendProps = {
   showDelegateCallWarning?: boolean
 }
 
+const MultisendActionsHeader = ({
+  setOpen,
+  amount,
+}: {
+  setOpen: Dispatch<SetStateAction<Record<number, boolean> | undefined>>
+  amount: number
+}) => {
+  const onClickAll = (expanded: boolean) => () => {
+    setOpen(Array(amount).fill(expanded))
+  }
+
+  return (
+    <AccordionSummary
+      sx={{ borderBottom: ({ palette }) => `1px solid ${palette.border.light}`, cursor: 'auto !important', pr: 0 }}
+      expandIcon={
+        <>
+          <Button onClick={onClickAll(true)} variant="text" sx={{ px: '18px' }}>
+            Expand all
+          </Button>
+          <Divider sx={{ my: '14px', borderColor: 'border.light' }} />
+          <Button onClick={onClickAll(false)} variant="text" sx={{ px: '18px' }}>
+            Collapse all
+          </Button>
+        </>
+      }
+    >
+      All actions
+    </AccordionSummary>
+  )
+}
+
 export const Multisend = ({
   txData,
   variant = 'elevation',
   showDelegateCallWarning = true,
 }: MultisendProps): ReactElement | null => {
+  const [open, setOpen] = useState<Record<number, boolean>>()
+
   if (!txData) return null
 
   // ? when can a multiSend call take no parameters?
@@ -26,9 +62,32 @@ export const Multisend = ({
   }
 
   // multiSend method receives one parameter `transactions`
+  const multiSendTransactions = txData.dataDecoded.parameters?.[0].valueDecoded
+
+  if (!multiSendTransactions) {
+    return null
+  }
+
+  // Initialise whether each transaction should be expanded or not
+  if (!open) {
+    setOpen(
+      multiSendTransactions.map(({ operation }) => {
+        return showDelegateCallWarning ? operation === Operation.DELEGATE : false
+      }),
+    )
+  }
+
   return (
     <>
-      {txData.dataDecoded?.parameters[0].valueDecoded?.map(({ dataDecoded, data, value, to, operation }, index) => {
+      <MultisendActionsHeader setOpen={setOpen} amount={multiSendTransactions.length} />
+      {multiSendTransactions?.map(({ dataDecoded, data, value, to, operation }, index) => {
+        const onChange: AccordionProps['onChange'] = (_, expanded) => {
+          setOpen((prev) => ({
+            ...prev,
+            [index]: expanded,
+          }))
+        }
+
         return (
           <SingleTxDecoded
             key={`${data ?? to}-${index}`}
@@ -43,6 +102,8 @@ export const Multisend = ({
             showDelegateCallWarning={showDelegateCallWarning}
             actionTitle={`Action ${index + 1}`}
             variant={variant}
+            expanded={open?.[index] ?? false}
+            onChange={onChange}
           />
         )
       })}

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -1,7 +1,7 @@
 import { HexEncodedData } from '@/components/transactions/HexEncodedData'
 import { Operation } from '@safe-global/safe-gateway-typescript-sdk'
 import type { TransactionData } from '@safe-global/safe-gateway-typescript-sdk'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import type { Dispatch, ReactElement, SetStateAction } from 'react'
 import type { AccordionProps } from '@mui/material/Accordion/Accordion'
 import SingleTxDecoded from '@/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded'
@@ -51,6 +51,21 @@ export const Multisend = ({
 }: MultisendProps): ReactElement | null => {
   const [open, setOpen] = useState<Record<number, boolean>>()
 
+  // multiSend method receives one parameter `transactions`
+  const multiSendTransactions = txData?.dataDecoded?.parameters?.[0].valueDecoded
+
+  useEffect(() => {
+    // Initialise whether each transaction should be expanded or not
+    const multiSendTransactions = txData?.dataDecoded?.parameters?.[0]?.valueDecoded
+    if (!open && multiSendTransactions) {
+      setOpen(
+        multiSendTransactions.map(({ operation }) => {
+          return showDelegateCallWarning ? operation === Operation.DELEGATE : false
+        }),
+      )
+    }
+  }, [open, showDelegateCallWarning, txData?.dataDecoded?.parameters])
+
   if (!txData) return null
 
   // ? when can a multiSend call take no parameters?
@@ -61,26 +76,14 @@ export const Multisend = ({
     return null
   }
 
-  // multiSend method receives one parameter `transactions`
-  const multiSendTransactions = txData.dataDecoded.parameters?.[0].valueDecoded
-
   if (!multiSendTransactions) {
     return null
-  }
-
-  // Initialise whether each transaction should be expanded or not
-  if (!open) {
-    setOpen(
-      multiSendTransactions.map(({ operation }) => {
-        return showDelegateCallWarning ? operation === Operation.DELEGATE : false
-      }),
-    )
   }
 
   return (
     <>
       <MultisendActionsHeader setOpen={setOpen} amount={multiSendTransactions.length} />
-      {multiSendTransactions?.map(({ dataDecoded, data, value, to, operation }, index) => {
+      {multiSendTransactions.map(({ dataDecoded, data, value, to, operation }, index) => {
         const onChange: AccordionProps['onChange'] = (_, expanded) => {
           setOpen((prev) => ({
             ...prev,

--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -19,6 +19,8 @@ type SingleTxDecodedProps = {
   actionTitle: string
   showDelegateCallWarning: boolean
   variant?: AccordionProps['variant']
+  expanded?: boolean
+  onChange?: AccordionProps['onChange']
 }
 
 export const SingleTxDecoded = ({
@@ -27,6 +29,8 @@ export const SingleTxDecoded = ({
   actionTitle,
   showDelegateCallWarning,
   variant,
+  expanded,
+  onChange,
 }: SingleTxDecodedProps) => {
   const chain = useCurrentChain()
   const method = tx.dataDecoded?.method || ''
@@ -50,7 +54,7 @@ export const SingleTxDecoded = ({
   const isSpendingLimitMethod = isSetAllowance(tx.dataDecoded?.method) || isDeleteAllowance(tx.dataDecoded?.method)
 
   return (
-    <Accordion variant={variant} defaultExpanded={isDelegateCall}>
+    <Accordion variant={variant} expanded={expanded} onChange={onChange}>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
         <div className={css.summary}>
           <CodeIcon />


### PR DESCRIPTION
## What it solves

Resolves #1687

## How this PR fixes it

Multisend transactions now have a header that includes "Expand all" and "Collapse all" buttons that open/close all actions in the transaction.

## How to test it

Open a multisend transaction and observe that each action can be individually expanded/collapse, but now also all at once. When some are open and globally expanded/collapsed, no bugs should exist.

## Screenshots

![transaction-list](https://user-images.githubusercontent.com/20442784/226408784-268a5d93-bcbb-4164-b814-f7937dfbf9a4.gif)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻