### PR TITLE
fix: Track most searched safe apps

### DIFF
--- a/src/hooks/safe-apps/useSafeAppsFilters.ts
+++ b/src/hooks/safe-apps/useSafeAppsFilters.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
 
@@ -6,6 +6,7 @@ import { useAppsFilterByCategory } from './useAppsFilterByCategory'
 import { useAppsSearch } from './useAppsSearch'
 import { useAppsFilterByOptimizedForBatch } from './useAppsFilterByOptimizedForBatch'
 import useDebounce from '../useDebounce'
+import { SAFE_APPS_EVENTS, trackSafeAppEvent } from '@/services/analytics'
 
 type ReturnType = {
   query: string
@@ -28,6 +29,14 @@ const useSafeAppsFilters = (safeAppsList: SafeAppData[]): ReturnType => {
   const filteredAppsByQueryAndCategories = useAppsFilterByCategory(filteredAppsByQuery, selectedCategories)
 
   const filteredApps = useAppsFilterByOptimizedForBatch(filteredAppsByQueryAndCategories, optimizedWithBatchFilter)
+
+  const debouncedSearchQuery = useDebounce(query, 500)
+
+  useEffect(() => {
+    if (debouncedSearchQuery) {
+      trackSafeAppEvent({ ...SAFE_APPS_EVENTS.SEARCH, label: debouncedSearchQuery })
+    }
+  }, [debouncedSearchQuery])
 
   return {
     query,


### PR DESCRIPTION
## What it solves

Resolves #1814 

## How this PR fixes it

- Adds back tracking for safe apps search which was accidently removed in #1537 (https://github.com/safe-global/web-core/pull/1537/files#diff-3b305e872dfa1d5d247bcb20a563b4a5f388c1cb0615d97d1cd911c450af4be8L30-L36)

## How to test it

1. Open the Safe
2. Navigate to Safe apps
3. Search for a safe app
4. Observe a tracking event after a small delay

## Screenshots

<img width="1279" alt="Screenshot 2023-03-31 at 10 43 56" src="https://user-images.githubusercontent.com/5880855/229071687-95f3cf7f-d6d2-4a4f-9adb-fbf83cdae69d.png">

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
