### PR TITLE
fix: remove slash from end of CLA links

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,7 +20,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://safe.global/cla/' # e.g. a CLA or a DCO document
+          path-to-document: 'https://safe.global/cla' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'main'
           # user names of users allowed to contribute without CLA

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Please note we have a Code of Conduct (see below), please follow it in all your 
 
 ## CLA
 
-It is a requirement for all contributors to sign the [Contributor License Agreement (CLA)](safe.global/cla/) in order to proceed with their contribution.
+It is a requirement for all contributors to sign the [Contributor License Agreement (CLA)](https://safe.global/cla) in order to proceed with their contribution.
 
 ## Pull Request Process
 


### PR DESCRIPTION
## What it solves

Resolves [linking to a 404 page](https://github.com/safe-global/web-core/pull/1906#issuecomment-1521650541)

## How this PR fixes it

All instances of links to our CLA have had the trailing forward slash removed.

## How to test it

Click the CLA link in the PR comments/`CONTRIBUTING.md` file and observe a working link to our CLA agreement.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
