### PR TITLE
fix: Spending limits: Table header is displayed when no records #1703

### DIFF
--- a/src/components/settings/SpendingLimits/SpendingLimitsTable.tsx
+++ b/src/components/settings/SpendingLimits/SpendingLimitsTable.tsx
@@ -152,10 +152,10 @@ export const SpendingLimitsTable = ({
           }),
     [isLoading, spendingLimits],
   )
-  return (
+  return spendingLimits.length > 0 ? (
     <>
       <EnhancedTable rows={rows} headCells={headCells} />
       {open && <TxModal onClose={() => setOpen(false)} steps={RemoveSpendingLimitSteps} initialData={[initialData]} />}
     </>
-  )
+  ) : null
 }


### PR DESCRIPTION
## What it solves
This solves the issue where Table header is displayed even when there are no records

Resolves #1703
I have added a conditonal statement which renders table only when data is avilable.

## How this PR fixes it
table is displayed only when it's not empty

## How to test it
Go to the spending limits page in the safe without the spending limits module enabled or to the Base network ( no support for spending limits). Now the table would not be rendered if there is no data in table.



## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
