### PR TITLE
fix: DateTime jest test

### DIFF
--- a/src/components/common/DateTime/index.test.tsx
+++ b/src/components/common/DateTime/index.test.tsx
@@ -9,6 +9,16 @@ jest.mock('@/utils/tx-history-filter', () => ({
 }))
 
 describe('DateTime', () => {
+  beforeAll(() => {
+    // If we do not use a fixed date, this test will fail once a year (in some timezones) due to daylight saving time.
+    jest.useFakeTimers()
+    jest.setSystemTime(Date.parse('01.01.2023'))
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
   it('should render the relative time before threshold on the queue', () => {
     const date = new Date()
     const days = 3


### PR DESCRIPTION
## What it solves
DateTime jest test failed during switch to daylight savings time.


Resolves #1803 

## How this PR fixes it
The test now mocks the system time to a fixed date time.

## How to test it
`yarn test`


## Checklist
* [X] I've tested the branch on mobile 📱
* [X] I've documented how it affects the analytics (if at all) 📊
* [X] I've written a unit/e2e test for it (if applicable) 🧑‍💻
