### PR TITLE
refactor: split create safe callbacks

### DIFF
--- a/src/components/new-safe/create/logic/index.test.ts
+++ b/src/components/new-safe/create/logic/index.test.ts
@@ -5,7 +5,7 @@ import * as web3 from '@/hooks/wallets/web3'
 import type { TransactionReceipt } from '@ethersproject/abstract-provider'
 import {
   checkSafeCreationTx,
-  createNewSafeViaRelayer,
+  relaySafeCreation,
   handleSafeCreationError,
 } from '@/components/new-safe/create/logic/index'
 import { ErrorCode } from '@ethersproject/logger'
@@ -251,7 +251,7 @@ describe('createNewSafeViaRelayer', () => {
       expectedSaltNonce,
     ])
 
-    const taskId = await createNewSafeViaRelayer(mockChainInfo, [owner1, owner2], expectedThreshold, expectedSaltNonce)
+    const taskId = await relaySafeCreation(mockChainInfo, [owner1, owner2], expectedThreshold, expectedSaltNonce)
 
     expect(taskId).toEqual('0x123')
     expect(sponsoredCallSpy).toHaveBeenCalledTimes(1)
@@ -267,6 +267,6 @@ describe('createNewSafeViaRelayer', () => {
 
     jest.spyOn(sponsoredCall, 'sponsoredCall').mockRejectedValue(relayFailedError)
 
-    expect(createNewSafeViaRelayer(mockChainInfo, [owner1, owner2], 1, 69)).rejects.toEqual(relayFailedError)
+    expect(relaySafeCreation(mockChainInfo, [owner1, owner2], 1, 69)).rejects.toEqual(relayFailedError)
   })
 })

--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -112,16 +112,18 @@ export const encodeSafeCreationTx = ({
  */
 export const getSafeCreationTxInfo = async (
   provider: Web3Provider,
-  params: NewSafeFormData,
+  owners: NewSafeFormData['owners'],
+  threshold: NewSafeFormData['threshold'],
+  saltNonce: NewSafeFormData['saltNonce'],
   chain: ChainInfo,
   wallet: ConnectedWallet,
 ): Promise<PendingSafeTx> => {
   const proxyContract = getProxyFactoryContractInstance(chain.chainId)
 
   const data = encodeSafeCreationTx({
-    owners: params.owners.map((owner) => owner.address),
-    threshold: params.threshold,
-    saltNonce: params.saltNonce,
+    owners: owners.map((owner) => owner.address),
+    threshold,
+    saltNonce,
     chain,
   })
 
@@ -265,12 +267,7 @@ export const getRedirect = (
   return redirectUrl + `${appendChar}safe=${address}`
 }
 
-export const createNewSafeViaRelayer = async (
-  chain: ChainInfo,
-  owners: string[],
-  threshold: number,
-  saltNonce: number,
-) => {
+export const relaySafeCreation = async (chain: ChainInfo, owners: string[], threshold: number, saltNonce: number) => {
   const proxyFactory = getProxyFactoryContractInstance(chain.chainId)
   const proxyFactoryAddress = proxyFactory.getAddress()
   const fallbackHandlerDeployment = getFallbackHandlerContractInstance(chain.chainId)

--- a/src/components/new-safe/create/steps/StatusStep/__tests__/useSafeCreation.test.ts
+++ b/src/components/new-safe/create/steps/StatusStep/__tests__/useSafeCreation.test.ts
@@ -216,7 +216,7 @@ describe('useSafeCreation', () => {
   })
 
   it('should set a PROCESSING state and monitor relay taskId after successfully tx relay', async () => {
-    jest.spyOn(logic, 'createNewSafeViaRelayer').mockResolvedValue('0x456')
+    jest.spyOn(logic, 'relaySafeCreation').mockResolvedValue('0x456')
 
     const txMonitorSpy = jest.spyOn(txMonitor, 'waitForCreateSafeTx').mockImplementation(jest.fn())
 

--- a/src/components/new-safe/create/steps/StatusStep/index.tsx
+++ b/src/components/new-safe/create/steps/StatusStep/index.tsx
@@ -39,7 +39,7 @@ export const CreateSafeStatus = ({ data, setProgressColor }: StepRenderProps<New
   const isWrongChain = useIsWrongChain()
   const isConnected = wallet && !isWrongChain
 
-  const { createSafe } = useSafeCreation(pendingSafe, setPendingSafe, status, setStatus, data.willRelay)
+  const { handleCreateSafe } = useSafeCreation(pendingSafe, setPendingSafe, status, setStatus, data.willRelay)
 
   useSafeCreationEffects({
     pendingSafe,
@@ -53,10 +53,10 @@ export const CreateSafeStatus = ({ data, setProgressColor }: StepRenderProps<New
     router.push(AppRoutes.welcome)
   }, [router, setPendingSafe])
 
-  const onCreate = useCallback(() => {
+  const handleRetry = useCallback(() => {
     setStatus(SafeCreationStatus.AWAITING)
-    void createSafe()
-  }, [createSafe, setStatus])
+    void handleCreateSafe()
+  }, [handleCreateSafe])
 
   const onFinish = useCallback(() => {
     trackEvent(CREATE_SAFE_EVENTS.GET_STARTED)
@@ -129,7 +129,7 @@ export const CreateSafeStatus = ({ data, setProgressColor }: StepRenderProps<New
                   title={!isConnected ? 'Please make sure your wallet is connected on the correct network.' : ''}
                 >
                   <Typography display="flex" height={1}>
-                    <Button onClick={onCreate} variant="contained" disabled={!isConnected}>
+                    <Button onClick={handleRetry} variant="contained" disabled={!isConnected}>
                       Retry
                     </Button>
                   </Typography>

--- a/src/components/new-safe/create/steps/StatusStep/useSafeCreation.ts
+++ b/src/components/new-safe/create/steps/StatusStep/useSafeCreation.ts
@@ -5,7 +5,7 @@ import { useCurrentChain } from '@/hooks/useChains'
 import useWallet from '@/hooks/wallets/useWallet'
 import type { EthersError } from '@/utils/ethers-utils'
 import type { PendingSafeData } from '@/components/new-safe/create/steps/StatusStep/index'
-import type { PendingSafeTx } from '@/components/new-safe/create/types'
+import type { NamedAddress, PendingSafeTx } from '@/components/new-safe/create/types'
 import {
   createNewSafe,
   getSafeDeployProps,
@@ -14,7 +14,7 @@ import {
   handleSafeCreationError,
   SAFE_CREATION_ERROR_KEY,
   showSafeCreationError,
-  createNewSafeViaRelayer,
+  relaySafeCreation,
 } from '@/components/new-safe/create/logic'
 import { useAppDispatch } from '@/store'
 import { closeByGroupKey } from '@/store/notificationsSlice'
@@ -58,18 +58,12 @@ export const useSafeCreation = (
     [setStatus, setPendingSafe],
   )
 
-  const createSafe = useCallback(async () => {
-    if (!pendingSafe || !provider || !chain || !wallet || isCreating) return
+  const createSafeViaRelayer = useCallback(
+    async (ownersAddresses: string[], threshold: number, saltNonce: number) => {
+      if (!chain) return
 
-    setIsCreating(true)
-    dispatch(closeByGroupKey({ groupKey: SAFE_CREATION_ERROR_KEY }))
-
-    const { owners, threshold, saltNonce } = pendingSafe
-    const ownersAddresses = owners.map((owner) => owner.address)
-
-    if (willRelay) {
       try {
-        const taskId = await createNewSafeViaRelayer(chain, ownersAddresses, threshold, saltNonce)
+        const taskId = await relaySafeCreation(chain, ownersAddresses, threshold, saltNonce)
 
         setPendingSafe((prev) => (prev ? { ...prev, taskId } : undefined))
         setStatus(SafeCreationStatus.PROCESSING)
@@ -78,14 +72,21 @@ export const useSafeCreation = (
         setStatus(SafeCreationStatus.ERROR)
         showSafeCreationError(error as Error)
       }
-    } else {
+    },
+    [chain, setPendingSafe, setStatus],
+  )
+
+  const createSafe = useCallback(
+    async (owners: NamedAddress[], threshold: number, saltNonce: number) => {
+      if (!provider || !chain || !wallet) return
+
       try {
-        const tx = await getSafeCreationTxInfo(provider, pendingSafe, chain, wallet)
+        const tx = await getSafeCreationTxInfo(provider, owners, threshold, saltNonce, chain, wallet)
 
         const safeParams = getSafeDeployProps(
           {
             threshold,
-            owners: ownersAddresses,
+            owners: owners.map((owner) => owner.address),
             saltNonce,
           },
           (txHash) => createSafeCallback(txHash, tx),
@@ -104,21 +105,29 @@ export const useSafeCreation = (
           dispatch(showSafeCreationError(_err))
         }
       }
+
+      setIsCreating(false)
+    },
+    [chain, createSafeCallback, dispatch, provider, setStatus, wallet],
+  )
+
+  const handleCreateSafe = useCallback(() => {
+    if (!pendingSafe || isCreating) return
+
+    setIsCreating(true)
+    dispatch(closeByGroupKey({ groupKey: SAFE_CREATION_ERROR_KEY }))
+
+    const { owners, threshold, saltNonce } = pendingSafe
+    const ownersAddresses = owners.map((owner) => owner.address)
+
+    if (willRelay) {
+      void createSafeViaRelayer(ownersAddresses, threshold, saltNonce)
+    } else {
+      void createSafe(owners, threshold, saltNonce)
     }
 
     setIsCreating(false)
-  }, [
-    chain,
-    createSafeCallback,
-    dispatch,
-    isCreating,
-    pendingSafe,
-    provider,
-    setPendingSafe,
-    setStatus,
-    wallet,
-    willRelay,
-  ])
+  }, [createSafe, createSafeViaRelayer, dispatch, isCreating, pendingSafe, willRelay])
 
   const watchSafeTx = useCallback(async () => {
     if (!pendingSafe?.tx || !pendingSafe?.txHash || !web3ReadOnly || isWatching) return
@@ -144,10 +153,10 @@ export const useSafeCreation = (
       return
     }
 
-    void createSafe()
-  }, [createSafe, watchSafeTx, isCreating, pendingSafe?.txHash, status, pendingSafe?.taskId, setStatus])
+    void handleCreateSafe()
+  }, [handleCreateSafe, isCreating, pendingSafe?.taskId, pendingSafe?.txHash, setStatus, status, watchSafeTx])
 
   return {
-    createSafe,
+    handleCreateSafe,
   }
 }


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/web-core/pull/1815#discussion_r1153032221

## How this PR fixes it
Splits the logic inside `useSafeCreation`

## How to test it
Create safe should work as expected with relay and without
