### PR TITLE
fix: height of "Explore Safe Apps" card

### DIFF
--- a/src/components/dashboard/SafeAppsDashboardSection/SafeAppsDashboardSection.tsx
+++ b/src/components/dashboard/SafeAppsDashboardSection/SafeAppsDashboardSection.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from 'next/router'
 import Typography from '@mui/material/Typography'
 import Grid from '@mui/material/Grid'
-import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 
 import { WidgetContainer } from '../styled'
@@ -11,6 +10,8 @@ import SafeAppPreviewDrawer from '@/components/safe-apps/SafeAppPreviewDrawer'
 import SafeAppCard, { SafeAppCardContainer } from '@/components/safe-apps/SafeAppCard'
 import { AppRoutes } from '@/config/routes'
 import ExploreSafeAppsIcon from '@/public/images/apps/explore.svg'
+
+import css from './styles.module.css'
 
 const SafeAppsDashboardSection = () => {
   const { rankedSafeApps, togglePin, pinnedSafeAppIds } = useSafeApps()
@@ -57,22 +58,12 @@ const ExploreSafeAppsCard = () => {
   const safeAppsLink = `${AppRoutes.apps.index}?safe=${router.query.safe}`
 
   return (
-    <SafeAppCardContainer safeAppUrl={safeAppsLink}>
-      <Box
-        display="flex"
-        flexDirection="column"
-        alignItems="center"
-        justifyContent="center"
-        height="100%"
-        gap={1}
-        padding={2}
-      >
-        <ExploreSafeAppsIcon alt="Explore Safe Apps icon" />
+    <SafeAppCardContainer safeAppUrl={safeAppsLink} className={css.container}>
+      <ExploreSafeAppsIcon alt="Explore Safe Apps icon" />
 
-        <Button variant="contained" size="small">
-          Explore Safe Apps
-        </Button>
-      </Box>
+      <Button variant="contained" size="small">
+        Explore Safe Apps
+      </Button>
     </SafeAppCardContainer>
   )
 }

--- a/src/components/dashboard/SafeAppsDashboardSection/styles.module.css
+++ b/src/components/dashboard/SafeAppsDashboardSection/styles.module.css
@@ -1,0 +1,9 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: var(--space-1);
+  padding: var(--space-2);
+}

--- a/src/components/safe-apps/SafeAppCard/index.tsx
+++ b/src/components/safe-apps/SafeAppCard/index.tsx
@@ -7,6 +7,7 @@ import Typography from '@mui/material/Typography'
 import CardActions from '@mui/material/CardActions'
 import Box from '@mui/material/Box'
 import { resolveHref } from 'next/dist/shared/lib/router/router'
+import classNames from 'classnames'
 import type { ReactNode, SyntheticEvent } from 'react'
 import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
 import type { NextRouter } from 'next/router'
@@ -196,9 +197,16 @@ type SafeAppCardContainerProps = {
   safeAppUrl: string
   children: ReactNode
   height?: string
+  className?: string
 }
 
-export const SafeAppCardContainer = ({ children, safeAppUrl, onClickSafeApp, height }: SafeAppCardContainerProps) => {
+export const SafeAppCardContainer = ({
+  children,
+  safeAppUrl,
+  onClickSafeApp,
+  height,
+  className,
+}: SafeAppCardContainerProps) => {
   const handleClickSafeApp = (event: SyntheticEvent) => {
     if (onClickSafeApp) {
       event.preventDefault()
@@ -209,7 +217,7 @@ export const SafeAppCardContainer = ({ children, safeAppUrl, onClickSafeApp, hei
   return (
     <Link href={safeAppUrl} passHref>
       <a rel="noreferrer" onClick={handleClickSafeApp}>
-        <Card className={css.safeAppContainer} sx={{ height }}>
+        <Card className={classNames(css.safeAppContainer, className)} sx={{ height }}>
           {children}
         </Card>
       </a>


### PR DESCRIPTION
## What it solves

Inconsistent height of card on dashboard

## How this PR fixes it

The height of the "Explore Safe Apps" card is now 100%, matching that of the other cards on the dashboard.

## How to test it

Open the dashboard and observe that the "Explore Safe Apps" card matches the same height as the tallest card in that row. The Safe Apps list should also appear as before.

## Screenshots

Before:

![image](https://user-images.githubusercontent.com/20442784/229497043-541a97cc-e3d9-4d0c-9ba1-ec968482d7a2.png)

After:

![image](https://user-images.githubusercontent.com/20442784/229497076-f981a0e8-5c3b-467b-a737-154abd4011c2.png)

![image](https://user-images.githubusercontent.com/20442784/229497090-f74efe84-708a-4132-a974-478dffae65a0.png)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻