### PR TITLE
fix: Over-initialization of the safe core sdk

### DIFF
--- a/src/hooks/coreSDK/__tests__/safeCoreSDK.test.ts
+++ b/src/hooks/coreSDK/__tests__/safeCoreSDK.test.ts
@@ -4,10 +4,10 @@ import {
   getProxyFactoryContract,
   getSafeContract,
 } from '@safe-global/safe-core-sdk/dist/src/contracts/safeDeploymentContracts'
-import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { ImplementationVersionState } from '@safe-global/safe-gateway-typescript-sdk'
 import { Web3Provider } from '@ethersproject/providers'
 
-import { isValidSafeVersion, initSafeSDK } from '../safeCoreSDK'
+import { initSafeSDK, isValidSafeVersion } from '../safeCoreSDK'
 
 jest.mock('@/services/contracts/safeContracts', () => {
   return {
@@ -112,13 +112,14 @@ describe('safeCoreSDK', () => {
 
         const mockProvider = getMockProvider(chainId, version)
 
-        const sdk = await initSafeSDK(mockProvider, {
+        const sdk = await initSafeSDK({
+          provider: mockProvider,
           chainId,
-          address: { value: ethers.utils.hexZeroPad('0x1', 20) },
+          address: ethers.utils.hexZeroPad('0x1', 20),
           version,
-          implementation: { value: MAINNET_MASTER_COPY },
-          implementationVersionState: 'UP_TO_DATE',
-        } as SafeInfo)
+          implementation: MAINNET_MASTER_COPY,
+          implementationVersionState: ImplementationVersionState.UP_TO_DATE,
+        })
 
         expect(sdk).toBeInstanceOf(Safe)
       })
@@ -129,13 +130,14 @@ describe('safeCoreSDK', () => {
 
         const mockProvider = getMockProvider(chainId, version)
 
-        const sdk = await initSafeSDK(mockProvider, {
+        const sdk = await initSafeSDK({
+          provider: mockProvider,
           chainId,
-          address: { value: ethers.utils.hexZeroPad('0x1', 20) },
+          address: ethers.utils.hexZeroPad('0x1', 20),
           version,
-          implementation: { value: MAINNET_MASTER_COPY },
-          implementationVersionState: 'UP_TO_DATE',
-        } as SafeInfo)
+          implementation: MAINNET_MASTER_COPY,
+          implementationVersionState: ImplementationVersionState.UP_TO_DATE,
+        })
 
         expect(sdk).toBeInstanceOf(Safe)
         expect(sdk?.getContractManager().isL1SafeMasterCopy).toBe(true)
@@ -147,13 +149,14 @@ describe('safeCoreSDK', () => {
 
         const mockProvider = getMockProvider(chainId, version)
 
-        const sdk = await initSafeSDK(mockProvider, {
+        const sdk = await initSafeSDK({
+          provider: mockProvider,
           chainId,
-          address: { value: ethers.utils.hexZeroPad('0x1', 20) },
+          address: ethers.utils.hexZeroPad('0x1', 20),
           version: `${version}+L2`,
-          implementation: { value: POLYGON_MASTER_COPY },
-          implementationVersionState: 'UP_TO_DATE',
-        } as SafeInfo)
+          implementation: POLYGON_MASTER_COPY,
+          implementationVersionState: ImplementationVersionState.UP_TO_DATE,
+        })
 
         expect(sdk).toBeInstanceOf(Safe)
         expect(sdk?.getContractManager().isL1SafeMasterCopy).toBe(false)
@@ -165,13 +168,14 @@ describe('safeCoreSDK', () => {
 
         const mockProvider = getMockProvider(chainId, version)
 
-        const sdk = await initSafeSDK(mockProvider, {
+        const sdk = await initSafeSDK({
+          provider: mockProvider,
           chainId,
-          address: { value: ethers.utils.hexZeroPad('0x1', 20) },
+          address: ethers.utils.hexZeroPad('0x1', 20),
           version,
-          implementation: { value: POLYGON_MASTER_COPY },
-          implementationVersionState: 'OUTDATED',
-        } as SafeInfo)
+          implementation: POLYGON_MASTER_COPY,
+          implementationVersionState: ImplementationVersionState.OUTDATED,
+        })
 
         expect(sdk).toBeInstanceOf(Safe)
         expect(sdk?.getContractManager().isL1SafeMasterCopy).toBe(true)
@@ -186,13 +190,14 @@ describe('safeCoreSDK', () => {
 
         const mockProvider = getMockProvider(chainId, version)
 
-        const sdk = await initSafeSDK(mockProvider, {
+        const sdk = await initSafeSDK({
+          provider: mockProvider,
           chainId: '1',
-          address: { value: ethers.utils.hexZeroPad('0x1', 20) },
+          address: ethers.utils.hexZeroPad('0x1', 20),
           version: null, // Indexer returns null if unsupported contract version
-          implementation: { value: MAINNET_MASTER_COPY },
-          implementationVersionState: 'UNKNOWN',
-        } as SafeInfo)
+          implementation: MAINNET_MASTER_COPY,
+          implementationVersionState: ImplementationVersionState.UNKNOWN,
+        })
 
         expect(sdk).toBeInstanceOf(Safe)
       })
@@ -203,13 +208,14 @@ describe('safeCoreSDK', () => {
 
         const mockProvider = getMockProvider(chainId, version)
 
-        const sdk = await initSafeSDK(mockProvider, {
+        const sdk = await initSafeSDK({
+          provider: mockProvider,
           chainId,
-          address: { value: ethers.utils.hexZeroPad('0x1', 20) },
+          address: ethers.utils.hexZeroPad('0x1', 20),
           version: null,
-          implementation: { value: MAINNET_MASTER_COPY },
-          implementationVersionState: 'UNKNOWN',
-        } as SafeInfo)
+          implementation: MAINNET_MASTER_COPY,
+          implementationVersionState: ImplementationVersionState.UNKNOWN,
+        })
 
         expect(sdk).toBeInstanceOf(Safe)
         expect(sdk?.getContractManager().isL1SafeMasterCopy).toBe(true)
@@ -221,13 +227,14 @@ describe('safeCoreSDK', () => {
 
         const mockProvider = getMockProvider(chainId, version)
 
-        const sdk = await initSafeSDK(mockProvider, {
+        const sdk = await initSafeSDK({
+          provider: mockProvider,
           chainId,
-          address: { value: ethers.utils.hexZeroPad('0x1', 20) },
+          address: ethers.utils.hexZeroPad('0x1', 20),
           version: null,
-          implementation: { value: '0xinvalid' },
-          implementationVersionState: 'UNKNOWN',
-        } as SafeInfo)
+          implementation: '0xinvalid',
+          implementationVersionState: ImplementationVersionState.UNKNOWN,
+        })
 
         expect(sdk).toBeUndefined()
       })

--- a/src/hooks/coreSDK/safeCoreSDK.ts
+++ b/src/hooks/coreSDK/safeCoreSDK.ts
@@ -51,17 +51,31 @@ const createReadOnlyEthersAdapter = (provider: JsonRpcProvider) => {
   })
 }
 
+type SafeCoreSDKProps = {
+  provider: JsonRpcProvider
+  chainId: SafeInfo['chainId']
+  address: SafeInfo['address']['value']
+  version: SafeInfo['version']
+  implementationVersionState: SafeInfo['implementationVersionState']
+  implementation: SafeInfo['implementation']['value']
+}
+
 // Safe Core SDK
-export const initSafeSDK = async (provider: JsonRpcProvider, safe: SafeInfo): Promise<Safe | undefined> => {
-  const chainId = safe.chainId
-  const safeAddress = safe.address.value
-  const safeVersion = safe.version ?? (await Gnosis_safe__factory.connect(safeAddress, provider).VERSION())
+export const initSafeSDK = async ({
+  provider,
+  chainId,
+  address,
+  version,
+  implementationVersionState,
+  implementation,
+}: SafeCoreSDKProps): Promise<Safe | undefined> => {
+  const safeVersion = version ?? (await Gnosis_safe__factory.connect(address, provider).VERSION())
 
   let isL1SafeMasterCopy = chainId === chains.eth
 
   // If it is an official deployment we should still initiate the safeSDK
-  if (!isValidMasterCopy(safe)) {
-    const masterCopy = safe.implementation.value
+  if (!isValidMasterCopy(implementationVersionState)) {
+    const masterCopy = implementation
 
     const safeL1Deployment = getSafeSingletonDeployment({ network: chainId, version: safeVersion })
     const safeL2Deployment = getSafeL2SingletonDeployment({ network: chainId, version: safeVersion })
@@ -82,7 +96,7 @@ export const initSafeSDK = async (provider: JsonRpcProvider, safe: SafeInfo): Pr
 
   return Safe.create({
     ethAdapter: createReadOnlyEthersAdapter(provider),
-    safeAddress,
+    safeAddress: address,
     isL1SafeMasterCopy,
   })
 }

--- a/src/hooks/coreSDK/useInitSafeCoreSDK.ts
+++ b/src/hooks/coreSDK/useInitSafeCoreSDK.ts
@@ -26,7 +26,14 @@ export const useInitSafeCoreSDK = () => {
     }
 
     // A read-only instance of the SDK is sufficient because we connect the signer to it when needed
-    initSafeSDK(web3ReadOnly, safe)
+    initSafeSDK({
+      provider: web3ReadOnly,
+      chainId: safe.chainId,
+      address: safe.address.value,
+      version: safe.version,
+      implementationVersionState: safe.implementationVersionState,
+      implementation: safe.implementation.value,
+    })
       .then(setSafeSDK)
       .catch((e) => {
         dispatch(
@@ -39,5 +46,15 @@ export const useInitSafeCoreSDK = () => {
         )
         trackError(ErrorCodes._105, (e as Error).message)
       })
-  }, [safe, safeLoaded, dispatch, web3ReadOnly, address])
+  }, [
+    address,
+    dispatch,
+    safe.address.value,
+    safe.chainId,
+    safe.implementation.value,
+    safe.implementationVersionState,
+    safe.version,
+    safeLoaded,
+    web3ReadOnly,
+  ])
 }

--- a/src/hooks/useSafeNotifications.ts
+++ b/src/hooks/useSafeNotifications.ts
@@ -133,7 +133,7 @@ const useSafeNotifications = (): void => {
    */
 
   useEffect(() => {
-    if (isValidMasterCopy(safe)) return
+    if (isValidMasterCopy(safe.implementationVersionState)) return
 
     const id = dispatch(
       showNotification({
@@ -149,7 +149,7 @@ const useSafeNotifications = (): void => {
     return () => {
       dispatch(closeNotification({ id }))
     }
-  }, [dispatch, safe])
+  }, [dispatch, safe.implementationVersionState])
 }
 
 export default useSafeNotifications

--- a/src/services/__tests__/safeContracts.test.ts
+++ b/src/services/__tests__/safeContracts.test.ts
@@ -1,28 +1,22 @@
-import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { ImplementationVersionState } from '@safe-global/safe-gateway-typescript-sdk'
 import { _getValidatedGetContractProps, isValidMasterCopy } from '../contracts/safeContracts'
 
 describe('safeContracts', () => {
   describe('isValidMasterCopy', () => {
     it('returns false if the implementation is unknown', async () => {
-      const isValid = isValidMasterCopy({
-        implementationVersionState: 'UNKNOWN',
-      } as SafeInfo)
+      const isValid = isValidMasterCopy(ImplementationVersionState.UNKNOWN)
 
       expect(isValid).toBe(false)
     })
 
     it('returns true if the implementation is up-to-date', async () => {
-      const isValid = isValidMasterCopy({
-        implementationVersionState: 'UP_TO_DATE',
-      } as SafeInfo)
+      const isValid = isValidMasterCopy(ImplementationVersionState.UP_TO_DATE)
 
       expect(isValid).toBe(true)
     })
 
     it('returns true if the implementation is outdated', async () => {
-      const isValid = isValidMasterCopy({
-        implementationVersionState: 'OUTDATED',
-      } as SafeInfo)
+      const isValid = isValidMasterCopy(ImplementationVersionState.OUTDATED)
 
       expect(isValid).toBe(true)
     })

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -21,8 +21,8 @@ import type { Web3Provider } from '@ethersproject/providers'
 // `UNKNOWN` is returned if the mastercopy does not match supported ones
 // @see https://github.com/safe-global/safe-client-gateway/blob/main/src/routes/safes/handlers/safes.rs#L28-L31
 //      https://github.com/safe-global/safe-client-gateway/blob/main/src/routes/safes/converters.rs#L77-L79
-export const isValidMasterCopy = (safe: SafeInfo): boolean => {
-  return safe.implementationVersionState !== ImplementationVersionState.UNKNOWN
+export const isValidMasterCopy = (implementationVersionState: SafeInfo['implementationVersionState']): boolean => {
+  return implementationVersionState !== ImplementationVersionState.UNKNOWN
 }
 
 export const _getValidatedGetContractProps = (


### PR DESCRIPTION
## What it solves

While working on #1829, I noticed that the core-sdk is re-initialized every time the queue or history updates e.g. when a user executes a transaction. This is not necessary so I narrowed down the dependencies instead of using the whole `safe` object.

## How to test it

1. Open the Safe
2. Create and execute a transaction
3. Observe that the `useInitSafeCoreSDK` hook is not running anymore

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
