### PR TITLE
feat: show alert for new versions in settings

### DIFF
--- a/src/components/settings/ContractVersion/UpdateSafeDialog.tsx
+++ b/src/components/settings/ContractVersion/UpdateSafeDialog.tsx
@@ -35,7 +35,7 @@ const UpdateSafeDialog = () => {
       <CheckWallet>
         {(isOk) => (
           <Button onClick={() => setOpen(true)} variant="contained" disabled={!isOk}>
-            Update Safe
+            Update
           </Button>
         )}
       </CheckWallet>

--- a/src/components/settings/ContractVersion/index.tsx
+++ b/src/components/settings/ContractVersion/index.tsx
@@ -35,7 +35,10 @@ export const ContractVersion = () => {
       <Box mt={2}>
         {safeLoaded ? (
           showUpdateDialog ? (
-            <Alert icon={<SvgIcon component={InfoIcon} inheritViewBox />}>
+            <Alert
+              sx={{ borderRadius: '2px', borderColor: '#B0FFC9' }}
+              icon={<SvgIcon component={InfoIcon} inheritViewBox color="secondary" />}
+            >
               <AlertTitle sx={{ fontWeight: 700 }}>New version is available: {LATEST_SAFE_VERSION}</AlertTitle>
               <Typography mb={3}>
                 Update now to take advantage of new features and the highest security standards available. You will need

--- a/src/components/settings/ContractVersion/index.tsx
+++ b/src/components/settings/ContractVersion/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Box, SvgIcon, Typography, Alert, AlertTitle } from '@mui/material'
+import { Box, SvgIcon, Typography, Alert, AlertTitle, Skeleton } from '@mui/material'
 import { ImplementationVersionState } from '@safe-global/safe-gateway-typescript-sdk'
 import { LATEST_SAFE_VERSION } from '@/config/constants'
 import { sameAddress } from '@/utils/addresses'
@@ -13,7 +13,7 @@ import UpdateSafeDialog from './UpdateSafeDialog'
 import ExternalLink from '@/components/common/ExternalLink'
 export const ContractVersion = () => {
   const [masterCopies] = useMasterCopies()
-  const { safe } = useSafeInfo()
+  const { safe, safeLoaded } = useSafeInfo()
   const masterCopyAddress = safe.implementation.value
 
   const safeMasterCopy: MasterCopy | undefined = useMemo(() => {
@@ -30,24 +30,26 @@ export const ContractVersion = () => {
       </Typography>
 
       <Typography variant="body1" fontWeight={400}>
-        {safe.version ? safe.version : 'Unsupported contract'}
+        {safeLoaded ? safe.version ? safe.version : 'Unsupported contract' : <Skeleton width="60px" />}
       </Typography>
       <Box mt={2}>
-        {showUpdateDialog ? (
-          <Alert icon={<SvgIcon component={InfoIcon} inheritViewBox />}>
-            <AlertTitle sx={{ fontWeight: 700 }}>New version is available: {LATEST_SAFE_VERSION}</AlertTitle>
-            <Typography mb={3}>
-              Update now to take advantage of new features and the highest security standards available. You will need
-              to confirm this update just like any other transaction.{' '}
-              <ExternalLink href={safeMasterCopy?.deployerRepoUrl}>GitHub</ExternalLink>
+        {safeLoaded ? (
+          showUpdateDialog ? (
+            <Alert icon={<SvgIcon component={InfoIcon} inheritViewBox />}>
+              <AlertTitle sx={{ fontWeight: 700 }}>New version is available: {LATEST_SAFE_VERSION}</AlertTitle>
+              <Typography mb={3}>
+                Update now to take advantage of new features and the highest security standards available. You will need
+                to confirm this update just like any other transaction.{' '}
+                <ExternalLink href={safeMasterCopy?.deployerRepoUrl}>GitHub</ExternalLink>
+              </Typography>
+              <UpdateSafeDialog />
+            </Alert>
+          ) : (
+            <Typography display="flex" alignItems="center">
+              <CheckCircleIcon color="primary" sx={{ mr: 0.5 }} /> Latest version
             </Typography>
-            <UpdateSafeDialog />
-          </Alert>
-        ) : (
-          <Typography display="flex" alignItems="center">
-            <CheckCircleIcon color="primary" sx={{ mr: 0.5 }} /> Latest version
-          </Typography>
-        )}
+          )
+        ) : null}
       </Box>
     </>
   )

--- a/src/components/settings/ContractVersion/index.tsx
+++ b/src/components/settings/ContractVersion/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Box, SvgIcon, Typography } from '@mui/material'
+import { Box, SvgIcon, Typography, Alert, AlertTitle } from '@mui/material'
 import { ImplementationVersionState } from '@safe-global/safe-gateway-typescript-sdk'
 import { LATEST_SAFE_VERSION } from '@/config/constants'
 import { sameAddress } from '@/utils/addresses'
@@ -11,8 +11,6 @@ import InfoIcon from '@/public/images/notifications/info.svg'
 
 import UpdateSafeDialog from './UpdateSafeDialog'
 import ExternalLink from '@/components/common/ExternalLink'
-import Tooltip from '@mui/material/Tooltip'
-
 export const ContractVersion = () => {
   const [masterCopies] = useMasterCopies()
   const { safe } = useSafeInfo()
@@ -23,11 +21,7 @@ export const ContractVersion = () => {
   }, [masterCopies, masterCopyAddress])
 
   const needsUpdate = safe.implementationVersionState === ImplementationVersionState.OUTDATED
-  const latestMasterContractVersion = LATEST_SAFE_VERSION
   const showUpdateDialog = safeMasterCopy?.deployer === MasterCopyDeployer.GNOSIS && needsUpdate
-  const getSafeVersionUpdate = () => {
-    return showUpdateDialog ? ` (there's a newer version: ${latestMasterContractVersion})` : ''
-  }
 
   return (
     <>
@@ -35,45 +29,20 @@ export const ContractVersion = () => {
         Contract version
       </Typography>
 
-      {safe.version ? (
-        <ExternalLink href={safeMasterCopy?.deployerRepoUrl}>
-          {safe.version}
-          {getSafeVersionUpdate()}
-        </ExternalLink>
-      ) : (
-        <Typography variant="body1" fontWeight={400}>
-          Unsupported contract
-        </Typography>
-      )}
-
+      <Typography variant="body1" fontWeight={400}>
+        {safe.version ? safe.version : 'Unsupported contract'}
+      </Typography>
       <Box mt={2}>
         {showUpdateDialog ? (
-          <Box display="flex" alignItems="center" gap={2}>
-            <UpdateSafeDialog />
-
-            <Typography display="flex" alignItems="center">
-              Why should I upgrade?
-              <Tooltip
-                title="Update now to take advantage of new features and the highest security standards available.
-  You will need to confirm this update just like any other transaction."
-                placement="right"
-                arrow
-              >
-                <span>
-                  <SvgIcon
-                    component={InfoIcon}
-                    inheritViewBox
-                    fontSize="small"
-                    color="border"
-                    sx={{
-                      verticalAlign: 'middle',
-                      ml: 0.5,
-                    }}
-                  />
-                </span>
-              </Tooltip>
+          <Alert icon={<SvgIcon component={InfoIcon} inheritViewBox />}>
+            <AlertTitle sx={{ fontWeight: 700 }}>New version is available: {LATEST_SAFE_VERSION}</AlertTitle>
+            <Typography mb={3}>
+              Update now to take advantage of new features and the highest security standards available. You will need
+              to confirm this update just like any other transaction.{' '}
+              <ExternalLink href={safeMasterCopy?.deployerRepoUrl}>GitHub</ExternalLink>
             </Typography>
-          </Box>
+            <UpdateSafeDialog />
+          </Alert>
         ) : (
           <Typography display="flex" alignItems="center">
             <CheckCircleIcon color="primary" sx={{ mr: 0.5 }} /> Latest version

--- a/src/pages/settings/setup.tsx
+++ b/src/pages/settings/setup.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
-import { Grid, Paper, SvgIcon, Tooltip, Typography } from '@mui/material'
+import { Grid, Paper, Skeleton, SvgIcon, Tooltip, Typography } from '@mui/material'
 import InfoIcon from '@/public/images/notifications/info.svg'
 import { ContractVersion } from '@/components/settings/ContractVersion'
 import { OwnerList } from '@/components/settings/owner/OwnerList'
@@ -9,7 +9,7 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import SettingsHeader from '@/components/settings/SettingsHeader'
 
 const Setup: NextPage = () => {
-  const { safe } = useSafeInfo()
+  const { safe, safeLoaded } = useSafeInfo()
   const nonce = safe.nonce
   const ownerLength = safe.owners.length
   const threshold = safe.threshold
@@ -45,7 +45,8 @@ const Setup: NextPage = () => {
               </Typography>
 
               <Typography pt={1}>
-                Current nonce: <b>{nonce}</b>
+                Current nonce:{' '}
+                {safeLoaded ? <b>{nonce}</b> : <Skeleton width="30px" sx={{ display: 'inline-block' }} />}
               </Typography>
             </Grid>
 


### PR DESCRIPTION
## What it solves

Resolves #1786

## How this PR fixes it

This adds a clearer overview of newer Safe versions in the settings.

Note: "Update" was used instead of "Upgrade" as we use that term throughout the app and the `Alert` style matches that of the others in the app, which is why it differs slightly from [the design](https://www.figma.com/file/ptTs6lDBeUuLNySroJ5PiF/Web-Master-File?node-id=501-11610&t=9g8AQ8txlqQ6WCF4-0).

![image](https://user-images.githubusercontent.com/20442784/227958547-aaba9e60-0189-4a07-a3e4-f51db358e713.png)

## How to test it

- Open a Safe that is up-to-date and observe the standard checkmark.
- Open an outdated Safe and obsert the new information.

## Screenshots

### Correct colours

![image](https://user-images.githubusercontent.com/20442784/228524657-3354db67-ca84-4bbf-8f7d-10bbebadf62e.png)

![image](https://user-images.githubusercontent.com/20442784/228524674-4ddb4525-12a2-4477-81f4-3270bc0686d2.png)

### Wrong colours but showcasing layout

![skeletons](https://user-images.githubusercontent.com/20442784/227978960-1f08f558-c080-4f65-a1de-a4f4901d67aa.gif)

![image](https://user-images.githubusercontent.com/20442784/227958760-e97ff3b5-63bb-4435-adb1-5fe77911e993.png)

![image](https://user-images.githubusercontent.com/20442784/227958679-d772f7f4-785f-4bcc-b5db-d1087d41c937.png)

![image](https://user-images.githubusercontent.com/20442784/227958329-8157c8db-0f12-4f4c-babd-6738d8eef395.png)

![image](https://user-images.githubusercontent.com/20442784/227958388-63e04980-e580-4d01-affe-0e0d9be06dbe.png)

![image](https://user-images.githubusercontent.com/20442784/227958492-a657fcf6-90d7-45ba-ba61-3cbb659f8a9b.png)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻