### PR TITLE
fix: Remove overlap of address and balance in safe list sidebar

### DIFF
--- a/src/components/sidebar/SafeListItem/index.tsx
+++ b/src/components/sidebar/SafeListItem/index.tsx
@@ -94,7 +94,7 @@ const SafeListItem = ({
             <SafeIcon address={address} {...rest} />
           </ListItemIcon>
           <ListItemText
-            sx={noActions ? undefined : { pr: 10 }}
+            sx={noActions ? undefined : { pr: 13 }}
             primaryTypographyProps={{
               variant: 'body2',
               component: 'div',

--- a/src/components/sidebar/SafeListItem/styles.module.css
+++ b/src/components/sidebar/SafeListItem/styles.module.css
@@ -28,9 +28,3 @@
 .withPendingButtons :global .MuiListItemSecondaryAction-root {
   right: 74px;
 }
-
-@media (max-width: 400px) {
-  .withPendingButtons :global .MuiListItemSecondaryAction-root {
-    right: 48px;
-  }
-}


### PR DESCRIPTION
## What it solves

Resolves #1492 

## How this PR fixes it

- Increases padding-right of address element to cover long balance values

## How to test it

1. Open the Safe
2. Add a safe that has a balance of native tokens < 0.00001
3. Observe no overlap in the sidebar on mobile screens

## Screenshots
<img width="396" alt="Screenshot 2023-03-30 at 16 30 30" src="https://user-images.githubusercontent.com/5880855/228871695-b6ebec4b-cea9-4823-850e-9f70a9a93870.png">

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
