### PR TITLE
fix: allow using the injected wallet on mobile

### DIFF
--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -92,12 +92,7 @@ const trackWalletType = (wallet: ConnectedWallet) => {
 const isMobile = () => /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
 
 // Detect injected wallet
-const hasInjectedWallet = () => {
-  if (typeof window === 'undefined') {
-    return false
-  }
-  return !!window?.ethereum
-}
+const hasInjectedWallet = () => typeof window !== 'undefined' && !!window?.ethereum
 
 // `connectWallet` is called when connecting/switching wallets and on pairing `connect` event (when prev. session connects)
 // This re-entrant lock prevents multiple `connectWallet`/tracking calls that would otherwise occur for pairing module

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -91,6 +91,14 @@ const trackWalletType = (wallet: ConnectedWallet) => {
 // Detect mobile devices
 const isMobile = () => /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
 
+// Detect injected wallet
+const hasInjectedWallet = () => {
+  if (typeof window === 'undefined') {
+    return false
+  }
+  return !!window?.ethereum
+}
+
 // `connectWallet` is called when connecting/switching wallets and on pairing `connect` event (when prev. session connects)
 // This re-entrant lock prevents multiple `connectWallet`/tracking calls that would otherwise occur for pairing module
 let isConnecting = false
@@ -106,8 +114,8 @@ export const connectWallet = async (
 
   isConnecting = true
 
-  // On mobile, automatically choose WalletConnect
-  if (!options && isMobile()) {
+  // On mobile, automatically choose WalletConnect if there is no injected wallet
+  if (!options && isMobile() && !hasInjectedWallet()) {
     options = {
       autoSelect: WalletNames.WALLET_CONNECT,
     }


### PR DESCRIPTION
Note: I do not have access to an iOS device and have only tested this on Android. Faking the UA on desktop shows it working on iOS, but it should still be tested on a physical device.

## What it solves

Resolves #1878

## How this PR fixes it

The presence of `window.ethereum` is also checked before automatically connecting to WalletConnect on mobile. If it _is_ present (an inject wallet exists), no autoconnection occurs.

## How to test it

### _Without_ injected wallet
1. Open the Safe on mobile _without_ an injected wallet installed: on Safari (on iPhone) or on Chrome/Firefox with no extensions (on Android).
2. Click connect and observe the WalletConnect QR immediately shown.

### _With_ injected wallet
1. Open the Safe on mobile _with_ an injected wallet installed: on Chrome/Firefox with the Coinbase/MetaMask extension installed (on Android).
2. Click connect and observe the standard wallet modal shown.

## Screenshots

### _Without_ injected wallet

![without-injected](https://user-images.githubusercontent.com/20442784/233023541-9b383a00-dce0-406c-a53e-4f5e1a72d405.gif)

### _With_ injected wallet

![with-injected](https://user-images.githubusercontent.com/20442784/233023564-1d7f681c-5a5d-4acf-aba6-32cbfd176cbe.gif)

## Checklist
* [x] I've tested the branch on *Android* 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
