### PR TITLE
fix: Token list layout on mobile screens

### DIFF
--- a/src/components/balances/HiddenTokenButton/index.tsx
+++ b/src/components/balances/HiddenTokenButton/index.tsx
@@ -22,10 +22,9 @@ const HiddenTokenButton = ({
     balances.items?.filter((item) => currentHiddenAssets.includes(item.tokenInfo.address)).length || 0
 
   return (
-    <div>
+    <div className={css.hiddenTokenButton}>
       <Track {...ASSETS_EVENTS.SHOW_HIDDEN_ASSETS}>
         <Button
-          className={css.hiddenTokenButton}
           sx={{
             gap: 1,
             padding: 1,

--- a/src/pages/balances/index.tsx
+++ b/src/pages/balances/index.tsx
@@ -13,6 +13,8 @@ import HiddenTokenButton from '@/components/balances/HiddenTokenButton'
 import CurrencySelect from '@/components/balances/CurrencySelect'
 import TokenListSelect from '@/components/balances/TokenListSelect'
 
+import css from './styles.module.css'
+
 const Balances: NextPage = () => {
   const { error } = useBalances()
   const [showHiddenAssets, setShowHiddenAssets] = useState(false)
@@ -25,14 +27,14 @@ const Balances: NextPage = () => {
       </Head>
 
       <AssetsHeader>
-        <Box display="flex" flexDirection="row" alignItems="center" gap={1}>
+        <Box className={css.assetsHeader}>
           <HiddenTokenButton showHiddenAssets={showHiddenAssets} toggleShowHiddenAssets={toggleShowHiddenAssets} />
           <TokenListSelect />
           <CurrencySelect />
         </Box>
       </AssetsHeader>
 
-      <main>
+      <main className={css.contentWrapper}>
         {error ? (
           <PagePlaceholder img={<NoAssetsIcon />} text="There was an error loading your assets" />
         ) : (

--- a/src/pages/balances/styles.module.css
+++ b/src/pages/balances/styles.module.css
@@ -1,0 +1,16 @@
+.assetsHeader {
+  display: flex;
+  gap: var(--space-1);
+  align-items: center;
+}
+
+@media (max-width: 600px) {
+  .assetsHeader {
+    position: absolute;
+    bottom: -56px;
+  }
+
+  .contentWrapper {
+    margin-top: 56px;
+  }
+}


### PR DESCRIPTION
## What it solves

Resolves #1732 

## How this PR fixes it

- Moves the token list select to the next row on smaller screens

## How to test it

1. Open a Safe on Mainnet with a mobile viewport (< 600px)
2. Navigate to Assets
3. Observe the buttons don't overlap anymore

## Screenshots
<img width="518" alt="Screenshot 2023-03-27 at 13 07 05" src="https://user-images.githubusercontent.com/5880855/227924677-2cdaf1a0-fcb4-48cd-8443-d3d869d699df.png">

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
