### PR TITLE
fix: refresh remaining relays after relay

### DIFF
--- a/src/hooks/__tests__/useRemainingRelays.test.ts
+++ b/src/hooks/__tests__/useRemainingRelays.test.ts
@@ -60,6 +60,25 @@ describe('fetch remaining relays hooks', () => {
       renderHook(() => useRemainingRelaysBySafe())
       expect(mockFetch).toHaveBeenCalledTimes(0)
     })
+
+    it('refetch if the txHistoryTag changes', () => {
+      global.fetch = jest.fn()
+      const mockFetch = jest.spyOn(global, 'fetch')
+
+      const render = renderHook(() => useRemainingRelaysBySafe())
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      jest.spyOn(useSafeInfo, 'default').mockReturnValue({
+        safe: {
+          txHistoryTag: 'new',
+        },
+        safeAddress: SAFE_ADDRESS,
+      } as ReturnType<typeof useSafeInfo.default>)
+
+      render.rerender()
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
   })
 
   describe('useLeastRemainingRelays hook', () => {
@@ -142,6 +161,28 @@ describe('fetch remaining relays hooks', () => {
 
       renderHook(() => useLeastRemainingRelays(ownerAddresses))
       expect(mockFetch).toHaveBeenCalledTimes(0)
+    })
+
+    it('refetch if the txHistoryTag changes', () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ remaining: 3 }),
+      })
+
+      const mockFetch = jest.spyOn(global, 'fetch')
+
+      const render = renderHook(() => useLeastRemainingRelays(ownerAddresses))
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+
+      jest.spyOn(useSafeInfo, 'default').mockReturnValue({
+        safe: {
+          txHistoryTag: 'new',
+        },
+        safeAddress: SAFE_ADDRESS,
+      } as ReturnType<typeof useSafeInfo.default>)
+
+      render.rerender()
+
+      expect(mockFetch).toHaveBeenCalledTimes(6)
     })
   })
 })

--- a/src/hooks/__tests__/useRemainingRelays.test.ts
+++ b/src/hooks/__tests__/useRemainingRelays.test.ts
@@ -4,9 +4,9 @@ import {
   useRemainingRelaysBySafe,
   SAFE_GELATO_RELAY_SERVICE_URL,
 } from '@/hooks/useRemainingRelays'
-import * as useSafeAddress from '@/hooks/useSafeAddress'
+import * as useSafeInfo from '@/hooks/useSafeInfo'
 import * as useChains from '@/hooks/useChains'
-import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { FEATURES } from '@/utils/chains'
 
 const SAFE_ADDRESS = '0x0000000000000000000000000000000000000001'
@@ -16,12 +16,22 @@ describe('fetch remaining relays hooks', () => {
     jest
       .spyOn(useChains, 'useCurrentChain')
       .mockReturnValue({ chainId: '5', features: FEATURES.RELAYING } as unknown as ChainInfo)
-    jest.spyOn(useSafeAddress, 'default').mockReturnValue(SAFE_ADDRESS)
+    jest.spyOn(useSafeInfo, 'default').mockReturnValue({
+      safe: {
+        txHistoryTag: '0',
+      },
+      safeAddress: SAFE_ADDRESS,
+    } as ReturnType<typeof useSafeInfo.default>)
   })
 
   describe('useRemainingRelaysBySafe hook', () => {
     it('should not call fetch if empty safe address', () => {
-      jest.spyOn(useSafeAddress, 'default').mockReturnValue('')
+      jest.spyOn(useSafeInfo, 'default').mockReturnValue({
+        safe: {
+          txHistoryTag: '0',
+        },
+        safeAddress: '',
+      } as ReturnType<typeof useSafeInfo.default>)
 
       global.fetch = jest.fn()
       const mockFetch = jest.spyOn(global, 'fetch')

--- a/src/hooks/useRemainingRelays.ts
+++ b/src/hooks/useRemainingRelays.ts
@@ -1,5 +1,5 @@
 import useAsync from '@/hooks/useAsync'
-import useSafeAddress from '@/hooks/useSafeAddress'
+import useSafeInfo from './useSafeInfo'
 import { Errors, logError } from '@/services/exceptions'
 import {
   IS_PRODUCTION,
@@ -31,20 +31,21 @@ const fetchRemainingRelays = async (chainId: string, address: string): Promise<n
 
 export const useRemainingRelaysBySafe = () => {
   const chain = useCurrentChain()
-  const safeAddress = useSafeAddress()
+  const { safe, safeAddress } = useSafeInfo()
   const [isRelayingEnabled] = useRelayingDebugger()
 
   return useAsync(() => {
     if (!safeAddress || !chain || !hasFeature(chain, FEATURES.RELAYING) || !isRelayingEnabled) return
 
     return fetchRemainingRelays(chain.chainId, safeAddress)
-  }, [chain, safeAddress])
+  }, [chain, safeAddress, safe.txHistoryTag])
 }
 
 const getMinimum = (result: number[]) => Math.min(...result)
 
 export const useLeastRemainingRelays = (ownerAddresses: string[]) => {
   const chain = useCurrentChain()
+  const { safe } = useSafeInfo()
   const [isRelayingEnabled] = useRelayingDebugger()
 
   return useAsync(async () => {
@@ -53,5 +54,5 @@ export const useLeastRemainingRelays = (ownerAddresses: string[]) => {
     const result = await Promise.all(ownerAddresses.map((address) => fetchRemainingRelays(chain.chainId, address)))
 
     return getMinimum(result)
-  }, [chain, ownerAddresses])
+  }, [chain, ownerAddresses, safe.txHistoryTag])
 }


### PR DESCRIPTION
## What it solves

Resolves #1879

## How this PR fixes it

Both `useRemainingRelaysBySafe` and `useLeastRemainingRelays` now refetch if the polled-for `safe.txHistoryTag` updates, meaning that any successful relays cause a refresh of the remaining relays possible.

## How to test it

1. Relay a transaction whilst on the dashboard and do not navigate away.
2. Observe the relay widget reducing after the transaction was successful.

## Screenshots

![dashboard-widget](https://user-images.githubusercontent.com/20442784/233096499-461d2912-2912-414d-9869-a1ffdba2ab47.gif)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
