### PR TITLE
fix: Unhandled error for pending txs in queue

### DIFF
--- a/src/components/transactions/GroupedTxListItems/index.tsx
+++ b/src/components/transactions/GroupedTxListItems/index.tsx
@@ -44,7 +44,9 @@ const TxGroup = ({ groupedListItems }: { groupedListItems: Transaction[] }): Rea
   )
 }
 
-const GroupedTxListItems = ({ groupedListItems }: { groupedListItems: Transaction[] }): ReactElement => {
+const GroupedTxListItems = ({ groupedListItems }: { groupedListItems: Transaction[] }): ReactElement | null => {
+  if (groupedListItems.length === 0) return null
+
   return (
     <ReplaceTxHoverProvider groupedListItems={groupedListItems}>
       <TxGroup groupedListItems={groupedListItems} />


### PR DESCRIPTION
## What it solves

Resolves #1829 

This issue was really hard to reproduce. I was able to reproduce it in a 2/n safe with multiple transactions in the queue that were missing signatures. When signing a transaction, it becomes pending which we then fetch the untrusted queue for. When signing a transaction that is not next in queue (e.g. with nonce 32), that fetch sometimes returns an array consisting only of the label and a conflict header i.e.

```
[{
    "type": "LABEL",
    "label": "Pending"
},
{
    "type": "CONFLICT_HEADER",
    "nonce": 31
}]
```

I suspect its either the CGW or the service worker returning cached data. In any case, we should not proceed to `TxGroup` if there is an empty array passed.

## How this PR fixes it

- Makes sure that `groupedListItems` is not empty before rendering 

## How to test it

1. Open a 2/n safe
2. Queue 2 transactions
3. Sign the latter one
4. Observe the app not crashing or showing related errors in the console

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
