### PR TITLE
fix: Unhandled exception in the Copy button #1782

### DIFF
--- a/src/components/common/CopyButton/index.tsx
+++ b/src/components/common/CopyButton/index.tsx
@@ -29,7 +29,7 @@ const CopyButton = ({
         onCopy?.()
       } catch (err) {
         setIsCopyEnabled(false);
-        setTooltipText('copying is disabled in your browser');
+        setTooltipText('Copying is disabled in your browser');
       }
     },
     [text, onCopy],

--- a/src/components/common/CopyButton/index.tsx
+++ b/src/components/common/CopyButton/index.tsx
@@ -18,24 +18,34 @@ const CopyButton = ({
   onCopy?: () => void
 }): ReactElement => {
   const [tooltipText, setTooltipText] = useState(initialToolTipText)
+  const [isCopyEnabled, setIsCopyEnabled] = useState(true)
 
   const handleCopy = useCallback(
     (e: SyntheticEvent) => {
       e.preventDefault()
       e.stopPropagation()
-      navigator.clipboard.writeText(text).then(() => setTooltipText('Copied'))
-      onCopy?.()
+      try {
+        navigator.clipboard.writeText(text).then(() => setTooltipText('Copied'))
+        onCopy?.()
+      } catch (err) {
+        setIsCopyEnabled(false);
+        setTooltipText('copying is disabled in your browser');
+      }
     },
     [text, onCopy],
   )
 
   const handleMouseLeave = useCallback(() => {
-    setTimeout(() => setTooltipText(initialToolTipText), 500)
-  }, [initialToolTipText])
+    setTimeout(() => {
+      if (isCopyEnabled) {
+        setTooltipText(initialToolTipText);
+      }
+    }, 500);
+  }, [initialToolTipText, isCopyEnabled])
 
   return (
     <Tooltip title={tooltipText} placement="top" onMouseLeave={handleMouseLeave}>
-      <IconButton aria-label={initialToolTipText} onClick={handleCopy} size="small" className={className}>
+      <IconButton aria-label={initialToolTipText} onClick={handleCopy} size="small" className={className} disabled={!isCopyEnabled}>
         {children ?? <SvgIcon component={CopyIcon} inheritViewBox color="border" fontSize="small" />}
       </IconButton>
     </Tooltip>

--- a/src/components/transactions/TxShareLink/index.tsx
+++ b/src/components/transactions/TxShareLink/index.tsx
@@ -5,8 +5,11 @@ import { AppRoutes } from '@/config/routes'
 import { useRouter } from 'next/router'
 import Track from '@/components/common/Track'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
+import React, {useState} from 'react'
 
 const TxShareLink = ({ id }: { id: string }): ReactElement => {
+  const [isCopyEnabled, setIsCopyEnabled] = useState(true)
+
   const router = useRouter()
   const { safe = '' } = router.query
   const href = `/${safe}${AppRoutes.transactions.tx}?id=${id}`
@@ -15,14 +18,19 @@ const TxShareLink = ({ id }: { id: string }): ReactElement => {
     if (!e.ctrlKey && !e.metaKey) {
       e.preventDefault()
     }
-
-    // copy href to clipboard
-    navigator.clipboard.writeText(location.origin + href)
+    
+    try {
+      // copy href to clipboard
+      navigator.clipboard.writeText(location.origin + href)
+    } catch (error) {
+      console.error(error)
+      setIsCopyEnabled(false)
+    }
   }
 
   return (
     <Track {...TX_LIST_EVENTS.COPY_DEEPLINK}>
-      <IconButton component={Link} aria-label="Share" href={href} onClick={onClick}>
+      <IconButton component={Link} aria-label="Share" href={href} onClick={onClick} disabled={!isCopyEnabled}>
         <SvgIcon component={ShareIcon} inheritViewBox fontSize="small" color="border" />
       </IconButton>
     </Track>


### PR DESCRIPTION
## What it solves
In some browser environments, navigator.clipboard.writeText  function isn't allowed (e.g. in a web view on Android). So it was throwing **NotAllowedError: Write permission denied**. errors on Sentry.
Resolves #1782

## How this PR fixes it
added a try-catch block that handles any errors. When error occurs the button is disabled and title is changed showing copying is disabled in your browser.

## How to test it
Open in webview on android and try to copy the text.


## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
