### PR TITLE
fix: rejection transaction description + link text

### DIFF
--- a/src/components/transactions/TxDetails/TxData/Rejection/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/Rejection/index.tsx
@@ -11,11 +11,13 @@ interface Props {
 
 const RejectionTxInfo = ({ nonce, isTxExecuted }: Props) => {
   const txNonce = nonce ?? NOT_AVAILABLE
-  const message = `This is an on-chain rejection that didn't send any funds. ${
+  const message = `This is an on-chain rejection that ${isTxExecuted ? "didn't" : "won't"} send any funds. ${
     isTxExecuted
       ? `This on-chain rejection replaced all transactions with nonce ${txNonce}.`
       : `Executing this on-chain rejection will replace all currently awaiting transactions with nonce ${txNonce}.`
   }`
+
+  const title = 'Why do I need to pay to reject a transaction?'
 
   return (
     <>
@@ -24,12 +26,10 @@ const RejectionTxInfo = ({ nonce, isTxExecuted }: Props) => {
         <Box mt={2} sx={{ width: 'fit-content' }}>
           <ExternalLink
             href="https://help.safe.global/en/articles/4738501-why-do-i-need-to-pay-for-cancelling-a-transaction"
-            title="Why do I need to pay for rejecting a transaction?"
+            title={title}
           >
             <Box sx={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-              <Typography sx={{ textDecoration: 'underline' }}>
-                Why do I need to pay for rejecting a transaction?
-              </Typography>
+              <Typography sx={{ textDecoration: 'underline' }}>{title}</Typography>
             </Box>
           </ExternalLink>
         </Box>


### PR DESCRIPTION
## What it solves

Resolves wrong text

## How this PR fixes it

The description of rejection transactions and the link to the relative help article have been adjusted.

## How to test it

Queue a rejection transaction and observe the following, with an updated description after executing it.

The description should read (relative to queue and history):

"This is an on-chain rejection that won't send any funds. Executing this on-chain rejection will replace all currently awaiting transactions with nonce n."
"This is an on-chain rejection that did't send any funds. This on-chain rejection replaced all transactions with nonce n."

The help article link text should read:

"Why do I need to pay to reject a transaction?"

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/228827971-77236cd6-69e7-4e65-9e2b-84b4d3bac555.png)

![image](https://user-images.githubusercontent.com/20442784/228828078-307421b3-a675-4dc3-9665-016a0f581251.png)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
