### PR TITLE
app store button - replaced with next image

### DIFF
--- a/src/components/common/AppStoreButton/index.tsx
+++ b/src/components/common/AppStoreButton/index.tsx
@@ -1,9 +1,8 @@
 import type { ReactElement } from 'react'
+import Image from 'next/image'
 
 import { useDarkMode } from '@/hooks/useDarkMode'
 import { MOBILE_APP_EVENTS, trackEvent } from '@/services/analytics'
-
-import css from '@/components/common/AppStoreButton/styles.module.css'
 
 // App Store campaigns track the user interaction
 enum LINKS {
@@ -23,10 +22,11 @@ const AppstoreButton = ({ placement }: { placement: keyof typeof LINKS }): React
 
   return (
     <a href={LINKS[placement]} target="_blank" rel="noreferrer" onClick={onClick}>
-      <img
+      <Image
         src={isDarkMode ? '/images/common/appstore-light.svg' : '/images/common/appstore.svg'}
         alt="Download on the App Store"
-        className={css.button}
+        width={105}
+        height={35}
       />
     </a>
   )

--- a/src/components/common/AppStoreButton/styles.module.css
+++ b/src/components/common/AppStoreButton/styles.module.css
@@ -1,4 +1,0 @@
-.button {
-  display: block;
-  height: 35px;
-}


### PR DESCRIPTION
## What it solves

A tiny part of PR #1389 

![image](https://user-images.githubusercontent.com/32815509/234265707-474c1796-8977-46e1-8ff0-351ce37734c8.png)

## How this PR fixes it
Replaced `<img>` tag with `<Image>` component by `next/image`

## How to test it
Visible on Connect wallet dropdown and in the footer of settings page

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

**Note -** I think PR #1389 is quite big and can be converted into either a milestone or smaller issues. For example, an issue which will target the images, other issue can target npm modules which can be optimized, and so on.

