### PR TITLE
Relay service deployment toggle

### DIFF
--- a/src/components/sidebar/DebugToggle/index.tsx
+++ b/src/components/sidebar/DebugToggle/index.tsx
@@ -1,23 +1,26 @@
 import { type ChangeEvent, type ReactElement } from 'react'
 import { Box, FormControlLabel, Switch } from '@mui/material'
 import { localItem } from '@/services/local-storage/local'
-import useLocalStorage from '@/services/local-storage/useLocalStorage'
+import useLocalStorage, { type Setter } from '@/services/local-storage/useLocalStorage'
 import { setDarkMode } from '@/store/settingsSlice'
 import { useDarkMode } from '@/hooks/useDarkMode'
 import { useAppDispatch } from '@/store'
 
 const LS_KEY = 'debugProdCgw'
+const RELAY_SERVICE_STORAGE_KEY = 'relayService'
 
 export const cgwDebugStorage = localItem<boolean>(LS_KEY)
+export const relayServiceStorage = localItem<boolean>(RELAY_SERVICE_STORAGE_KEY)
 
 const DebugToggle = (): ReactElement => {
   const dispatch = useAppDispatch()
   const isDarkMode = useDarkMode()
 
   const [isProdGateway = false, setIsProdGateway] = useLocalStorage<boolean>(LS_KEY)
+  const [isProdRelayService = false, setIsProdRelayService] = useLocalStorage<boolean>(RELAY_SERVICE_STORAGE_KEY)
 
-  const onToggle = (event: ChangeEvent<HTMLInputElement>) => {
-    setIsProdGateway(event.target.checked)
+  const onToggle = (event: ChangeEvent<HTMLInputElement>, cb: Setter<boolean>) => {
+    cb(event.target.checked)
 
     setTimeout(() => {
       location.reload()
@@ -30,7 +33,14 @@ const DebugToggle = (): ReactElement => {
         control={<Switch checked={isDarkMode} onChange={(_, checked) => dispatch(setDarkMode(checked))} />}
         label="Dark mode"
       />
-      <FormControlLabel control={<Switch checked={isProdGateway} onChange={onToggle} />} label="Use prod CGW" />
+      <FormControlLabel
+        control={<Switch checked={isProdGateway} onChange={(e) => onToggle(e, setIsProdGateway)} />}
+        label="Use prod CGW"
+      />
+      <FormControlLabel
+        control={<Switch checked={isProdRelayService} onChange={(e) => onToggle(e, setIsProdRelayService)} />}
+        label="Use prod Relay Service"
+      />
     </Box>
   )
 }

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,5 +1,4 @@
 import chains from './chains'
-import { cgwDebugStorage } from '@/components/sidebar/DebugToggle'
 
 export const IS_PRODUCTION = process.env.NEXT_PUBLIC_IS_PRODUCTION
 
@@ -66,9 +65,3 @@ export enum SafeAppsTag {
   // TODO: Remove safe-claiming-app when we remove the old claiming app
   SAFE_CLAIMING_APP = 'safe-claiming-app',
 }
-
-// Safe Gelato relay service
-export const SAFE_GELATO_RELAY_SERVICE_URL =
-  IS_PRODUCTION || cgwDebugStorage.get()
-    ? SAFE_GELATO_RELAY_SERVICE_URL_PRODUCTION
-    : SAFE_GELATO_RELAY_SERVICE_URL_STAGING

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,10 +1,16 @@
 import chains from './chains'
+import { cgwDebugStorage } from '@/components/sidebar/DebugToggle'
 
 export const IS_PRODUCTION = process.env.NEXT_PUBLIC_IS_PRODUCTION
 
 export const GATEWAY_URL_PRODUCTION =
   process.env.NEXT_PUBLIC_GATEWAY_URL_PRODUCTION || 'https://safe-client.safe.global'
 export const GATEWAY_URL_STAGING = process.env.NEXT_PUBLIC_GATEWAY_URL_STAGING || 'https://safe-client.staging.5afe.dev'
+
+export const SAFE_GELATO_RELAY_SERVICE_URL_PRODUCTION =
+  process.env.NEXT_PUBLIC_SAFE_GELATO_RELAY_SERVICE_URL_PRODUCTION || 'https://safe-client-nest.safe.global/v1/relay'
+export const SAFE_GELATO_RELAY_SERVICE_URL_STAGING =
+  process.env.NEXT_PUBLIC_SAFE_GELATO_RELAY_SERVICE_URL_STAGING || 'https://safe-client-nest.staging.5afe.dev/v1/relay'
 
 // Magic numbers
 export const POLLING_INTERVAL = 15_000
@@ -62,4 +68,7 @@ export enum SafeAppsTag {
 }
 
 // Safe Gelato relay service
-export const SAFE_GELATO_RELAY_SERVICE_URL = process.env.NEXT_PUBLIC_SAFE_GELATO_RELAY_SERVICE_URL || ''
+export const SAFE_GELATO_RELAY_SERVICE_URL =
+  IS_PRODUCTION || cgwDebugStorage.get()
+    ? SAFE_GELATO_RELAY_SERVICE_URL_PRODUCTION
+    : SAFE_GELATO_RELAY_SERVICE_URL_STAGING

--- a/src/hooks/__tests__/useRemainingRelays.test.ts
+++ b/src/hooks/__tests__/useRemainingRelays.test.ts
@@ -1,6 +1,9 @@
 import { renderHook, waitFor } from '@/tests/test-utils'
-import { useLeastRemainingRelays, useRemainingRelaysBySafe } from '@/hooks/useRemainingRelays'
-import { SAFE_GELATO_RELAY_SERVICE_URL } from '@/config/constants'
+import {
+  SAFE_GELATO_RELAY_SERVICE_URL,
+  useLeastRemainingRelays,
+  useRemainingRelaysBySafe,
+} from '@/hooks/useRemainingRelays'
 import * as useSafeAddress from '@/hooks/useSafeAddress'
 import * as useChains from '@/hooks/useChains'
 import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'

--- a/src/hooks/useRemainingRelays.ts
+++ b/src/hooks/useRemainingRelays.ts
@@ -1,9 +1,19 @@
 import useAsync from '@/hooks/useAsync'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import { Errors, logError } from '@/services/exceptions'
-import { SAFE_GELATO_RELAY_SERVICE_URL } from '@/config/constants'
 import { FEATURES, hasFeature } from '@/utils/chains'
 import { useCurrentChain } from '@/hooks/useChains'
+import {
+  IS_PRODUCTION,
+  SAFE_GELATO_RELAY_SERVICE_URL_PRODUCTION,
+  SAFE_GELATO_RELAY_SERVICE_URL_STAGING,
+} from '@/config/constants'
+import { relayServiceStorage } from '@/components/sidebar/DebugToggle'
+
+export const SAFE_GELATO_RELAY_SERVICE_URL =
+  IS_PRODUCTION || relayServiceStorage.get()
+    ? SAFE_GELATO_RELAY_SERVICE_URL_PRODUCTION
+    : SAFE_GELATO_RELAY_SERVICE_URL_STAGING
 
 const fetchRemainingRelays = async (chainId: string, address: string): Promise<number> => {
   const url = `${SAFE_GELATO_RELAY_SERVICE_URL}/${chainId}/${address}`

--- a/src/services/local-storage/useLocalStorage.ts
+++ b/src/services/local-storage/useLocalStorage.ts
@@ -6,7 +6,7 @@ import local from './local'
 // Mimics the behavior of useState
 type Undefinable<T> = T | undefined
 
-type Setter<T> = (val: T | ((prevVal: Undefinable<T>) => Undefinable<T>)) => void
+export type Setter<T> = (val: T | ((prevVal: Undefinable<T>) => Undefinable<T>)) => void
 
 // External stores for each localStorage key which act as a shared cache for LS
 const externalStores: Record<string, ExternalStore<any>> = {}

--- a/src/services/tx/sponsoredCall.ts
+++ b/src/services/tx/sponsoredCall.ts
@@ -1,5 +1,5 @@
-import { SAFE_GELATO_RELAY_SERVICE_URL } from '@/config/constants'
 import { type SafeTransactionData } from '@safe-global/safe-core-sdk-types'
+import { SAFE_GELATO_RELAY_SERVICE_URL } from '@/hooks/useRemainingRelays'
 
 // TODO: import type from relay-service
 export type SponsoredCallPayload = {


### PR DESCRIPTION
## What it solves

Adds a toggle in non-PRODUCTION environments to toggle between deployments (STG vs PROD) of the Safe Gelato relay service

## How to test it
1. Switching on the "Use prod Relay Service" should make the app use the PROD deployment of the  Safe Gelato relay service

## Screenshots
<img width="223" alt="Screenshot 2023-03-31 at 16 59 59" src="https://user-images.githubusercontent.com/32431609/229156815-bac2bc81-e1d7-4062-9b38-d582b8c00d83.png">

