### PR TITLE
fix: support tokens with no decimals

### DIFF
--- a/src/components/tx/modals/TokenTransferModal/ReviewMultisigTx.tsx
+++ b/src/components/tx/modals/TokenTransferModal/ReviewMultisigTx.tsx
@@ -20,7 +20,7 @@ const ReviewMultisigTx = ({ params, onSubmit }: TokenTransferModalProps): ReactE
 
   // Create a safeTx
   const [safeTx, safeTxError] = useAsync<SafeTransaction>(() => {
-    if (!address || !decimals) return
+    if (!address || typeof decimals === 'undefined') return
     const txParams = createTokenTransferParams(params.recipient, params.amount, decimals, address)
     return createTx(txParams, params.txNonce)
   }, [params, decimals, address, createTx])

--- a/src/utils/__tests__/validation.test.ts
+++ b/src/utils/__tests__/validation.test.ts
@@ -57,9 +57,12 @@ describe('validation', () => {
 
   describe('Limited amount validation', () => {
     it('returns an error if its not a number', () => {
-      const result = validateLimitedAmount('abc', 18, '100')
+      const result1 = validateLimitedAmount('abc', 18, '100')
+      expect(result1).toBe('The value must be a number')
 
-      expect(result).toBe('The value must be a number')
+      // No decimals
+      const result2 = validateLimitedAmount('abc', 0, '100')
+      expect(result2).toBe('The value must be a number')
     })
 
     it('returns an error if its a number smaller than or equal 0', () => {
@@ -68,11 +71,22 @@ describe('validation', () => {
 
       const result2 = validateLimitedAmount('-1', 18, '100')
       expect(result2).toBe('The value must be greater than 0')
+
+      // No decimals
+      const result3 = validateLimitedAmount('0', 0, '100')
+      expect(result3).toBe('The value must be greater than 0')
+
+      const result4 = validateLimitedAmount('-1', 0, '100')
+      expect(result4).toBe('The value must be greater than 0')
     })
 
     it('returns an error if its larger than the max', () => {
-      const result = validateLimitedAmount('101', 18, '100000000000000000000')
-      expect(result).toBe('Maximum value is 100')
+      const result1 = validateLimitedAmount('101', 18, '100000000000000000000')
+      expect(result1).toBe('Maximum value is 100')
+
+      // No decimals
+      const result2 = validateLimitedAmount('101', 18, '100000000000000000000')
+      expect(result2).toBe('Maximum value is 100')
     })
   })
 

--- a/src/utils/__tests__/validation.test.ts
+++ b/src/utils/__tests__/validation.test.ts
@@ -100,14 +100,15 @@ describe('validation', () => {
     })
 
     it('returns an error if there are too many decimals', () => {
-      const result = validateDecimalLength('1.123', 2)
+      const result1 = validateDecimalLength('1.123', 2)
+      expect(result1).toBe('Should have 1 to 2 decimals')
 
-      expect(result).toBe('Should have 1 to 2 decimals')
+      const result2 = validateDecimalLength('1.2', 0)
+      expect(result2).toBe('Should not have decimals')
     })
 
     it('returns undefined if no maximum length is given', () => {
       const result = validateDecimalLength('1.123')
-
       expect(result).toBeUndefined()
     })
 
@@ -123,6 +124,9 @@ describe('validation', () => {
 
       const result2 = validateDecimalLength('1.234', 18, 3)
       expect(result2).toBeUndefined()
+
+      const result3 = validateDecimalLength('1', 0)
+      expect(result3).toBeUndefined()
     })
   })
 })

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -70,8 +70,12 @@ export const validateLimitedAmount = (amount: string, decimals?: number, max?: s
 }
 
 export const validateDecimalLength = (value: string, maxLen?: number, minLen = 1) => {
-  if (!maxLen || !value.includes('.')) {
+  if (typeof maxLen === 'undefined' || !value.includes('.')) {
     return
+  }
+
+  if (maxLen === 0) {
+    return 'Should not have decimals'
   }
 
   const decimals = value.split('.')[1] || ''

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -57,7 +57,7 @@ export const validateAmount = (amount?: string) => {
 }
 
 export const validateLimitedAmount = (amount: string, decimals?: number, max?: string) => {
-  if (!decimals || !max) return
+  if (typeof decimals === 'undefined' || !max) return
 
   const numberError = validateAmount(amount)
   if (numberError) {


### PR DESCRIPTION
## What it solves

Resolves https://github.com/5afe/safe-support/issues/158

## How this PR fixes it

Tokens with `0` decimals are now successfully created. Token amount validation also works, e.g.: negative, 0 and above the supported amount.

## How to test it

1. Impersonate `eth:0x98329910449586BA244d9edEa97496f8ccf1C6Be`.
2. Create a new transaction with the "Smooth Love Potion" token and observe that all valid amounts can be entered and all invalid amounts error.
3. When a valid amount was entered, the transaction successfully loads on the review screen.

## Screenshots

![slp-token](https://user-images.githubusercontent.com/20442784/226855767-6bbd2e8b-c6d7-407b-89a3-28f26aa27de0.gif)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
