### PR TITLE
[POC] feat: validate batch and exclude txs that revert

### DIFF
--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -10,6 +10,7 @@ import type {
   TransactionListPage,
 } from '@safe-global/safe-gateway-typescript-sdk'
 import { ConflictType, getTransactionDetails, TransactionListItemType } from '@safe-global/safe-gateway-typescript-sdk'
+import { encodeMultiSendData } from '@safe-global/safe-core-sdk/dist/src/utils/transactions/utils'
 import {
   isModuleDetailedExecutionInfo,
   isMultisigDetailedExecutionInfo,
@@ -19,13 +20,14 @@ import {
 } from './transaction-guards'
 import type { MetaTransactionData } from '@safe-global/safe-core-sdk-types/dist/src/types'
 import { OperationType } from '@safe-global/safe-core-sdk-types/dist/src/types'
-import { getGnosisSafeContractInstance } from '@/services/contracts/safeContracts'
+import { getGnosisSafeContractInstance, getMultiSendCallOnlyContractInstance } from '@/services/contracts/safeContracts'
 import extractTxInfo from '@/services/tx/extractTxInfo'
 import type { AdvancedParameters } from '@/components/tx/AdvancedParams'
 import type { TransactionOptions, SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { FEATURES, hasFeature } from '@/utils/chains'
 import uniqBy from 'lodash/uniqBy'
 import { Errors, logError } from '@/services/exceptions'
+import { LATEST_SAFE_VERSION } from '@/config/constants'
 
 export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction => {
   const getMissingSigners = ({
@@ -128,6 +130,49 @@ export const getMultiSendTxs = (
       }
     })
     .filter(Boolean) as MetaTransactionData[]
+}
+
+export const _isValidMultiSend = async (safe: SafeInfo, txs: MetaTransactionData[]): Promise<boolean> => {
+  const multiSendContract = getMultiSendCallOnlyContractInstance(safe.chainId, safe.version)
+  const data = encodeMultiSendData(txs)
+
+  try {
+    await multiSendContract.contract.callStatic.multiSend(data)
+    return true
+  } catch (err) {
+    return false
+  }
+}
+
+export const getValidBatch = async (
+  txs: TransactionDetails[],
+  safe: SafeInfo,
+  chain: ChainInfo,
+): Promise<MetaTransactionData[]> => {
+  const safeAddress = safe.address.value
+  const safeVersion = safe.version || LATEST_SAFE_VERSION
+
+  const multiSendTxs = getMultiSendTxs(txs, chain, safeAddress, safeVersion)
+
+  const isValidBatch = await _isValidMultiSend(safe, multiSendTxs)
+
+  if (isValidBatch) {
+    return multiSendTxs
+  }
+
+  const validMultiSendTxs: MetaTransactionData[] = []
+
+  for await (const multiSendTx of multiSendTxs) {
+    const isValidBatch = await _isValidMultiSend(safe, [...validMultiSendTxs, multiSendTx])
+
+    if (!isValidBatch) {
+      break
+    }
+
+    validMultiSendTxs.push(multiSendTx)
+  }
+
+  return validMultiSendTxs
 }
 
 export const getTxsWithDetails = (txs: Transaction[], chainId: string) => {


### PR DESCRIPTION
## What it solves

Resolves #1130

## How this PR fixes it

The initial batched transaction is validated and, if it fails, each nested transaction is sequentially included and validated inside a new batch. The valid batch is then returned, excluding the transaction that would otherwise fail and those thereafter.

## How to test it

Open a m/n Safe and queue the following transactions in order:

1. Remove owner and set threshold to 1.
2. Set threshold to m.

Transaction 2 is invalid as it attempts to set the threshold higher than that of the Safe is transaction 1 succeeds, which should fail validation.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/229847339-95abbb1b-71fe-4157-9603-aad3cd2ad070.png)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
