### PR TITLE
Chore: repace http-server with serve

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "cypress:open": "cross-env TZ=UTC cypress open",
     "cypress:run": "cypress run",
     "cypress:ci": "yarn cypress:run --config baseUrl=http://localhost:8080 --spec cypress/e2e/smoke/*.cy.js",
-    "static-serve": "yarn build && yarn export && yarn serve",
-    "serve": "npx -y http-server out"
+    "serve": "npx -y serve -p 8080 out",
+    "static-serve": "yarn build && yarn export && yarn serve"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
## What it solves

Resolves #1900

## How this PR fixes it

Replaces http-server with the serve package from Vercel. It's much faster and doesn't add trailing slashes to directory URLs.

## How to test it
Run `year static-serve`.