### PR TITLE
fix: Navigation tabs break the layout on mobile viewports

### DIFF
--- a/src/components/balances/AssetsHeader/index.tsx
+++ b/src/components/balances/AssetsHeader/index.tsx
@@ -5,15 +5,19 @@ import NavTabs from '@/components/common/NavTabs'
 import PageHeader from '@/components/common/PageHeader'
 import { balancesNavItems } from '@/components/sidebar/SidebarNavigation/config'
 
+import css from '@/components/common/PageHeader/styles.module.css'
+
 const AssetsHeader = ({ children }: { children?: ReactNode }): ReactElement => {
   return (
     <PageHeader
       title="Assets"
       action={
         <>
-          <Box display="flex" justifyContent="space-between" alignItems="center">
-            <NavTabs tabs={balancesNavItems} />
-            {children}
+          <Box className={css.pageHeader}>
+            <Box className={css.navWrapper}>
+              <NavTabs tabs={balancesNavItems} />
+            </Box>
+            {children && <Box className={css.actionsWrapper}>{children}</Box>}
           </Box>
         </>
       }

--- a/src/components/balances/AssetsTable/styles.module.css
+++ b/src/components/balances/AssetsTable/styles.module.css
@@ -14,24 +14,9 @@
   gap: var(--space-1);
 }
 
-.assetsHeader {
-  display: flex;
-  gap: var(--space-1);
-  align-items: center;
-}
-
 @media (max-width: 600px) {
   .container td:last-of-type,
   .container th:last-of-type {
     display: none;
-  }
-
-  .assetsHeader {
-    position: absolute;
-    bottom: -56px;
-  }
-
-  .contentWrapper {
-    margin-top: 56px;
   }
 }

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -67,7 +67,7 @@ const Header = ({ onMenuToggle }: HeaderProps): ReactElement => {
         <NotificationCenter />
       </div>
 
-      <div className={css.element}>
+      <div className={classnames(css.element, css.connectWallet)}>
         <ConnectWallet />
       </div>
 

--- a/src/components/common/Header/styles.module.css
+++ b/src/components/common/Header/styles.module.css
@@ -42,6 +42,10 @@
   border-right: none;
 }
 
+.connectWallet {
+  flex-shrink: 0;
+}
+
 @media (max-width: 900px) {
   .logo {
     display: none;

--- a/src/components/common/NavTabs/styles.module.css
+++ b/src/components/common/NavTabs/styles.module.css
@@ -12,11 +12,11 @@
 }
 
 .tabs :global .MuiTabScrollButton-root:first-of-type {
-  margin-left: -24px;
+  margin-left: -16px;
 }
 
 .tabs :global .MuiTabScrollButton-root:last-of-type {
-  margin-right: -24px;
+  margin-right: -16px;
 }
 
 .tab {

--- a/src/components/common/PageHeader/index.tsx
+++ b/src/components/common/PageHeader/index.tsx
@@ -1,4 +1,6 @@
 import { Box, Typography } from '@mui/material'
+import classNames from 'classnames'
+
 import type { ReactElement } from 'react'
 
 import css from './styles.module.css'
@@ -13,12 +15,7 @@ const PageHeader = ({
   noBorder?: boolean
 }): ReactElement => {
   return (
-    <Box
-      className={css.container}
-      sx={{
-        borderBottom: noBorder ? undefined : ({ palette }) => `1px solid ${palette.border.light}`,
-      }}
-    >
+    <Box className={classNames(css.container, { [css.border]: !noBorder })}>
       <Typography variant="h3" className={css.title}>
         {title}
       </Typography>

--- a/src/components/common/PageHeader/styles.module.css
+++ b/src/components/common/PageHeader/styles.module.css
@@ -15,8 +15,43 @@
   margin-bottom: var(--space-3);
 }
 
+.border {
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.pageHeader,
+.actionsWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-1);
+}
+
 @media (max-width: 600px) {
   .container {
     padding: var(--space-3) var(--space-2) 0;
+  }
+
+  .border {
+    border: 0;
+  }
+
+  .pageHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-3);
+  }
+
+  .navWrapper {
+    border-bottom: 1px solid var(--color-border-light);
+    margin-left: -16px;
+    padding-left: 16px;
+    margin-right: -16px;
+    padding-right: 16px;
+    align-self: stretch;
+  }
+
+  .actionsWrapper {
+    padding-bottom: 16px;
   }
 }

--- a/src/components/settings/SettingsHeader/index.tsx
+++ b/src/components/settings/SettingsHeader/index.tsx
@@ -1,11 +1,22 @@
 import type { ReactElement } from 'react'
+import { Box } from '@mui/material'
 
 import NavTabs from '@/components/common/NavTabs'
 import PageHeader from '@/components/common/PageHeader'
 import { settingsNavItems } from '@/components/sidebar/SidebarNavigation/config'
+import css from '@/components/common/PageHeader/styles.module.css'
 
 const SettingsHeader = (): ReactElement => {
-  return <PageHeader title="Settings" action={<NavTabs tabs={settingsNavItems} />} />
+  return (
+    <PageHeader
+      title="Settings"
+      action={
+        <Box className={css.navWrapper}>
+          <NavTabs tabs={settingsNavItems} />
+        </Box>
+      }
+    />
+  )
 }
 
 export default SettingsHeader

--- a/src/components/transactions/TxFilterForm/index.tsx
+++ b/src/components/transactions/TxFilterForm/index.tsx
@@ -20,6 +20,8 @@ import { txFilter, useTxFilter, TxFilterType, type TxFilter } from '@/utils/tx-h
 import { useCurrentChain } from '@/hooks/useChains'
 import NumberField from '@/components/common/NumberField'
 
+import css from './styles.module.css'
+
 enum TxFilterFormFieldNames {
   FILTER_TYPE = 'type',
   DATE_FROM = 'execution_date__gte',
@@ -114,17 +116,7 @@ const TxFilterForm = ({ toggleFilter }: { toggleFilter: () => void }): ReactElem
   }
 
   return (
-    <Paper
-      elevation={0}
-      variant="outlined"
-      sx={{
-        borderWidth: '1px',
-        // Below page header
-        position: 'sticky',
-        top: 144,
-        zIndex: 2,
-      }}
-    >
+    <Paper elevation={0} variant="outlined" className={css.filterWrapper}>
       <FormProvider {...formMethods}>
         <form onSubmit={handleSubmit(onSubmit)}>
           <Grid container>

--- a/src/components/transactions/TxFilterForm/styles.module.css
+++ b/src/components/transactions/TxFilterForm/styles.module.css
@@ -1,0 +1,14 @@
+.filterWrapper {
+  position: sticky;
+  z-index: 2;
+  top: 144px;
+  border-width: 1px;
+}
+
+@media (max-width: 600px) {
+  .filterWrapper {
+    position: relative;
+    z-index: 0;
+    top: 0;
+  }
+}

--- a/src/components/transactions/TxHeader/index.tsx
+++ b/src/components/transactions/TxHeader/index.tsx
@@ -1,9 +1,26 @@
-import type { ReactElement } from 'react'
+import type { ReactElement, ReactNode } from 'react'
 
 import PageHeader from '@/components/common/PageHeader'
+import { Box } from '@mui/material'
+import css from '@/components/common/PageHeader/styles.module.css'
+import TxNavigation from '@/components/transactions/TxNavigation'
 
-const TxHeader = ({ action }: { action?: ReactElement }): ReactElement => {
-  return <PageHeader title="Transactions" action={action} />
+const TxHeader = ({ children }: { children?: ReactNode }): ReactElement => {
+  return (
+    <PageHeader
+      title="Transactions"
+      action={
+        <>
+          <Box className={css.pageHeader}>
+            <Box className={css.navWrapper}>
+              <TxNavigation />
+            </Box>
+            {children && <Box className={css.actionsWrapper}>{children}</Box>}
+          </Box>
+        </>
+      }
+    />
+  )
 }
 
 export default TxHeader

--- a/src/pages/balances/index.tsx
+++ b/src/pages/balances/index.tsx
@@ -1,6 +1,5 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
-import { Box } from '@mui/material'
 
 import AssetsTable from '@/components/balances/AssetsTable'
 import AssetsHeader from '@/components/balances/AssetsHeader'
@@ -12,8 +11,6 @@ import NoAssetsIcon from '@/public/images/balances/no-assets.svg'
 import HiddenTokenButton from '@/components/balances/HiddenTokenButton'
 import CurrencySelect from '@/components/balances/CurrencySelect'
 import TokenListSelect from '@/components/balances/TokenListSelect'
-
-import css from '@/components/balances/AssetsTable/styles.module.css'
 
 const Balances: NextPage = () => {
   const { error } = useBalances()
@@ -27,14 +24,12 @@ const Balances: NextPage = () => {
       </Head>
 
       <AssetsHeader>
-        <Box className={css.assetsHeader}>
-          <HiddenTokenButton showHiddenAssets={showHiddenAssets} toggleShowHiddenAssets={toggleShowHiddenAssets} />
-          <TokenListSelect />
-          <CurrencySelect />
-        </Box>
+        <HiddenTokenButton showHiddenAssets={showHiddenAssets} toggleShowHiddenAssets={toggleShowHiddenAssets} />
+        <TokenListSelect />
+        <CurrencySelect />
       </AssetsHeader>
 
-      <main className={css.contentWrapper}>
+      <main>
         {error ? (
           <PagePlaceholder img={<NoAssetsIcon />} text="There was an error loading your assets" />
         ) : (

--- a/src/pages/transactions/history.tsx
+++ b/src/pages/transactions/history.tsx
@@ -10,7 +10,6 @@ import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import TxFilterForm from '@/components/transactions/TxFilterForm'
 import { useTxFilter } from '@/utils/tx-history-filter'
-import TxNavigation from '../../components/transactions/TxNavigation'
 
 const History: NextPage = () => {
   const [filter] = useTxFilter()
@@ -28,16 +27,11 @@ const History: NextPage = () => {
         <title>Safe – Transaction history</title>
       </Head>
 
-      <TxHeader
-        action={
-          <Box display="flex" justifyContent="space-between" alignItems="center">
-            <TxNavigation />
-            <Button variant="outlined" onClick={toggleFilter} size="small" endIcon={<ExpandIcon />}>
-              {filter?.type ?? 'Filter'}
-            </Button>
-          </Box>
-        }
-      />
+      <TxHeader>
+        <Button variant="outlined" onClick={toggleFilter} size="small" endIcon={<ExpandIcon />}>
+          {filter?.type ?? 'Filter'}
+        </Button>
+      </TxHeader>
 
       <main>
         {showFilter && <TxFilterForm toggleFilter={toggleFilter} />}

--- a/src/pages/transactions/messages.tsx
+++ b/src/pages/transactions/messages.tsx
@@ -3,9 +3,7 @@ import type { NextPage } from 'next'
 
 import PaginatedMsgs from '@/components/safe-messages/PaginatedMsgs'
 import TxHeader from '@/components/transactions/TxHeader'
-import { Box } from '@mui/material'
 import SignedMessagesHelpLink from '@/components/transactions/SignedMessagesHelpLink'
-import TxNavigation from '../../components/transactions/TxNavigation'
 
 const Messages: NextPage = () => {
   return (
@@ -14,14 +12,9 @@ const Messages: NextPage = () => {
         <title>Safe – Messages</title>
       </Head>
 
-      <TxHeader
-        action={
-          <Box display="flex" justifyContent="space-between" alignItems="center">
-            <TxNavigation />
-            <SignedMessagesHelpLink />
-          </Box>
-        }
-      />
+      <TxHeader>
+        <SignedMessagesHelpLink />
+      </TxHeader>
 
       <main>
         <PaginatedMsgs />

--- a/src/pages/transactions/queue.tsx
+++ b/src/pages/transactions/queue.tsx
@@ -6,7 +6,6 @@ import TxHeader from '@/components/transactions/TxHeader'
 import BatchExecuteButton from '@/components/transactions/BatchExecuteButton'
 import { Box } from '@mui/material'
 import { BatchExecuteHoverProvider } from '@/components/transactions/BatchExecuteButton/BatchExecuteHoverProvider'
-import TxNavigation from '../../components/transactions/TxNavigation'
 import { useHasPendingTxs, usePendingTxsQueue } from '@/hooks/usePendingTxs'
 
 const Queue: NextPage = () => {
@@ -19,14 +18,9 @@ const Queue: NextPage = () => {
       </Head>
 
       <BatchExecuteHoverProvider>
-        <TxHeader
-          action={
-            <Box display="flex" justifyContent="space-between" alignItems="center">
-              <TxNavigation />
-              <BatchExecuteButton />
-            </Box>
-          }
-        />
+        <TxHeader>
+          <BatchExecuteButton />
+        </TxHeader>
 
         <main>
           <Box mb={4}>


### PR DESCRIPTION
## What it solves

Resolves #1777 

## How this PR fixes it

- Unifies all `PageHeader`s (Settings, Transactions, Assets)
- Removes the word-break for connect wallet on mobile
- Removes sticky from the transaction filter on mobile because buttons are not reachable

## How to test it

1. Open the Safe on mobile
2. Observe the Connect wallet button in the header not breaking words to the next line
3. Navigate to Assets, NFTs, History, Queue, Settings
4. Observe the layout not breaking

## Screenshots

<img width="406" alt="Screenshot 2023-04-13 at 15 06 29" src="https://user-images.githubusercontent.com/5880855/231767917-560de46f-9378-4035-b964-b41a69ffad5e.png">
<img width="396" alt="Screenshot 2023-04-13 at 15 06 39" src="https://user-images.githubusercontent.com/5880855/231767952-564d99a0-e5f4-4efa-81d3-bd4b97c62e81.png">
<img width="396" alt="Screenshot 2023-04-13 at 15 06 51" src="https://user-images.githubusercontent.com/5880855/231768001-1a4a637b-bf1f-41b2-8c0c-51ca6a969307.png">
<img width="399" alt="Screenshot 2023-04-13 at 15 07 05" src="https://user-images.githubusercontent.com/5880855/231768049-cadab9d3-3291-4352-9a28-3a26683df3f7.png">


## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
