### PR TITLE
Feat: decode native transfers + show Multisend in the tx info block

### DIFF
--- a/cypress/e2e/smoke/balances.cy.js
+++ b/cypress/e2e/smoke/balances.cy.js
@@ -15,7 +15,7 @@ describe('Assets > Coins', () => {
   before(() => {
     // Open the Safe used for testing
     cy.visit(`/${TEST_SAFE}/balances`, { failOnStatusCode: false })
-    cy.contains('button', 'Accept selection').click()
+    cy.contains('button', 'Accept all').click()
     // Table is loaded
     cy.contains('Görli Ether')
 
@@ -201,6 +201,7 @@ describe('Assets > Coins', () => {
     before(() => {
       // Open the Safe used for testing pagination
       cy.visit(`/${PAGINATION_TEST_SAFE}/balances`, { failOnStatusCode: false })
+      cy.contains('button', 'Accept all').click()
 
       // Table is loaded
       cy.contains('Görli Ether')

--- a/cypress/e2e/smoke/nfts.cy.js
+++ b/cypress/e2e/smoke/nfts.cy.js
@@ -80,9 +80,11 @@ describe('Assets > NFTs', () => {
       cy.contains('button', 'Next').click()
 
       // Review modal appears
-      cy.contains('Review transaction')
+      cy.contains('Review NFT transaction')
       cy.contains('Sending 2 NFTs from')
-      cy.contains('Batched transactions')
+      cy.wait(1000)
+      cy.contains('Action 1')
+      cy.contains('Action 2')
       cy.get('b:contains("safeTransferFrom")').should('have.length', 2)
       cy.contains('button:not([disabled])', 'Submit')
     })

--- a/src/components/safe-apps/SafeAppsTxModal/ReviewSafeAppsTx.tsx
+++ b/src/components/safe-apps/SafeAppsTxModal/ReviewSafeAppsTx.tsx
@@ -1,15 +1,11 @@
 import { useMemo, useState } from 'react'
 import type { ReactElement } from 'react'
 import type { DecodedDataResponse } from '@safe-global/safe-gateway-typescript-sdk'
-import { getDecodedData, Operation } from '@safe-global/safe-gateway-typescript-sdk'
+import { getDecodedData } from '@safe-global/safe-gateway-typescript-sdk'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
-import { OperationType } from '@safe-global/safe-core-sdk-types'
-import { Box, Typography } from '@mui/material'
 import SendFromBlock from '@/components/tx/SendFromBlock'
-import Multisend from '@/components/transactions/TxDetails/TxData/DecodedData/Multisend'
 import SendToBlock from '@/components/tx/SendToBlock'
 import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
-import { generateDataRowValue } from '@/components/transactions/TxDetails/Summary/TxDataRow'
 import useAsync from '@/hooks/useAsync'
 import useChainId from '@/hooks/useChainId'
 import { useCurrentChain } from '@/hooks/useChains'
@@ -75,34 +71,10 @@ const ReviewSafeAppsTx = ({
     <SignOrExecuteForm safeTx={safeTx} onSubmit={handleSubmit} error={safeTxError || submitError} origin={origin}>
       <>
         <ApprovalEditor txs={txList} updateTxs={setTxList} />
+
         <SendFromBlock />
-        {safeTx && (
-          <>
-            <SendToBlock address={safeTx.data.to} title={getInteractionTitle(safeTx.data.value || '', chain)} />
 
-            <Box pb={2}>
-              <Typography mt={2} color="primary.light">
-                Data (hex encoded)
-              </Typography>
-              {generateDataRowValue(safeTx.data.data, 'rawData')}
-            </Box>
-
-            {isMultiSend && (
-              <Box mb={2} display="flex" flexDirection="column" gap={1}>
-                <Multisend
-                  txData={{
-                    dataDecoded: decodedData,
-                    to: { value: safeTx.data.to },
-                    value: safeTx.data.value,
-                    operation: safeTx.data.operation === OperationType.Call ? Operation.CALL : Operation.DELEGATE,
-                    trustedDelegateCallTarget: false,
-                  }}
-                  variant="outlined"
-                />
-              </Box>
-            )}
-          </>
-        )}
+        {safeTx && <SendToBlock address={safeTx.data.to} title={getInteractionTitle(safeTx.data.value || '', chain)} />}
       </>
     </SignOrExecuteForm>
   )

--- a/src/components/transactions/HexEncodedData/index.tsx
+++ b/src/components/transactions/HexEncodedData/index.tsx
@@ -28,7 +28,7 @@ export const HexEncodedData = ({ hexData, title, limit = 20 }: Props): ReactElem
       {showExpandBtn ? (
         <>
           {showTxData ? hexData : shortenText(hexData, 25)}{' '}
-          <Link component="button" onClick={toggleExpanded} type="button">
+          <Link component="button" onClick={toggleExpanded} type="button" sx={{ verticalAlign: 'text-top' }}>
             Show {showTxData ? 'less' : 'more'}
           </Link>
         </>

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -6,6 +6,7 @@ import type { Dispatch, ReactElement, SetStateAction } from 'react'
 import type { AccordionProps } from '@mui/material/Accordion/Accordion'
 import SingleTxDecoded from '@/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded'
 import { AccordionSummary, Box, Button, Divider } from '@mui/material'
+import css from './styles.module.css'
 
 type MultisendProps = {
   txData?: TransactionData
@@ -14,24 +15,7 @@ type MultisendProps = {
   noHeader?: boolean
 }
 
-const MIN_MULTISEND_TXS = 3
-
-const multisendScrollSx = {
-  'max-height': '168px',
-  overflow: 'auto',
-  pb: '2em',
-  '&:after': {
-    content: '""',
-    position: 'absolute',
-    'z-index': 1,
-    bottom: 0,
-    left: 0,
-    'pointer-events': 'none',
-    'background-image': 'linear-gradient(to bottom, rgba(255,255,255,0), rgba(255,255,255, 1) 90%)',
-    width: '100%',
-    height: '4em',
-  },
-}
+const MIN_SCROLL_TXS = 4
 
 const MultisendActionsHeader = ({
   setOpen,
@@ -46,14 +30,14 @@ const MultisendActionsHeader = ({
 
   return (
     <AccordionSummary
-      sx={{ borderBottom: ({ palette }) => `1px solid ${palette.border.light}`, cursor: 'auto !important', pr: 0 }}
+      className={css.summary}
       expandIcon={
         <>
-          <Button onClick={onClickAll(true)} variant="text" sx={{ px: '18px' }}>
+          <Button onClick={onClickAll(true)} variant="text">
             Expand all
           </Button>
-          <Divider sx={{ my: '14px', borderColor: 'border.light' }} />
-          <Button onClick={onClickAll(false)} variant="text" sx={{ px: '18px' }}>
+          <Divider className={css.divider} />
+          <Button onClick={onClickAll(false)} variant="text">
             Collapse all
           </Button>
         </>
@@ -105,7 +89,7 @@ export const Multisend = ({
     <>
       {!noHeader && <MultisendActionsHeader setOpen={setOpenMap} amount={multiSendTransactions.length} />}
 
-      <Box sx={multiSendTransactions.length > MIN_MULTISEND_TXS ? multisendScrollSx : undefined}>
+      <div className={multiSendTransactions.length >= MIN_SCROLL_TXS ? css.scrollWrapper : undefined}>
         <Box display="flex" flexDirection="column" gap={1}>
           {multiSendTransactions.map(({ dataDecoded, data, value, to, operation }, index) => {
             const onChange: AccordionProps['onChange'] = (_, expanded) => {
@@ -135,7 +119,7 @@ export const Multisend = ({
             )
           })}
         </Box>
-      </Box>
+      </div>
     </>
   )
 }

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -5,12 +5,32 @@ import { useState, useEffect } from 'react'
 import type { Dispatch, ReactElement, SetStateAction } from 'react'
 import type { AccordionProps } from '@mui/material/Accordion/Accordion'
 import SingleTxDecoded from '@/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded'
-import { AccordionSummary, Button, Divider } from '@mui/material'
+import { AccordionSummary, Box, Button, Divider } from '@mui/material'
 
 type MultisendProps = {
   txData?: TransactionData
   variant?: AccordionProps['variant']
   showDelegateCallWarning?: boolean
+  noHeader?: boolean
+}
+
+const MIN_MULTISEND_TXS = 3
+
+const multisendScrollSx = {
+  'max-height': '168px',
+  overflow: 'auto',
+  pb: '2em',
+  '&:after': {
+    content: '""',
+    position: 'absolute',
+    'z-index': 1,
+    bottom: 0,
+    left: 0,
+    'pointer-events': 'none',
+    'background-image': 'linear-gradient(to bottom, rgba(255,255,255,0), rgba(255,255,255, 1) 90%)',
+    width: '100%',
+    height: '4em',
+  },
 }
 
 const MultisendActionsHeader = ({
@@ -48,6 +68,7 @@ export const Multisend = ({
   txData,
   variant = 'elevation',
   showDelegateCallWarning = true,
+  noHeader = false,
 }: MultisendProps): ReactElement | null => {
   const [openMap, setOpenMap] = useState<Record<number, boolean>>()
   const isOpenMapUndefined = openMap == null
@@ -82,34 +103,39 @@ export const Multisend = ({
 
   return (
     <>
-      <MultisendActionsHeader setOpen={setOpenMap} amount={multiSendTransactions.length} />
-      {multiSendTransactions.map(({ dataDecoded, data, value, to, operation }, index) => {
-        const onChange: AccordionProps['onChange'] = (_, expanded) => {
-          setOpenMap((prev) => ({
-            ...prev,
-            [index]: expanded,
-          }))
-        }
+      {!noHeader && <MultisendActionsHeader setOpen={setOpenMap} amount={multiSendTransactions.length} />}
 
-        return (
-          <SingleTxDecoded
-            key={`${data ?? to}-${index}`}
-            tx={{
-              dataDecoded,
-              data,
-              value,
-              to,
-              operation,
-            }}
-            txData={txData}
-            showDelegateCallWarning={showDelegateCallWarning}
-            actionTitle={`Action ${index + 1}`}
-            variant={variant}
-            expanded={openMap?.[index] ?? false}
-            onChange={onChange}
-          />
-        )
-      })}
+      <Box sx={multiSendTransactions.length > MIN_MULTISEND_TXS ? multisendScrollSx : undefined}>
+        <Box display="flex" flexDirection="column" gap={1}>
+          {multiSendTransactions.map(({ dataDecoded, data, value, to, operation }, index) => {
+            const onChange: AccordionProps['onChange'] = (_, expanded) => {
+              setOpenMap((prev) => ({
+                ...prev,
+                [index]: expanded,
+              }))
+            }
+
+            return (
+              <SingleTxDecoded
+                key={`${data ?? to}-${index}`}
+                tx={{
+                  dataDecoded,
+                  data,
+                  value,
+                  to,
+                  operation,
+                }}
+                txData={txData}
+                showDelegateCallWarning={showDelegateCallWarning}
+                actionTitle={`Action ${index + 1}`}
+                variant={variant}
+                expanded={openMap?.[index] ?? false}
+                onChange={onChange}
+              />
+            )
+          })}
+        </Box>
+      </Box>
     </>
   )
 }

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
@@ -1,0 +1,34 @@
+.scrollWrapper {
+  max-height: 168px;
+  overflow: auto;
+  padding-bottom: 2em;
+}
+
+.scrollWrapper:after {
+  content: '';
+  position: absolute;
+  z-index: 1;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+  background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 90%);
+  width: 100%;
+  height: 4em;
+}
+
+.summary {
+  border-bottom: 1px solid var(--color-border-light);
+  cursor: auto !important;
+  padding-right: 0;
+}
+
+.summary button {
+  padding-left: 18px;
+  padding-right: 18px;
+}
+
+.divider {
+  margin-top: 14px;
+  margin-bottom: 14px;
+  border-color: var(--color-border-light);
+}

--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -34,7 +34,6 @@ export const SingleTxDecoded = ({
 }: SingleTxDecodedProps) => {
   const chain = useCurrentChain()
   const method = tx.dataDecoded?.method || ''
-  // @FIXME: why is this always taking the native token decimals?
   const { decimals, symbol } = chain?.nativeCurrency || {}
   const amount = tx.value ? formatVisualAmount(tx.value, decimals) : 0
 

--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -34,7 +34,8 @@ export const SingleTxDecoded = ({
 }: SingleTxDecodedProps) => {
   const chain = useCurrentChain()
   const method = tx.dataDecoded?.method || ''
-  const { decimals, symbol } = chain!.nativeCurrency
+  // @FIXME: why is this always taking the native token decimals?
+  const { decimals, symbol } = chain?.nativeCurrency || {}
   const amount = tx.value ? formatVisualAmount(tx.value, decimals) : 0
 
   let details

--- a/src/components/tx/DecodedTx/index.test.tsx
+++ b/src/components/tx/DecodedTx/index.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render } from '@/tests/test-utils'
+import { act, fireEvent, render } from '@/tests/test-utils'
 import { type SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import * as gatewayMethods from '@safe-global/safe-gateway-typescript-sdk'
 import DecodedTx from '.'
 
 describe('DecodedTx', () => {
@@ -25,7 +26,9 @@ describe('DecodedTx', () => {
       />,
     )
 
-    fireEvent.click(result.getByText('Transaction details'))
+    act(() => {
+      fireEvent.click(result.getByText('Transaction details'))
+    })
 
     expect(result.queryByText('Native token transfer')).toBeInTheDocument()
     expect(result.queryByText('to(address):')).toBeInTheDocument()
@@ -34,7 +37,25 @@ describe('DecodedTx', () => {
     expect(result.queryByText('1000000')).toBeInTheDocument()
   })
 
-  xit('should render an ERC20 transfer', async () => {
+  it('should render an ERC20 transfer', async () => {
+    jest.spyOn(gatewayMethods, 'getDecodedData').mockReturnValue(
+      Promise.resolve({
+        method: 'transfer',
+        parameters: [
+          {
+            name: 'to',
+            type: 'address',
+            value: '0x474e5Ded6b5D078163BFB8F6dBa355C3aA5478C8',
+          },
+          {
+            name: 'value',
+            type: 'uint256',
+            value: '16745726664999765048',
+          },
+        ],
+      }),
+    )
+
     const result = render(
       <DecodedTx
         tx={
@@ -56,10 +77,88 @@ describe('DecodedTx', () => {
       />,
     )
 
-    fireEvent.click(result.getByText('Transaction details'))
+    await act(() => {
+      fireEvent.click(result.getByText('Transaction details'))
+      return Promise.resolve()
+    })
+
+    result.debug()
+
+    expect(result.queryByText('transfer')).toBeInTheDocument()
+    expect(result.queryByText('to(address):')).toBeInTheDocument()
+    expect(result.queryByText('0x474e...78C8')).toBeInTheDocument()
+    expect(result.queryByText('value(uint256):')).toBeInTheDocument()
+    expect(result.queryByText('16745726664999765048')).toBeInTheDocument()
   })
 
-  xit('should render a multisend transaction', () => {
+  it('should render a multisend transaction', async () => {
+    jest.spyOn(gatewayMethods, 'getDecodedData').mockReturnValue(
+      Promise.resolve({
+        method: 'multiSend',
+        parameters: [
+          {
+            name: 'transactions',
+            type: 'bytes',
+            value: '0x0057f1887a8bf19b14fc0df',
+            valueDecoded: [
+              {
+                operation: 0,
+                to: '0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85',
+                value: '0',
+                data: '0x42842e0e0000000000000000000',
+                dataDecoded: {
+                  method: 'safeTransferFrom',
+                  parameters: [
+                    {
+                      name: 'from',
+                      type: 'address',
+                      value: '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
+                    },
+                    {
+                      name: 'to',
+                      type: 'address',
+                      value: '0x474e5Ded6b5D078163BFB8F6dBa355C3aA5478C8',
+                    },
+                    {
+                      name: 'tokenId',
+                      type: 'uint256',
+                      value: '52964617156216674852059480948658573966398315289847646343083345905048987083870',
+                    },
+                  ],
+                },
+              },
+              {
+                operation: 0,
+                to: '0xD014e20A75437a4bd0FbB40498FF94e6F337c3e9',
+                value: '0',
+                data: '0x42842e0e000000000000000000000000a77de',
+                dataDecoded: {
+                  method: 'safeTransferFrom',
+                  parameters: [
+                    {
+                      name: 'from',
+                      type: 'address',
+                      value: '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
+                    },
+                    {
+                      name: 'to',
+                      type: 'address',
+                      value: '0x474e5Ded6b5D078163BFB8F6dBa355C3aA5478C8',
+                    },
+                    {
+                      name: 'tokenId',
+                      type: 'uint256',
+                      value: '412',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
     const result = render(
       <DecodedTx
         tx={
@@ -67,7 +166,7 @@ describe('DecodedTx', () => {
             data: {
               to: '0x40A2aCCbd92BCA938b02010E17A5b8929b49130D',
               value: '0',
-              data: '0x8d80ff0a0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000017200317a8fe0f1c7102e7674ab231441e485c64c178a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006442842e0e000000000000000000000000c8b4da63f0b4413e4c8815143d28a642f6bd2309000000000000000000000000474e5ded6b5d078163bfb8f6dba355c3aa5478c80000000000000000000000000000000000000000000000000000000000075be60057f1887a8bf19b14fc0df6fd9b2acc9af147ea850000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006442842e0e000000000000000000000000c8b4da63f0b4413e4c8815143d28a642f6bd2309000000000000000000000000474e5ded6b5d078163bfb8f6dba355c3aa5478c81fc6ee99304bff67410b0c26bb11c8fa36bf39e7de082f8e437231e89ed069dc0000000000000000000000000000',
+              data: '0x8d80ff0',
               operation: 1,
               baseGas: 0,
               gasPrice: 0,
@@ -81,6 +180,11 @@ describe('DecodedTx', () => {
       />,
     )
 
-    fireEvent.click(result.getByText('Transaction details'))
+    await act(() => Promise.resolve())
+
+    expect(result.queryByText('multi Send')).toBeInTheDocument()
+    expect(result.queryByText('transactions(bytes):')).toBeInTheDocument()
+    expect(result.queryByText('Action 1')).toBeInTheDocument()
+    expect(result.queryByText('Action 2')).toBeInTheDocument()
   })
 })

--- a/src/components/tx/DecodedTx/index.test.tsx
+++ b/src/components/tx/DecodedTx/index.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render } from '@/tests/test-utils'
+import { type SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import DecodedTx from '.'
+
+describe('DecodedTx', () => {
+  it('should render a native transfer', async () => {
+    const result = render(
+      <DecodedTx
+        tx={
+          {
+            data: {
+              to: '0x3430d04E42a722c5Ae52C5Bffbf1F230C2677600',
+              value: '1000000',
+              data: '0x',
+              operation: 0,
+              baseGas: 0,
+              gasPrice: 0,
+              gasToken: '0x0000000000000000000000000000000000000000',
+              refundReceiver: '0x0000000000000000000000000000000000000000',
+              nonce: 58,
+              safeTxGas: 0,
+            },
+          } as SafeTransaction
+        }
+      />,
+    )
+
+    fireEvent.click(result.getByText('Transaction details'))
+
+    expect(result.queryByText('Native token transfer')).toBeInTheDocument()
+    expect(result.queryByText('to(address):')).toBeInTheDocument()
+    expect(result.queryByText('0x3430...7600')).toBeInTheDocument()
+    expect(result.queryByText('value(uint256):')).toBeInTheDocument()
+    expect(result.queryByText('1000000')).toBeInTheDocument()
+  })
+
+  xit('should render an ERC20 transfer', async () => {
+    const result = render(
+      <DecodedTx
+        tx={
+          {
+            data: {
+              to: '0x3430d04E42a722c5Ae52C5Bffbf1F230C2677600',
+              value: '0',
+              data: '0xa9059cbb000000000000000000000000474e5ded6b5d078163bfb8f6dba355c3aa5478c80000000000000000000000000000000000000000000000008ac7230489e80000',
+              operation: 0,
+              baseGas: 0,
+              gasPrice: 0,
+              gasToken: '0x0000000000000000000000000000000000000000',
+              refundReceiver: '0x0000000000000000000000000000000000000000',
+              nonce: 58,
+              safeTxGas: 0,
+            },
+          } as SafeTransaction
+        }
+      />,
+    )
+
+    fireEvent.click(result.getByText('Transaction details'))
+  })
+
+  xit('should render a multisend transaction', () => {
+    const result = render(
+      <DecodedTx
+        tx={
+          {
+            data: {
+              to: '0x40A2aCCbd92BCA938b02010E17A5b8929b49130D',
+              value: '0',
+              data: '0x8d80ff0a0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000017200317a8fe0f1c7102e7674ab231441e485c64c178a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006442842e0e000000000000000000000000c8b4da63f0b4413e4c8815143d28a642f6bd2309000000000000000000000000474e5ded6b5d078163bfb8f6dba355c3aa5478c80000000000000000000000000000000000000000000000000000000000075be60057f1887a8bf19b14fc0df6fd9b2acc9af147ea850000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006442842e0e000000000000000000000000c8b4da63f0b4413e4c8815143d28a642f6bd2309000000000000000000000000474e5ded6b5d078163bfb8f6dba355c3aa5478c81fc6ee99304bff67410b0c26bb11c8fa36bf39e7de082f8e437231e89ed069dc0000000000000000000000000000',
+              operation: 1,
+              baseGas: 0,
+              gasPrice: 0,
+              gasToken: '0x0000000000000000000000000000000000000000',
+              refundReceiver: '0x0000000000000000000000000000000000000000',
+              nonce: 58,
+              safeTxGas: 0,
+            },
+          } as SafeTransaction
+        }
+      />,
+    )
+
+    fireEvent.click(result.getByText('Transaction details'))
+  })
+})

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -1,6 +1,6 @@
 import type { SyntheticEvent, ReactElement } from 'react'
 import { Accordion, AccordionDetails, AccordionSummary, Box, Skeleton } from '@mui/material'
-import { type SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import { OperationType, type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import {
   type DecodedDataResponse,
   getDecodedData,
@@ -82,7 +82,7 @@ const DecodedTx = ({ tx, txId }: DecodedTxProps): ReactElement | null => {
                   dataDecoded: decodedData,
                   to: { value: tx?.data.to || '' },
                   value: tx?.data.value,
-                  operation: Operation.CALL,
+                  operation: tx?.data.operation === OperationType.DelegateCall ? Operation.DELEGATE : Operation.CALL,
                   trustedDelegateCallTarget: false,
                 }}
                 variant="outlined"

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -27,7 +27,8 @@ const DecodedTx = ({ tx, txId }: DecodedTxProps): ReactElement | null => {
   const chainId = useChainId()
   const encodedData = tx?.data.data
   const isEmptyData = !!encodedData && isEmptyHexData(encodedData)
-  const nativeTransfer = isEmptyData ? getNativeTransferData(tx?.data) : undefined
+  const isRejection = isEmptyData && tx?.data.value === '0'
+  const nativeTransfer = isEmptyData && !isRejection ? getNativeTransferData(tx?.data) : undefined
 
   const [decodedData = nativeTransfer, decodedDataError, decodedDataLoading] = useAsync<DecodedDataResponse>(() => {
     if (!encodedData || isEmptyData) return
@@ -44,6 +45,8 @@ const DecodedTx = ({ tx, txId }: DecodedTxProps): ReactElement | null => {
   const onChangeExpand = (_: SyntheticEvent, expanded: boolean) => {
     trackEvent({ ...MODALS_EVENTS.TX_DETAILS, label: expanded ? 'Open' : 'Close' })
   }
+
+  if (isRejection) return null
 
   return (
     <Box mb={2}>

--- a/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.test.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.test.tsx
@@ -113,12 +113,17 @@ describe('SignOrExecuteForm', () => {
     expect(result.getByText('Transaction details')).toBeInTheDocument()
   })
 
-  it("doesn't display decoded data if tx is a native transfer", () => {
+  it('displays decoded data if tx is a native transfer', () => {
     const mockTx = createSafeTx()
 
     const result = render(<SignOrExecuteForm isExecutable={true} onSubmit={jest.fn} safeTx={mockTx} />)
 
-    expect(result.queryByText('Transaction details')).not.toBeInTheDocument()
+    expect(result.queryByText('Transaction details')).toBeInTheDocument()
+
+    // Click on it
+    fireEvent.click(result.getByText('Transaction details'))
+
+    expect(result.queryByText('Native token transfer')).toBeInTheDocument()
   })
 
   it('displays an execute checkbox if tx can be executed', () => {

--- a/src/components/tx/modals/NftBatchModal/index.tsx
+++ b/src/components/tx/modals/NftBatchModal/index.tsx
@@ -17,7 +17,7 @@ export const NftTransferSteps: TxStepperProps['steps'] = [
     render: (data, onSubmit) => <SendNftBatch onSubmit={onSubmit} params={data as NftTransferParams} />,
   },
   {
-    label: 'Review transaction',
+    label: 'Review NFT transaction',
     render: (data, onSubmit) => <ReviewNftBatch onSubmit={onSubmit} params={data as NftTransferParams} />,
   },
 ]

--- a/src/services/tx/tokenTransferParams.ts
+++ b/src/services/tx/tokenTransferParams.ts
@@ -1,6 +1,7 @@
+import type { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
+import type { DecodedDataResponse } from '@safe-global/safe-gateway-typescript-sdk'
 import { safeParseUnits } from '@/utils/formatters'
 import { Interface } from '@ethersproject/abi'
-import type { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
 import { sameAddress } from '@/utils/addresses'
 
 // CryptoKitties Contract Addresses by network
@@ -60,5 +61,23 @@ export const createNftTransferParams = (
     to: tokenAddress,
     value: '0',
     data,
+  }
+}
+
+export const getNativeTransferData = (data: MetaTransactionData): DecodedDataResponse => {
+  return {
+    method: 'Native token transfer',
+    parameters: [
+      {
+        name: 'to',
+        type: 'address',
+        value: data.to,
+      },
+      {
+        name: 'value',
+        type: 'uint256',
+        value: data.value,
+      },
+    ],
   }
 }


### PR DESCRIPTION
## What it solves

Enhances the "Transaction details" block in SignOrExecuteForm:
* Show decoded native token transfers (previously we didn't show them at all)
* Show multisend actions (previously it showed only the raw data)

## How this PR fixes it
I've removed <Multisend> from custom Review modals, and it's now shown in Transaction details instead.

## How to test it
Test native token transfers, NFT batches, Safe App batches.

## Screenshots
<img width="638" alt="Screenshot 2023-04-24 at 12 16 03" src="https://user-images.githubusercontent.com/381895/233954495-0f8f7233-d19e-4eee-a7fe-4ffdb10e964a.png">
<img width="636" alt="Screenshot 2023-04-24 at 12 14 55" src="https://user-images.githubusercontent.com/381895/233954521-f3a3df04-c080-4341-a177-b88b6a53f228.png">
<img width="635" alt="Screenshot 2023-04-24 at 12 13 20" src="https://user-images.githubusercontent.com/381895/233954539-e383c9d1-9f0e-47d0-9c35-bf68116a012f.png">

