### PR TITLE
fix: tweak wording of Safe Account/{Wallet}

### DIFF
--- a/cypress/e2e/smoke/create_safe_simple.cy.js
+++ b/cypress/e2e/smoke/create_safe_simple.cy.js
@@ -13,7 +13,7 @@ describe('Create Safe form', () => {
     // Ensure wallet is connected to correct chain via header
     cy.contains('E2E Wallet @ Görli')
 
-    cy.contains('Create new Safe').click()
+    cy.contains('Create new Account').click()
   })
 
   it('should allow setting a name', () => {

--- a/cypress/e2e/smoke/load_safe.cy.js
+++ b/cypress/e2e/smoke/load_safe.cy.js
@@ -20,7 +20,7 @@ describe('Load existing Safe', () => {
     cy.contains('Accept selection').click()
 
     // Enters Loading Safe form
-    cy.contains('button', 'Add existing Safe').click()
+    cy.contains('button', 'Add existing Account').click()
     cy.contains('Connect wallet & select network')
   })
 

--- a/cypress/e2e/smoke/pending_actions.cy.js
+++ b/cypress/e2e/smoke/pending_actions.cy.js
@@ -25,7 +25,7 @@ describe('Pending actions', () => {
 
   it('should add the Safe with the pending actions', () => {
     // Enters Loading Safe form
-    cy.contains('button', 'Add existing Safe').click()
+    cy.contains('button', 'Add').click()
     cy.contains('Connect wallet & select network')
 
     // Inputs the Safe address

--- a/src/components/sidebar/SafeListItemSecondaryAction/index.tsx
+++ b/src/components/sidebar/SafeListItemSecondaryAction/index.tsx
@@ -42,7 +42,7 @@ const SafeListItemSecondaryAction = ({
             onClick?.()
           }}
         >
-          Add Safe Account
+          Add
         </Button>
       </Link>
     )

--- a/src/components/welcome/NewSafe.tsx
+++ b/src/components/welcome/NewSafe.tsx
@@ -61,7 +61,7 @@ const NewSafe = () => {
             color="static.main"
             mb={1}
           >
-            Welcome to Safe{`Wallet`}
+            Welcome to Safe{'{Wallet}'}
           </Typography>
 
           <Typography mb={5} color="static.main">
@@ -77,12 +77,12 @@ const NewSafe = () => {
                 </Typography>
 
                 <Typography variant="body2" mb={3}>
-                  A new Safe Account that is controlled by one or multiple owners.
+                  A new Account that is controlled by one or multiple owners.
                 </Typography>
 
                 <Track {...CREATE_SAFE_EVENTS.CREATE_BUTTON}>
                   <Button variant="contained" onClick={() => router.push(AppRoutes.newSafe.create)}>
-                    + Create new Safe Account
+                    + Create new Account
                   </Button>
                 </Track>
               </Paper>
@@ -96,12 +96,12 @@ const NewSafe = () => {
                 </Typography>
 
                 <Typography variant="body2" mb={3}>
-                  Already have a Safe Account? Add your Safe Account using your Safe Account address.
+                  Already have an Account? Add it via its address.
                 </Typography>
 
                 <Track {...LOAD_SAFE_EVENTS.LOAD_BUTTON}>
                   <Button variant="outlined" onClick={() => router.push(AppRoutes.newSafe.load)}>
-                    Add existing Safe Account
+                    Add existing Account
                   </Button>
                 </Track>
               </Paper>

--- a/src/services/pairing/module.ts
+++ b/src/services/pairing/module.ts
@@ -28,7 +28,7 @@ enum ProviderMethods {
   WALLET_SWITCH_ETHEREUM_CHAIN = 'wallet_switchEthereumChain',
 }
 
-export const PAIRING_MODULE_LABEL = 'Safe{Wallet} mobile'
+export const PAIRING_MODULE_LABEL = 'Safe{Wallet}'
 
 // Modified version of: https://github.com/blocknative/web3-onboard/blob/v2-web3-onboard-develop/packages/walletconnect/src/index.ts
 const pairingModule = (): WalletInit => {


### PR DESCRIPTION
## What it solves

Resolves a few inconsistencies in the UI after renaming from "Safe" to "Safe Account" or "Safe{Wallet}".

## How this PR fixes it

- The name of the pairing wallet is now "Safe{Wallet}" in the onboard modal, not "Safe{Wallet} mobile}".
- The sidebar button to add a specific Safe Account is now just "Add" instead of "Add Safe Account".
- The title on the welcome page (on desktop/mobile) is now "Safe{Wallet}", not "SafeWallet".
- The wording below the create/add blocks on the welcome page do not repeat "Safe Account" frequently.

## How to test it

Observe the above changes are present in the UI.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/234029344-3134024f-4b65-4c92-9404-2b7283fd1fd5.png)

![image](https://user-images.githubusercontent.com/20442784/234029362-ef395816-48ac-4931-9de3-bef8e9e43b8b.png)

![image](https://user-images.githubusercontent.com/20442784/234029386-46313e37-36d3-4eec-9d90-8f3719858f23.png)

![image](https://user-images.githubusercontent.com/20442784/234029405-d4f5177c-0d8e-40c6-a171-b1892bebe605.png)

![image](https://user-images.githubusercontent.com/20442784/234029432-cb8fbf3f-9f14-459e-b00c-2168e1cac8fe.png)

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
