### PR TITLE
Fix: sort Safe App tags

### DIFF
--- a/src/components/safe-apps/SafeAppCard/index.tsx
+++ b/src/components/safe-apps/SafeAppCard/index.tsx
@@ -159,7 +159,7 @@ const SafeAppCardListView = ({
 }: SafeAppCardViewProps) => {
   return (
     <SafeAppCardContainer safeAppUrl={safeAppUrl} onClickSafeApp={onClickSafeApp}>
-      <CardContent>
+      <CardContent sx={{ pb: '16px !important' }}>
         <Box display="flex" flexDirection="row" alignItems="center" gap={2}>
           <div className={css.safeAppIconContainer}>
             {/* Batch transactions Icon */}

--- a/src/components/safe-apps/SafeAppCard/styles.module.css
+++ b/src/components/safe-apps/SafeAppCard/styles.module.css
@@ -20,6 +20,10 @@
   position: relative;
 }
 
+.safeAppIconContainer iframe {
+  display: block;
+}
+
 .safeAppBatchIcon {
   position: absolute;
   top: -6px;

--- a/src/components/safe-apps/SafeAppList/index.tsx
+++ b/src/components/safe-apps/SafeAppList/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
 import classnames from 'classnames'
 
@@ -12,8 +12,7 @@ import SafeAppsZeroResultsPlaceholder from '@/components/safe-apps/SafeAppsZeroR
 import useSafeAppsFilters from '@/hooks/safe-apps/useSafeAppsFilters'
 import useSafeAppPreviewDrawer from '@/hooks/safe-apps/useSafeAppPreviewDrawer'
 import css from './styles.module.css'
-import { Box, Grid, Skeleton, Typography } from '@mui/material'
-import { getUniqueTags } from '../utils'
+import { Skeleton } from '@mui/material'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
 
 type SafeAppListProps = {
@@ -56,11 +55,6 @@ const SafeAppList = ({
     [openPreviewDrawer],
   )
 
-  // Get the list of categories from the safeAppsList
-  const categories: string[] = useMemo(() => {
-    return getUniqueTags(safeAppsList)
-  }, [safeAppsList])
-
   return (
     <>
       {/* Safe Apps Filters */}
@@ -81,75 +75,41 @@ const SafeAppList = ({
         setSafeAppsViewMode={setSafeAppsViewMode}
       />
 
-      {/* Categorized list */}
-      {!query && safeAppsViewMode !== GRID_VIEW_MODE ? (
-        categories.map((category) => {
-          const categoryApps = filteredApps.filter((app) => app.tags.includes(category))
+      {/* Safe Apps List */}
+      <ul
+        className={classnames(
+          css.safeAppsContainer,
+          safeAppsViewMode === GRID_VIEW_MODE ? css.safeAppsGridViewContainer : css.safeAppsListViewContainer,
+        )}
+      >
+        {/* Add Custom Safe App Card */}
+        {addCustomApp && (
+          <li>
+            <AddCustomSafeAppCard safeAppList={safeAppsList} onSave={addCustomApp} />
+          </li>
+        )}
 
-          return (
-            <Box key={category} pb={2}>
-              <h3>
-                {category}&nbsp;
-                <Typography component="span" variant="body2" sx={{ opacity: 0.4 }}>
-                  ({categoryApps.length})
-                </Typography>
-              </h3>
-
-              <Grid container spacing={2}>
-                {categoryApps.map((safeApp) => {
-                  return (
-                    <Grid item key={safeApp.id} xl={3} lg={4} sm={6} xs={12}>
-                      <SafeAppCard
-                        safeApp={safeApp}
-                        viewMode={safeAppsViewMode}
-                        isBookmarked={bookmarkedSafeAppsId?.has(safeApp.id)}
-                        onBookmarkSafeApp={onBookmarkSafeApp}
-                        removeCustomApp={removeCustomApp}
-                        onClickSafeApp={handleSafeAppClick(safeApp)}
-                      />
-                    </Grid>
-                  )
-                })}
-              </Grid>
-            </Box>
-          )
-        })
-      ) : (
-        <ul
-          className={classnames(
-            css.safeAppsContainer,
-            safeAppsViewMode === GRID_VIEW_MODE ? css.safeAppsGridViewContainer : css.safeAppsListViewContainer,
-          )}
-        >
-          {/* Add Custom Safe App Card */}
-          {addCustomApp && (
-            <li>
-              <AddCustomSafeAppCard safeAppList={safeAppsList} onSave={addCustomApp} />
-            </li>
-          )}
-
-          {safeAppsListLoading &&
-            Array.from({ length: 8 }, (_, index) => (
-              <li key={index}>
-                <Skeleton variant="rounded" height="271px" />
-              </li>
-            ))}
-
-          {/* Flat list filtered by search query */}
-          {filteredApps.map((safeApp) => (
-            <li key={safeApp.id}>
-              <SafeAppCard
-                safeApp={safeApp}
-                viewMode={safeAppsViewMode}
-                isBookmarked={bookmarkedSafeAppsId?.has(safeApp.id)}
-                onBookmarkSafeApp={onBookmarkSafeApp}
-                removeCustomApp={removeCustomApp}
-                onClickSafeApp={handleSafeAppClick(safeApp)}
-              />
+        {safeAppsListLoading &&
+          Array.from({ length: 8 }, (_, index) => (
+            <li key={index}>
+              <Skeleton variant="rounded" height="271px" />
             </li>
           ))}
-        </ul>
-      )}
+
+        {/* Flat list filtered by search query */}
+        {filteredApps.map((safeApp) => (
+          <li key={safeApp.id}>
+            <SafeAppCard
+              safeApp={safeApp}
+              viewMode={safeAppsViewMode}
+              isBookmarked={bookmarkedSafeAppsId?.has(safeApp.id)}
+              onBookmarkSafeApp={onBookmarkSafeApp}
+              removeCustomApp={removeCustomApp}
+              onClickSafeApp={handleSafeAppClick(safeApp)}
+            />
+          </li>
+        ))}
+      </ul>
 
       {/* Zero results placeholder */}
       {showZeroResultsPlaceholder && <SafeAppsZeroResultsPlaceholder searchQuery={query} />}

--- a/src/components/safe-apps/SafeAppList/index.tsx
+++ b/src/components/safe-apps/SafeAppList/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
 import classnames from 'classnames'
 
@@ -12,8 +12,9 @@ import SafeAppsZeroResultsPlaceholder from '@/components/safe-apps/SafeAppsZeroR
 import useSafeAppsFilters from '@/hooks/safe-apps/useSafeAppsFilters'
 import useSafeAppPreviewDrawer from '@/hooks/safe-apps/useSafeAppPreviewDrawer'
 import css from './styles.module.css'
-import { Box, Grid, Skeleton } from '@mui/material'
+import { Box, Grid, Skeleton, Typography } from '@mui/material'
 import { getUniqueTags } from '../utils'
+import useLocalStorage from '@/services/local-storage/useLocalStorage'
 
 type SafeAppListProps = {
   safeAppsList: SafeAppData[]
@@ -25,6 +26,8 @@ type SafeAppListProps = {
   removeCustomApp?: (safeApp: SafeAppData) => void
 }
 
+const VIEW_MODE_KEY = 'SafeApps_viewMode'
+
 const SafeAppList = ({
   safeAppsList,
   safeAppsListLoading,
@@ -34,7 +37,7 @@ const SafeAppList = ({
   addCustomApp,
   removeCustomApp,
 }: SafeAppListProps) => {
-  const [safeAppsViewMode, setSafeAppsViewMode] = useState<SafeAppsViewMode>(GRID_VIEW_MODE)
+  const [safeAppsViewMode = GRID_VIEW_MODE, setSafeAppsViewMode] = useLocalStorage<SafeAppsViewMode>(VIEW_MODE_KEY)
   const { isPreviewDrawerOpen, previewDrawerApp, openPreviewDrawer, closePreviewDrawer } = useSafeAppPreviewDrawer()
 
   const { filteredApps, query, setQuery, setSelectedCategories, setOptimizedWithBatchFilter, selectedCategories } =
@@ -85,7 +88,12 @@ const SafeAppList = ({
 
           return (
             <Box key={category} pb={2}>
-              <h3>{category}</h3>
+              <h3>
+                {category}&nbsp;
+                <Typography component="span" variant="body2" sx={{ opacity: 0.4 }}>
+                  ({categoryApps.length})
+                </Typography>
+              </h3>
 
               <Grid container spacing={2}>
                 {categoryApps.map((safeApp) => {

--- a/src/components/safe-apps/SafeAppsFilters/index.tsx
+++ b/src/components/safe-apps/SafeAppsFilters/index.tsx
@@ -18,7 +18,7 @@ import CloseIcon from '@mui/icons-material/Close'
 import type { SelectChangeEvent } from '@mui/material/Select'
 import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
 
-import { filterInternalCategories } from '@/components/safe-apps/utils'
+import { getUniqueTags } from '@/components/safe-apps/utils'
 import SearchIcon from '@/public/images/common/search.svg'
 import BatchIcon from '@/public/images/apps/batch-icon.svg'
 import css from './styles.module.css'
@@ -191,21 +191,8 @@ const categoryMenuProps = {
 }
 
 const getCategoryOptions = (safeAppList: SafeAppData[]): safeAppCatogoryOptionType[] => {
-  return safeAppList.reduce<safeAppCatogoryOptionType[]>((categoryOptions, safeApp) => {
-    // we filter internal categories
-    const categories = filterInternalCategories(safeApp.tags)
-
-    // avoid repeated categories
-    const removeRepeatedCategories = categories.filter(
-      (category) => !categoryOptions.some((option) => option.value === category),
-    )
-
-    // from string[] to Object[] (label & value)
-    const newCategoryOptions = removeRepeatedCategories.map((category) => ({
-      label: category,
-      value: category,
-    }))
-
-    return [...categoryOptions, ...newCategoryOptions]
-  }, [])
+  return getUniqueTags(safeAppList).map((category) => ({
+    label: category,
+    value: category,
+  }))
 }

--- a/src/components/safe-apps/SafeAppsListHeader/index.tsx
+++ b/src/components/safe-apps/SafeAppsListHeader/index.tsx
@@ -9,6 +9,7 @@ import ListViewIcon from '@/public/images/apps/list-view-icon.svg'
 import { GRID_VIEW_MODE, LIST_VIEW_MODE } from '@/components/safe-apps/SafeAppCard'
 import type { SafeAppsViewMode } from '@/components/safe-apps/SafeAppCard'
 import css from './styles.module.css'
+import { SAFE_APPS_EVENTS, trackEvent } from '@/services/analytics'
 
 type SafeAppsListHeaderProps = {
   amount?: number
@@ -31,7 +32,8 @@ const SafeAppsListHeader = ({ amount, safeAppsViewMode, setSafeAppsViewMode }: S
           aria-label="safe apps view mode selector"
           name="safe-apps-view-mode"
           sx={{ flexDirection: 'row' }}
-          onChange={(e, viewMode) => {
+          onChange={(_, viewMode) => {
+            trackEvent({ ...SAFE_APPS_EVENTS.SWITCH_LIST_VIEW, label: viewMode })
             setSafeAppsViewMode(viewMode as SafeAppsViewMode)
           }}
         >

--- a/src/components/safe-apps/utils.ts
+++ b/src/components/safe-apps/utils.ts
@@ -98,3 +98,18 @@ export const filterInternalCategories = (categories: string[]): string[] => {
   const internalCategories = Object.values(SafeAppsTag)
   return categories.filter((tag) => !internalCategories.some((internalCategory) => tag === internalCategory))
 }
+
+// Get unique tags from all apps
+export const getUniqueTags = (apps: SafeAppData[]): string[] => {
+  // Get the list of categories from the safeAppsList
+  const tags = apps.reduce<Set<string>>((result, app) => {
+    app.tags.forEach((tag) => result.add(tag))
+    return result
+  }, new Set())
+
+  // Filter out internal tags
+  const filteredTags = filterInternalCategories(Array.from(tags))
+
+  // Sort alphabetically
+  return filteredTags.sort()
+}

--- a/src/services/analytics/events/safeApps.ts
+++ b/src/services/analytics/events/safeApps.ts
@@ -58,6 +58,12 @@ export const SAFE_APPS_EVENTS = {
     ...SAFE_APPS_EVENT_DATA,
     action: 'Open shared app after Safe creation',
   },
+  SWITCH_LIST_VIEW: {
+    ...SAFE_APPS_EVENT_DATA,
+    action: 'Switch list view',
+  },
+
+  // SDK
   SAFE_APP_SDK_METHOD_CALL: {
     ...SAFE_APPS_EVENT_DATA,
     category: SAFE_APPS_SDK_CATEGORY,


### PR DESCRIPTION
## What it solves

Resolves #1788

## How this PR fixes it

Sorts the tags alphabetically.

<img width="342" alt="Screenshot 2023-03-22 at 08 19 37" src="https://user-images.githubusercontent.com/381895/226829346-2653cd26-8132-424f-92e0-0e7feff28baa.png">

## How to test it
Check that the categories select is sorted.

## Other changes
Unrelated to tags, I've also added tracking on the grid/list view toggle. There should be a new event when you click on one of these: 
<img width="56" alt="Screenshot 2023-03-22 at 09 38 30" src="https://user-images.githubusercontent.com/381895/226846551-ccc957be-f1d8-453f-8731-e48719e11b47.png">
These buttons will now also remember the last view choice.