### PR TITLE
fix: create Safe App share URL in `useEffect`

### DIFF
--- a/src/components/safe-apps/AddCustomAppModal/index.tsx
+++ b/src/components/safe-apps/AddCustomAppModal/index.tsx
@@ -26,7 +26,7 @@ import { SAFE_APPS_EVENTS, trackSafeAppEvent } from '@/services/analytics'
 import { isSameUrl, trimTrailingSlash } from '@/utils/url'
 import CustomAppPlaceholder from './CustomAppPlaceholder'
 import CustomApp from './CustomApp'
-import { getShareSafeAppUrl } from '@/components/safe-apps/SafeAppActionButtons'
+import { useShareSafeAppUrl } from '@/components/safe-apps/hooks/useShareSafeAppUrl'
 
 import css from './styles.module.css'
 import ExternalLink from '@/components/common/ExternalLink'
@@ -90,7 +90,7 @@ export const AddCustomAppModal = ({ open, onClose, onSave, safeAppsList }: Props
     [safeAppsList],
   )
 
-  const shareSafeAppUrl = getShareSafeAppUrl(router, safeApp?.url || '', currentChain)
+  const shareSafeAppUrl = useShareSafeAppUrl(safeApp?.url || '')
   const isSafeAppValid = isValid && safeApp
   const isCustomAppInTheDefaultList = errors?.appUrl?.type === 'alreadyExists'
 

--- a/src/components/safe-apps/SafeAppActionButtons/index.tsx
+++ b/src/components/safe-apps/SafeAppActionButtons/index.tsx
@@ -1,16 +1,11 @@
-import { useRouter } from 'next/router'
-import { resolveHref } from 'next/dist/shared/lib/router/router'
-import type { UrlObject } from 'url'
-import type { ChainInfo, SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
-import type { NextRouter } from 'next/router'
+import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
 import Box from '@mui/material/Box'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
 import SvgIcon from '@mui/material/SvgIcon'
 
-import { AppRoutes } from '@/config/routes'
+import { useShareSafeAppUrl } from '@/components/safe-apps/hooks/useShareSafeAppUrl'
 import { SAFE_APPS_EVENTS, trackSafeAppEvent } from '@/services/analytics'
-import { useCurrentChain } from '@/hooks/useChains'
 import CopyButton from '@/components/common/CopyButton'
 import ShareIcon from '@/public/images/common/share.svg'
 import BookmarkIcon from '@/public/images/apps/bookmark.svg'
@@ -30,11 +25,8 @@ const SafeAppActionButtons = ({
   onBookmarkSafeApp,
   removeCustomApp,
 }: SafeAppActionButtonsProps) => {
-  const router = useRouter()
-  const currentChain = useCurrentChain()
-
   const isCustomApp = safeApp.id < 1
-  const shareSafeAppUrl = getShareSafeAppUrl(router, safeApp.url, currentChain)
+  const shareSafeAppUrl = useShareSafeAppUrl(safeApp.url)
 
   const handleCopyShareSafeAppUrl = () => {
     const appName = isCustomApp ? safeApp.url : safeApp.name
@@ -93,14 +85,3 @@ const SafeAppActionButtons = ({
 }
 
 export default SafeAppActionButtons
-
-export const getShareSafeAppUrl = (router: NextRouter, appUrl: string, currentChain?: ChainInfo) => {
-  const shareUrlObj: UrlObject = {
-    protocol: typeof window !== 'undefined' ? window.location.protocol : '',
-    host: typeof window !== 'undefined' ? window.location.host : '',
-    pathname: AppRoutes.share.safeApp,
-    query: { appUrl, chain: currentChain?.shortName },
-  }
-
-  return resolveHref(router, shareUrlObj)
-}

--- a/src/components/safe-apps/hooks/useShareSafeAppUrl.ts
+++ b/src/components/safe-apps/hooks/useShareSafeAppUrl.ts
@@ -1,0 +1,30 @@
+import { useRouter } from 'next/router'
+import { resolveHref } from 'next/dist/shared/lib/router/router'
+import { useEffect, useState } from 'react'
+import type { UrlObject } from 'url'
+
+import { AppRoutes } from '@/config/routes'
+import { useCurrentChain } from '@/hooks/useChains'
+
+export const useShareSafeAppUrl = (appUrl: string): string => {
+  const router = useRouter()
+  const chain = useCurrentChain()
+  const [shareSafeAppUrl, setShareSafeAppUrl] = useState('')
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const shareUrlObj: UrlObject = {
+      protocol: window.location.protocol,
+      host: window.location.host,
+      pathname: AppRoutes.share.safeApp,
+      query: { appUrl, chain: chain?.shortName },
+    }
+
+    setShareSafeAppUrl(resolveHref(router, shareUrlObj))
+  }, [appUrl, chain?.shortName, router])
+
+  return shareSafeAppUrl
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,6 +13,10 @@ const IndexPage: NextPage = () => {
   const safeAddress = safe || lastSafe
 
   useIsomorphicEffect(() => {
+    if (router.pathname !== AppRoutes.index) {
+      return
+    }
+
     router.replace(
       safeAddress
         ? `${AppRoutes.home}?safe=${safeAddress}`


### PR DESCRIPTION
## What it solves

Resolves #1644

## How this PR fixes it

Creation of the Safe App share URL now happens inside a `useEffect`.

## How to test it

- Ensure Safe Apps share URL is created correctly.
- Ensure the share page of the Safe App opens and does not redirect away.

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
