### PR TITLE
fix: brand alignment inconsistencies

### DIFF
--- a/src/components/address-book/ImportDialog/index.tsx
+++ b/src/components/address-book/ImportDialog/index.tsx
@@ -151,7 +151,7 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
         {error && <ErrorMessage>{error}</ErrorMessage>}
 
         <Typography>
-          Only CSV files exported from a Safe{'{Wallet}'} can be imported.
+          Only CSV files exported from a {'Safe{Wallet}'} can be imported.
           <br />
           <ExternalLink
             href="https://help.safe.global/en/articles/5299068-address-book-export-and-import"

--- a/src/components/common/PairingDetails/PairingDescription.tsx
+++ b/src/components/common/PairingDetails/PairingDescription.tsx
@@ -10,7 +10,7 @@ const PairingDescription = (): ReactElement => {
   return (
     <>
       <Typography variant="caption" align="center">
-        Scan this code in the Safe{'{Wallet}'} mobile app to sign transactions with your mobile device.
+        Scan this code in the {'Safe{Wallet}'} mobile app to sign transactions with your mobile device.
         <br />
         <ExternalLink href={HELP_ARTICLE} title="Learn more about mobile pairing.">
           Learn more about this feature.

--- a/src/components/dashboard/CreationDialog/index.tsx
+++ b/src/components/dashboard/CreationDialog/index.tsx
@@ -34,7 +34,7 @@ const CreationDialog = () => {
     <Dialog open={open}>
       <DialogContent sx={{ paddingX: 8, paddingTop: 9, paddingBottom: 6 }}>
         <Typography variant="h3" fontWeight="700" mb={1}>
-          Welcome to Safe{'{Wallet}'}!
+          Welcome to {'Safe{Wallet}'}!
         </Typography>
         <Typography variant="body2">
           Congratulations on your first step to truly unlock ownership. Enjoy the experience and discover our app.

--- a/src/components/dashboard/Relaying/index.tsx
+++ b/src/components/dashboard/Relaying/index.tsx
@@ -19,7 +19,7 @@ const Relaying = () => {
   return (
     <WidgetContainer>
       <Typography component="h2" variant="subtitle1" fontWeight={700} mb={2}>
-        New in Safe{'{Wallet}'}
+        New in {'Safe{Wallet}'}
       </Typography>
 
       <WidgetBody>

--- a/src/components/dashboard/SafeAppsDashboardSection/SafeAppsDashboardSection.tsx
+++ b/src/components/dashboard/SafeAppsDashboardSection/SafeAppsDashboardSection.tsx
@@ -20,7 +20,7 @@ const SafeAppsDashboardSection = () => {
   return (
     <WidgetContainer>
       <Typography component="h2" variant="subtitle1" fontWeight={700} mb={2}>
-        Safe{'{Apps}'}
+        {'Safe{Apps}'}
       </Typography>
 
       <Grid container spacing={3}>

--- a/src/components/licenses/index.tsx
+++ b/src/components/licenses/index.tsx
@@ -14,7 +14,7 @@ const SafeLicenses = () => {
       <Box mb={4}>
         <Typography mb={3}>
           This page contains a list of attribution notices for third party software that may be contained in portions of
-          the Safe{'{Wallet}'}. We thank the open source community for all of their contributions.
+          the {'Safe{Wallet}'}. We thank the open source community for all of their contributions.
         </Typography>
         <Typography variant="h2" mb={2}>
           Android

--- a/src/components/new-safe/create/steps/ConnectWalletStep/index.tsx
+++ b/src/components/new-safe/create/steps/ConnectWalletStep/index.tsx
@@ -47,7 +47,7 @@ const ConnectWalletStep = ({ onSubmit, setStep }: StepRenderProps<NewSafeFormDat
             <Grid item xs={12} md={6} display="flex" flexDirection="column" alignItems="center" gap={2}>
               <PairingQRCode />
               <Typography variant="h6" fontWeight="700">
-                Connect to Safe{'{Wallet}'} mobile
+                Connect to {'Safe{Wallet}'} mobile
               </Typography>
               <PairingDescription />
             </Grid>

--- a/src/components/new-safe/create/steps/OwnerPolicyStep/index.tsx
+++ b/src/components/new-safe/create/steps/OwnerPolicyStep/index.tsx
@@ -113,7 +113,7 @@ const OwnerPolicyStep = ({
           </Button>
           <Box p={2} mt={3} sx={{ backgroundColor: 'background.main', borderRadius: '8px' }}>
             <Typography variant="subtitle1" fontWeight={700} display="inline-flex" alignItems="center" gap={1}>
-              Safe{'{Wallet}'} mobile owner key (optional){' '}
+              {'Safe{Wallet}'} mobile owner key (optional){' '}
               <Tooltip
                 title="The Safe{Wallet} mobile app allows for the generation of owner keys that you can add to this or an existing Safe Account."
                 arrow

--- a/src/components/new-safe/create/steps/StatusStep/index.tsx
+++ b/src/components/new-safe/create/steps/StatusStep/index.tsx
@@ -107,7 +107,7 @@ export const CreateSafeStatus = ({ data, setProgressColor }: StepRenderProps<New
           <Box className={layoutCss.row}>
             <Track {...CREATE_SAFE_EVENTS.GO_TO_SAFE}>
               <Button variant="contained" onClick={onFinish}>
-                Start using Safe{'{Wallet}'}
+                Start using {'Safe{Wallet}'}
               </Button>
             </Track>
           </Box>

--- a/src/components/privacy/index.tsx
+++ b/src/components/privacy/index.tsx
@@ -149,7 +149,7 @@ const SafePrivacyPolicy = () => {
           &nbsp;released under LGPL-3.0.
         </li>
         <li>
-          &ldquo;Safe{'{Wallet}'}&rdquo; refers to a web-based graphical user interface for Safe Accounts as well as a
+          &ldquo;{'Safe{Wallet}'}&rdquo; refers to a web-based graphical user interface for Safe Accounts as well as a
           mobile application on Android and iOS.
         </li>
         <li>
@@ -194,9 +194,9 @@ const SafePrivacyPolicy = () => {
         BLOCKCHAIN WILL BECOME PUBLICLY AVAILABLE
       </p>
       <h3 id="4">4. How We Use Personal Data</h3>
-      <h4>4.1. When visiting our website and using Safe{'{Wallet}'}</h4>
+      <h4>4.1. When visiting our website and using {'Safe{Wallet}'}</h4>
       <p>
-        When visiting our website or using Safe{'{Wallet}'}, we may collect and process personal data. The data will be
+        When visiting our website or using {'Safe{Wallet}'}, we may collect and process personal data. The data will be
         stored in different instances
       </p>
       <ol start={1} className={css.alphaList}>
@@ -235,7 +235,7 @@ const SafePrivacyPolicy = () => {
       <ol start={4} className={css.alphaList}>
         <li>
           When you create a Profile for an existing Safe Account for the purpose of allowing you to view and use them in
-          the Safe{'{Wallet}'}, we process your
+          the {'Safe{Wallet}'}, we process your
           <ol start={1} className={css.romanList}>
             <li>public Wallet address, </li>
             <li>Safe Account balance, </li>
@@ -279,8 +279,8 @@ const SafePrivacyPolicy = () => {
       </ol>
       <ol start={8} className={css.alphaList}>
         <li>
-          When we collect relevant&nbsp;data&nbsp;from the Blockchain to display context information in the Safe
-          {`Wallet`}
+          When we collect relevant&nbsp;data&nbsp;from the Blockchain to display context information in the
+          {`Safe{Wallet}`}
           we process:
           <ol start={1} className={css.romanList}>
             <li>your public Wallet address, </li>
@@ -368,7 +368,7 @@ const SafePrivacyPolicy = () => {
         <li>range of managed funds</li>
       </ol>
       <p>
-        In addition, we may take a recording of you while testing Safe{'{Wallet}'} for internal and external use. The
+        In addition, we may take a recording of you while testing {'Safe{Wallet}'} for internal and external use. The
         basis for this collection and processing is our legitimate business interest in monitoring and improving our
         services.
       </p>
@@ -492,7 +492,7 @@ const SafePrivacyPolicy = () => {
       </p>
       <h4>5.4. Mobile app stores</h4>
       <p>
-        Safe{'{Wallet}'} mobile apps are distributed via{' '}
+        {'Safe{Wallet}'} mobile apps are distributed via{' '}
         <Link href="https://www.apple.com/app-store/" passHref>
           <MUILink target="_blank" rel="noreferrer">
             Apple AppStore
@@ -510,7 +510,7 @@ const SafePrivacyPolicy = () => {
       </p>
       <h4>5.5. Fingerprint/Touch ID/ Face ID</h4>
       <p>
-        We enable the user to unlock the Safe{'{Wallet}'} mobile app via biometrics information (touch ID or face ID).
+        We enable the user to unlock the {'Safe{Wallet}'} mobile app via biometrics information (touch ID or face ID).
         This is a feature of the operating system. We do not store any of this data. Instead, the API of the operating
         system is used to validate the user input. If you have any further questions you should consult with your
         preferred mobile device provider or manufacturer.
@@ -588,8 +588,8 @@ const SafePrivacyPolicy = () => {
             Nodereal
           </MUILink>
         </Link>
-        &nbsp;to query public blockchain data from our backend services. All Safes are monitored, no personalization is
-        happening and no user IP addresses are forwarded. Personal data processed are:
+        &nbsp;to query public blockchain data from our backend services. All Safe Accounts are monitored, no
+        personalization is happening and no user IP addresses are forwarded. Personal data processed are:
       </p>
       <ul>
         <li>Your smart contract address of the Safe;</li>

--- a/src/components/safe-apps/AddCustomAppModal/index.tsx
+++ b/src/components/safe-apps/AddCustomAppModal/index.tsx
@@ -121,7 +121,7 @@ export const AddCustomAppModal = ({ open, onClose, onSave, safeAppsList }: Props
                   {isCustomAppInTheDefaultList ? (
                     <Box display="flex" mt={2} alignItems="center">
                       <CheckIcon color="success" />
-                      <Typography ml={1}>This Safe{'{App}'} is already registered</Typography>
+                      <Typography ml={1}>This {'Safe{App}'} is already registered</Typography>
                     </Box>
                   ) : (
                     <>
@@ -154,7 +154,7 @@ export const AddCustomAppModal = ({ open, onClose, onSave, safeAppsList }: Props
             <InfoOutlinedIcon className={css.addCustomAppHelpIcon} />
             <Typography ml={0.5}>Learn more about building</Typography>
             <ExternalLink className={css.addCustomAppHelpLink} href={HELP_LINK} fontWeight={700}>
-              Safe{'{Apps}'}
+              {'Safe{Apps}'}
             </ExternalLink>
             .
           </div>

--- a/src/components/safe-apps/AddCustomSafeAppCard/index.tsx
+++ b/src/components/safe-apps/AddCustomSafeAppCard/index.tsx
@@ -28,7 +28,7 @@ const AddCustomSafeAppCard = ({ onSave, safeAppList }: Props) => {
               mt: 3,
             }}
           >
-            Add custom Safe{'{App}'}
+            Add custom {'Safe{App}'}
           </Button>
         </Box>
       </Card>

--- a/src/components/safe-apps/AppFrame/ThirdPartyCookiesWarning.tsx
+++ b/src/components/safe-apps/AppFrame/ThirdPartyCookiesWarning.tsx
@@ -22,7 +22,7 @@ export const ThirdPartyCookiesWarning = ({ onClose }: ThirdPartyCookiesWarningPr
       })}
     >
       <AlertTitle>
-        Third party cookies are disabled. Safe{'{Apps}'} may therefore not work properly. You can find out more
+        Third party cookies are disabled. {'Safe{Apps}'} may therefore not work properly. You can find out more
         information about this{' '}
         <ExternalLink href={HELP_LINK} fontSize="inherit">
           here

--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -249,7 +249,9 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
     <>
       <Head>
         <title>
-          Safe{'{Apps}'} - Viewer - {remoteApp ? remoteApp.name : UNKNOWN_APP_NAME}
+          <>
+            {'Safe{Apps}'} - Viewer - {remoteApp ? remoteApp.name : UNKNOWN_APP_NAME}
+          </>
         </title>
       </Head>
 
@@ -260,7 +262,7 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
           <div className={css.loadingContainer}>
             {isLoadingSlow && (
               <Typography variant="h4" gutterBottom>
-                The Safe{'{App}'} is taking too long to load, consider refreshing.
+                The {'Safe{App}'} is taking too long to load, consider refreshing.
               </Typography>
             )}
             <CircularProgress size={48} color="primary" />

--- a/src/components/safe-apps/SafeAppLandingPage/SafeAppDetails.tsx
+++ b/src/components/safe-apps/SafeAppLandingPage/SafeAppDetails.tsx
@@ -28,7 +28,7 @@ const SafeAppDetails = ({ app, showDefaultListWarning }: DetailsProps) => (
     </Box>
     <Divider />
     <Box sx={{ mt: 4 }}>
-      <Typography variant="body1">Safe{'{App}'} URL</Typography>
+      <Typography variant="body1">{'Safe{App}'} URL</Typography>
       <Typography
         variant="body2"
         sx={({ palette, shape }) => ({
@@ -64,7 +64,7 @@ const SafeAppDetails = ({ app, showDefaultListWarning }: DetailsProps) => (
             </Typography>
           </Box>
           <Typography variant="body1" mt={1} sx={({ palette }) => ({ color: palette.warning.dark })}>
-            The application is not in the default Safe{'{App}'} list
+            The application is not in the default {'Safe{App}'} list
           </Typography>
           <Typography variant="body2" mt={2}>
             Check the app link and ensure it comes from a trusted source

--- a/src/components/safe-apps/SafeAppLandingPage/index.tsx
+++ b/src/components/safe-apps/SafeAppLandingPage/index.tsx
@@ -58,7 +58,7 @@ const SafeAppLanding = ({ appUrl, chain }: Props) => {
   }
 
   if (!safeApp) {
-    return <div>No Safe{'{App}'} found</div>
+    return <div>No {'Safe{App}'} found</div>
   }
 
   return (

--- a/src/components/safe-apps/SafeAppPreviewDrawer/index.tsx
+++ b/src/components/safe-apps/SafeAppPreviewDrawer/index.tsx
@@ -83,7 +83,7 @@ const SafeAppPreviewDrawer = ({ isOpen, safeApp, isBookmarked, onClose, onBookma
         {/* Open Safe App button */}
         <Link href={safeAppUrl} passHref>
           <Button fullWidth variant="contained" color="primary" component={'a'} href={safeApp?.url} sx={{ mt: 3 }}>
-            Open Safe{'{App}'}
+            Open {'Safe{App}'}
           </Button>
         </Link>
 

--- a/src/components/safe-apps/SafeAppSocialLinksCard/index.tsx
+++ b/src/components/safe-apps/SafeAppSocialLinksCard/index.tsx
@@ -40,7 +40,7 @@ const SafeAppSocialLinksCard = ({ safeApp }: SafeAppSocialLinksCardProps) => {
         </div>
         <div>
           <Typography fontWeight="bold" variant="subtitle1">
-            Something wrong with the Safe{'{App}'}?
+            Something wrong with the {'Safe{App}'}?
           </Typography>
           <Typography color="primary.light" variant="body2">
             Get in touch with the team

--- a/src/components/safe-apps/SafeAppsErrorBoundary/SafeAppsLoadError.tsx
+++ b/src/components/safe-apps/SafeAppsErrorBoundary/SafeAppsLoadError.tsx
@@ -15,7 +15,7 @@ const SafeAppsLoadError = ({ onBackToApps }: SafeAppsLoadErrorProps): React.Reac
   return (
     <div className={css.wrapper}>
       <div className={css.content}>
-        <Typography variant="h1">Safe{'{App}'} could not be loaded</Typography>
+        <Typography variant="h1">{'Safe{App}'} could not be loaded</Typography>
 
         <SvgIcon component={NetworkError} inheritViewBox className={css.image} />
 
@@ -27,7 +27,7 @@ const SafeAppsLoadError = ({ onBackToApps }: SafeAppsLoadErrorProps): React.Reac
         </div>
 
         <Button href="#back" color="primary" onClick={onBackToApps}>
-          Go back to the Safe{'{Apps}'} list
+          Go back to the {'Safe{Apps}'} list
         </Button>
       </div>
     </div>

--- a/src/components/safe-apps/SafeAppsHeader/index.tsx
+++ b/src/components/safe-apps/SafeAppsHeader/index.tsx
@@ -12,7 +12,7 @@ const SafeAppsHeader = (): ReactElement => {
       <Box className={css.container}>
         {/* Safe Apps Title */}
         <Typography className={css.title} variant="h3">
-          Explore the Safe{'{Apps}'} ecosystem
+          Explore the {'Safe{Apps}'} ecosystem
         </Typography>
 
         {/* Safe Apps Subtitle */}

--- a/src/components/safe-apps/SafeAppsInfoModal/AllowedFeaturesList.tsx
+++ b/src/components/safe-apps/SafeAppsInfoModal/AllowedFeaturesList.tsx
@@ -28,11 +28,11 @@ const AllowedFeaturesList: React.FC<SafeAppsInfoAllowedFeaturesProps> = ({
           margin: '0 75px',
         }}
       >
-        Manage the features Safe{'{Apps}'} can use
+        Manage the features {'Safe{Apps}'} can use
       </Typography>
 
       <Box mx={1} my={3} textAlign="left">
-        <Typography>This Safe{'{App}'} is requesting permission to use:</Typography>
+        <Typography>This {'Safe{App}'} is requesting permission to use:</Typography>
 
         <Box display="flex" flexDirection="column" ml={2} mt={1}>
           {features

--- a/src/components/safe-apps/SafeAppsModalLabel/index.tsx
+++ b/src/components/safe-apps/SafeAppsModalLabel/index.tsx
@@ -6,7 +6,7 @@ const APP_LOGO_FALLBACK_IMAGE = '/images/apps/apps-icon.svg'
 
 const SafeAppsModalLabel = ({ app }: { app?: SafeAppData }) => {
   if (!app) {
-    return <Typography variant="h3">Safe{'{Apps}'} Transaction</Typography>
+    return <Typography variant="h3">{'Safe{Apps}'} Transaction</Typography>
   }
 
   return (

--- a/src/components/safe-apps/SafeAppsSDKLink/index.tsx
+++ b/src/components/safe-apps/SafeAppsSDKLink/index.tsx
@@ -33,7 +33,7 @@ const SafeAppsSDKLink = () => {
       </Typography>
 
       <ExternalLink href={SAFE_APPS_SDK_DOCS_URL} className={css.link} noIcon variant="body2">
-        <span>Learn more about Safe{'{Apps}'} SDK</span>
+        <span>Learn more about {'Safe{Apps}'} SDK</span>
       </ExternalLink>
 
       <Fab className={css.openButton} variant="extended" size="small" color="secondary" tabIndex={-1}>

--- a/src/components/safe-apps/SafeAppsTxModal/InvalidTransaction.tsx
+++ b/src/components/safe-apps/SafeAppsTxModal/InvalidTransaction.tsx
@@ -11,8 +11,8 @@ const InvalidTransaction = (): ReactElement => {
       </Box>
       <br />
       <Typography>
-        This Safe{'{App}'} initiated a transaction which cannot be processed. Please get in touch with the developer of
-        this Safe{'{App}'} for more information.
+        This {'Safe{App}'} initiated a transaction which cannot be processed. Please get in touch with the developer of
+        this {'Safe{App}'} for more information.
       </Typography>
     </Box>
   )

--- a/src/components/safe-apps/SafeAppsZeroResultsPlaceholder/index.tsx
+++ b/src/components/safe-apps/SafeAppsZeroResultsPlaceholder/index.tsx
@@ -32,8 +32,8 @@ const SafeAppsZeroResultsPlaceholder = ({ searchQuery }: { searchQuery: string }
       img={<AddCustomAppIcon />}
       text={
         <Typography variant="body1" color="primary.light" m={2} maxWidth="600px">
-          No Safe{'{Apps}'} found matching <strong>{searchQuery}</strong>. Connect to dApps that haven&apos;t yet been
-          integrated with the Safe{'{Wallet}'} using the WalletConnect Safe{'{App}'}.
+          No {'Safe{Apps}'} found matching <strong>{searchQuery}</strong>. Connect to dApps that haven&apos;t yet been
+          integrated with the {'Safe{Wallet}'} using the WalletConnect {'Safe{App}'}.
         </Typography>
       }
     >

--- a/src/components/settings/DataManagement/index.tsx
+++ b/src/components/settings/DataManagement/index.tsx
@@ -25,7 +25,9 @@ const DataManagement = () => {
             .
           </Typography>
 
-          <Typography mb={3}>The imported data will overwrite all added Safes and all address book entries.</Typography>
+          <Typography mb={3}>
+            The imported data will overwrite all added Safe Accounts and all address book entries.
+          </Typography>
 
           <Track {...SETTINGS_EVENTS.DATA.IMPORT_ALL_BUTTON}>
             <Button size="small" variant="contained" onClick={() => setModalOpen(true)}>

--- a/src/components/settings/FallbackHandler/index.tsx
+++ b/src/components/settings/FallbackHandler/index.tsx
@@ -39,7 +39,7 @@ export const FallbackHandler = (): ReactElement | null => {
 
   const tooltip = !safe.fallbackHandler ? (
     <>
-      The Safe{'{Wallet}'} may not work correctly as no fallback handler is currently set.
+      The {'Safe{Wallet}'} may not work correctly as no fallback handler is currently set.
       {txBuilder && (
         <>
           {' '}

--- a/src/components/settings/ImportAllDialog/documentation.md
+++ b/src/components/settings/ImportAllDialog/documentation.md
@@ -22,7 +22,7 @@ In the new interface navigate to `/import` or `Settings -> Data` and open the _I
 
 This will only import specific data:
 
-- The added Safes
+- The added Safe Accounts
 - The (valid\*) address book entries
 
 * Only named, checksummed address book entries will be added.
@@ -52,9 +52,9 @@ Example:
 }
 ```
 
-#### Added safes
+#### Added Safe Accounts
 
-Added safes are stored under one entry per chain.
+Added Safe Accounts are stored under one entry per chain.
 Each entry has a key in following format: `_immortal|v2_<chainPrefix>__SAFES`
 The chain prefix is either the chain ID or prefix, as follows:
 

--- a/src/components/settings/ImportAllDialog/index.tsx
+++ b/src/components/settings/ImportAllDialog/index.tsx
@@ -94,7 +94,7 @@ const ImportAllDialog = ({ handleClose }: { handleClose: () => void }): ReactEle
         groupKey: 'global-import-success',
         message: 'Successfully imported data',
         detailedMessage: [
-          ...(addedSafesCount > 0 ? [`${addedSafesCount} Safes were added.`] : []),
+          ...(addedSafesCount > 0 ? [`${addedSafesCount} Safe Accounts were added.`] : []),
           ...(addressBookEntriesCount > 0
             ? [`${addressBookEntriesCount} addresses were added to your address book.`]
             : []),
@@ -113,7 +113,7 @@ const ImportAllDialog = ({ handleClose }: { handleClose: () => void }): ReactEle
           ...(addedSafesCount > 0 && addedSafes
             ? [
                 <Typography key="addedSafesInfo">
-                  Found <strong>{addedSafesCount} Added Safes</strong> entries on{' '}
+                  Found <strong>{addedSafesCount} Added Safe Account</strong> entries on{' '}
                   <strong>{Object.keys(addedSafes).length} chain(s)</strong>
                 </Typography>,
               ]
@@ -145,11 +145,11 @@ const ImportAllDialog = ({ handleClose }: { handleClose: () => void }): ReactEle
 
         <div className={css.horizontalDivider} />
 
-        <Typography>Only JSON files exported from a Safe{'{Wallet}'} can be imported.</Typography>
+        <Typography>Only JSON files exported from a {'Safe{Wallet}'} can be imported.</Typography>
         <Alert severity="warning" sx={{ mt: 3 }}>
           <AlertTitle sx={{ fontWeight: 700 }}>Overwrite your current data?</AlertTitle>
-          This action will overwrite your currently added Safes and address book entries with those from the imported
-          file.
+          This action will overwrite your currently added Safe Accounts and address book entries with those from the
+          imported file.
         </Alert>
       </DialogContent>
       <DialogActions>

--- a/src/components/settings/SafeAppsPermissions/index.tsx
+++ b/src/components/settings/SafeAppsPermissions/index.tsx
@@ -97,12 +97,12 @@ const SafeAppsPermissions = (): ReactElement => {
   return (
     <Paper sx={{ padding: 4 }}>
       <Typography variant="h4" fontWeight={700}>
-        Safe{'{Apps}'} permissions
+        {'Safe{Apps}'} permissions
       </Typography>
       <br />
       {!domains.length && (
         <Typography variant="body1" color={({ palette }) => palette.primary.light}>
-          There are no Safe{'{Apps}'} using permissions.
+          There are no {'Safe{Apps}'} using permissions.
         </Typography>
       )}
       {domains.map((domain) => (

--- a/src/components/sidebar/SafeList/index.tsx
+++ b/src/components/sidebar/SafeList/index.tsx
@@ -212,7 +212,7 @@ const SafeList = ({ closeDrawer }: { closeDrawer?: () => void }): ReactElement =
                 <>
                   <div onClick={() => toggleOpen(chain.chainId, !isOpen)} className={css.ownedLabelWrapper}>
                     <Typography variant="body2" display="inline" className={css.ownedLabel}>
-                      Safes owned on {chain.chainName} ({ownedSafesOnChain.length})
+                      Safe Accounts owned on {chain.chainName} ({ownedSafesOnChain.length})
                       <IconButton disableRipple>{isOpen ? <ExpandLess /> : <ExpandMore />}</IconButton>
                     </Typography>
                   </div>

--- a/src/components/sidebar/SafeListRemoveDialog/index.tsx
+++ b/src/components/sidebar/SafeListRemoveDialog/index.tsx
@@ -32,7 +32,7 @@ const SafeListRemoveDialog = ({
     <ModalDialog open onClose={handleClose} dialogTitle="Delete entry">
       <DialogContent sx={{ p: '24px !important' }}>
         <Typography>
-          Are you sure you want to remove <b>{safe}</b> from your list of added Safes?
+          Are you sure you want to remove <b>{safe}</b> from your list of added Safe Accounts?
         </Typography>
       </DialogContent>
 

--- a/src/components/terms/index.tsx
+++ b/src/components/terms/index.tsx
@@ -79,8 +79,8 @@ const SafeTerms = () => {
       </ol>
       <h3>3. What are the Services offered?</h3>
       <p>
-        Our services (&ldquo;Services&rdquo;) primarily consist of enabling users to create their Safes and ongoing
-        interaction with it on the Blockchain.
+        Our services (&ldquo;Services&rdquo;) primarily consist of enabling users to create their Safe Accounts and
+        ongoing interaction with it on the Blockchain.
       </p>
       <ol start={1}>
         <li>&ldquo;Safe Account&rdquo; </li>
@@ -106,32 +106,32 @@ const SafeTerms = () => {
         key Wallets such as hardware wallets, browser extension wallets and mobile wallets that support WalletConnect.
       </p>
       <ol start={2}>
-        <li>&ldquo;Safe&nbsp;{'{App}'}&rdquo;</li>
+        <li>&ldquo;{'Safe{App}'}&rdquo;</li>
       </ol>
       <p>
-        You may access the Safe Account using the Safe{'{Wallet}'} web app, mobile app for iOS and android, or the
-        browser extension&nbsp;(each a &ldquo;Safe&nbsp;{'{App}'}&rdquo;). The Safe&nbsp;{'{App}'} may be used to manage
-        your personal digital assets on Ethereum and other common EVM chains when you connect the Safe Account with
-        third-party&nbsp;services (as defined below). The Safe&nbsp;{'{App}'} provides certain features that may be
-        amended from time to time.{' '}
+        You may access the Safe Account using the {'Safe{Wallet}'} web app, mobile app for iOS and android, or the
+        browser extension&nbsp;(each a &ldquo;{'Safe{App}'}&rdquo;). The {'Safe{App}'} may be used to manage your
+        personal digital assets on Ethereum and other common EVM chains when you connect the Safe Account with
+        third-party&nbsp;services (as defined below). The {'Safe{App}'} provides certain features that may be amended
+        from time to time.{' '}
       </p>
       <ol start={3}>
-        <li>&ldquo;Third-Party&nbsp;Safe{'{Apps}'}&rdquo;</li>
+        <li>&ldquo;Third-Party&nbsp;{'Safe{Apps}'}&rdquo;</li>
       </ol>
       <p>
-        The Safe&nbsp;{'{App}'} allows you to connect the Safe Account to third-party decentralized applications
-        (&ldquo;Third-Party&nbsp;Safe{'{Apps}'}&rdquo;) and use third-party&nbsp;services such as from the decentralized
+        The {'Safe{App}'} allows you to connect the Safe Account to third-party decentralized applications
+        (&ldquo;Third-Party&nbsp;{'Safe{Apps}'}&rdquo;) and use third-party&nbsp;services such as from the decentralized
         finance sector, DAO Tools or services related to NFTs (&ldquo;Third-Party&nbsp;Services&quot;). The
-        Third-Party&nbsp;Safe{'{Apps}'} are integrated in the user interface of the Safe&nbsp;{'{App}'} via inline
-        framing. The provider of the Third-Party&nbsp;Safe{'{App}'} and related Third-Party Service is responsible for
-        the operation of the service and the correctness, completeness and actuality of any information provided
-        therein. We make a pre-selection of Third-Party&nbsp;Safe{'{Apps}'} that we show in the Safe&nbsp;{'{App}'}.
-        However, we only perform a rough triage in advance for obvious problems and functionality in terms of loading
-        time and resolution capability of the transactions. Accordingly, in the event of any (technical) issues
-        concerning the Third-Party Services, the user must only contact the respective service provider directly. The
-        terms of service, if any, shall be governed by the applicable contractual provisions between the User and the
-        respective provider of the Third-Party&nbsp;Service. Accordingly, we are not liable in the event of a breach of
-        contract, damage or loss related to the use of such Third-Party Service.
+        Third-Party&nbsp;{'Safe{Apps}'} are integrated in the user interface of the {'Safe{App}'} via inline framing.
+        The provider of the Third-Party&nbsp;{'Safe{App}'} and related Third-Party Service is responsible for the
+        operation of the service and the correctness, completeness and actuality of any information provided therein. We
+        make a pre-selection of Third-Party&nbsp;{'Safe{Apps}'} that we show in the {'Safe{App}'}. However, we only
+        perform a rough triage in advance for obvious problems and functionality in terms of loading time and resolution
+        capability of the transactions. Accordingly, in the event of any (technical) issues concerning the Third-Party
+        Services, the user must only contact the respective service provider directly. The terms of service, if any,
+        shall be governed by the applicable contractual provisions between the User and the respective provider of the
+        Third-Party&nbsp;Service. Accordingly, we are not liable in the event of a breach of contract, damage or loss
+        related to the use of such Third-Party Service.
       </p>
       <h3>4. What do the Services not consist of?</h3>
       <p>Our Services do not&nbsp;consist of:</p>
@@ -178,7 +178,7 @@ const SafeTerms = () => {
       <ul>
         <li>
           We do not have any oversight over your activities with Third-Party&nbsp;Services especially by using
-          Third-Party&nbsp;Safe{'{Apps}'}, and therefore we do not and cannot make any representation regarding their
+          Third-Party&nbsp;{'Safe{Apps}'}, and therefore we do not and cannot make any representation regarding their
           appropriateness and suitability for you.
         </li>
         <li>
@@ -199,7 +199,7 @@ const SafeTerms = () => {
           When you access or use Third-Party&nbsp;Services you accept that there are risks in doing so and that you
           alone assume any such risks when choosing to interact with them. We are not liable for any errors or omissions
           or for any damages or loss you might suffer through interacting with those Third-Party&nbsp;Services, such as
-          Third-Party&nbsp;Safe{'{Apps}'}.
+          Third-Party&nbsp;{'Safe{Apps}'}.
         </li>
         <li>
           You know of the inherent risks of cryptographic and Blockchain-based systems and the high volatility of Token
@@ -234,7 +234,7 @@ const SafeTerms = () => {
       <h3>6. What are the fees for the Services?</h3>
       <ol start={1}>
         <li>
-          The use of the Safe{'{App}'} or Third-Party&nbsp;Safe{'{Apps}'} may cause fees, including network fees, as
+          The use of the {'Safe{App}'} or Third-Party&nbsp;{'Safe{Apps}'} may cause fees, including network fees, as
           indicated in the respective app. CC has no control over the fees charged by the Third-Party Services. CC may
           change its own fees at any time. Price changes will be communicated to the User in due time before taking
           effect.
@@ -283,7 +283,7 @@ const SafeTerms = () => {
           All intellectual property rights in the Safe Account and the Services throughout the world belong to us as
           owner or our licensors. Nothing in these Terms gives you any rights in respect of any intellectual property
           owned by us or our licensors and you acknowledge that you do not acquire any ownership rights by downloading
-          the Safe{'{App}'} or any content from the Safe{'{App}'}.
+          the {'Safe{App}'} or any content from the {'Safe{App}'}.
         </li>
         <li>
           If you are a consumer we grant you a simple, limited license, but do not sell, to you the Services you
@@ -298,7 +298,7 @@ const SafeTerms = () => {
           title or non-infringement.{' '}
         </li>
         <li>
-          If you use the Safe{'{App}'} via web browser, the strict liability of CC for damages (sec. 536a German Civil
+          If you use the {'Safe{App}'} via web browser, the strict liability of CC for damages (sec. 536a German Civil
           Code) for defects existing at the time of conclusion of the contract is precluded.{' '}
         </li>
         <li>The foregoing provisions will not limit CC&rsquo;s liability as defined in Clause 13. </li>
@@ -386,7 +386,7 @@ const SafeTerms = () => {
           negligence on our part, our legal representatives, our executive employees or other vicarious agents.
         </li>
         <li>
-          If we do not provide the Safe{'{App}'} or Services to you free of charge, we are liable in case of simple
+          If we do not provide the {'Safe{App}'} or Services to you free of charge, we are liable in case of simple
           negligence for damages resulting from the breach of an essential contractual duty (e.g. a duty, the
           performance of which enables the proper execution of the contract in the first place and on the compliance of
           which the contractual partner regularly relies and may rely), whereby in the latter case of breach of an

--- a/src/components/welcome/NewSafe.tsx
+++ b/src/components/welcome/NewSafe.tsx
@@ -61,7 +61,7 @@ const NewSafe = () => {
             color="static.main"
             mb={1}
           >
-            Welcome to Safe{'{Wallet}'}
+            Welcome to {'Safe{Wallet}'}
           </Typography>
 
           <Typography mb={5} color="static.main">

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -97,7 +97,7 @@ const WebCoreApp = ({
   return (
     <StoreHydrator>
       <Head>
-        <title key="default-title">Safe{'{Wallet}'}</title>
+        <title key="default-title">{'Safe{Wallet}'}</title>
         <MetaTags prefetchUrl={GATEWAY_URL} />
       </Head>
 

--- a/src/pages/_offline.tsx
+++ b/src/pages/_offline.tsx
@@ -7,7 +7,9 @@ const Offline: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Offline</title>
+        <title>
+          <>{'Safe{Wallet}'} – Offline</>
+        </title>
       </Head>
 
       <main>

--- a/src/pages/address-book.tsx
+++ b/src/pages/address-book.tsx
@@ -6,7 +6,9 @@ const AddressBook: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Address book</title>
+        <title>
+          <>{'Safe{Wallet}'} – Address book</>
+        </title>
       </Head>
 
       <AddressBookTable />

--- a/src/pages/apps/bookmarked.tsx
+++ b/src/pages/apps/bookmarked.tsx
@@ -16,7 +16,9 @@ const BookmarkedSafeApps: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Bookmarked Safe{'{Apps}'}</title>
+        <title>
+          <>Bookmarked {'Safe{Apps}'}</>
+        </title>
       </Head>
 
       <SafeAppsSDKLink />

--- a/src/pages/apps/custom.tsx
+++ b/src/pages/apps/custom.tsx
@@ -29,7 +29,9 @@ const CustomSafeApps: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Custom Safe{'{Apps}'}</title>
+        <title>
+          <>Custom {'Safe{Apps}'}</>
+        </title>
       </Head>
 
       <SafeAppsSDKLink />

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -31,7 +31,9 @@ const SafeApps: NextPage = () => {
     <>
       <Head>
         <title>
-          Safe{'{Wallet}'} – Safe{'{Apps}'}
+          <>
+            {'Safe{Wallet}'} – {'Safe{Apps}'}
+          </>
         </title>
       </Head>
 

--- a/src/pages/balances/index.tsx
+++ b/src/pages/balances/index.tsx
@@ -20,7 +20,9 @@ const Balances: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Assets</title>
+        <title>
+          <>{'Safe{Wallet}'} – Assets</>
+        </title>
       </Head>
 
       <AssetsHeader>

--- a/src/pages/balances/nfts.tsx
+++ b/src/pages/balances/nfts.tsx
@@ -19,7 +19,7 @@ const NftApps = memo(function NftApps(): ReactElement | null {
   return (
     <Grid item sm={12} lg={3} order={{ lg: 1 }}>
       <Typography component="h2" variant="subtitle1" fontWeight={700} mb={2} mt={0.75}>
-        NFT Safe{'{Apps}'}
+        NFT {'Safe{Apps}'}
       </Typography>
 
       <Grid container spacing={3}>
@@ -43,7 +43,9 @@ const NFTs: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – NFTs</title>
+        <title>
+          <>{'Safe{Wallet}'} – NFTs</>
+        </title>
       </Head>
 
       <AssetsHeader />

--- a/src/pages/cookie.tsx
+++ b/src/pages/cookie.tsx
@@ -6,7 +6,9 @@ const CookiePolicy: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Cookie policy</title>
+        <title>
+          <>{'Safe{Wallet}'} – Cookie policy</>
+        </title>
       </Head>
 
       <main>

--- a/src/pages/environment-variables.tsx
+++ b/src/pages/environment-variables.tsx
@@ -6,7 +6,9 @@ const EnvironmentVariablesPage: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Environment variables</title>
+        <title>
+          <>{'Safe{Wallet}'} – Environment variables</>
+        </title>
       </Head>
 
       <main>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -7,7 +7,9 @@ const Home: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Dashboard</title>
+        <title>
+          <>{'Safe{Wallet}'} – Dashboard</>
+        </title>
       </Head>
 
       <main>

--- a/src/pages/import.tsx
+++ b/src/pages/import.tsx
@@ -6,7 +6,9 @@ const Import: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Data import</title>
+        <title>
+          <>{'Safe{Wallet}'} – Data import</>
+        </title>
       </Head>
 
       <main>

--- a/src/pages/imprint.tsx
+++ b/src/pages/imprint.tsx
@@ -6,7 +6,9 @@ const Imprint: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Imprint</title>
+        <title>
+          <>{'Safe{Wallet}'} – Imprint</>
+        </title>
       </Head>
 
       <main>

--- a/src/pages/licenses.tsx
+++ b/src/pages/licenses.tsx
@@ -6,7 +6,9 @@ const Imprint: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Licenses</title>
+        <title>
+          <>{'Safe{Wallet}'} – Licenses</>
+        </title>
       </Head>
 
       <main>

--- a/src/pages/new-safe/create.tsx
+++ b/src/pages/new-safe/create.tsx
@@ -7,7 +7,9 @@ const Open: NextPage = () => {
   return (
     <main>
       <Head>
-        <title>Safe{'{Wallet}'} – Create Safe Account</title>
+        <title>
+          <>{'Safe{Wallet}'} – Create Safe Account</>
+        </title>
       </Head>
 
       <CreateSafe />

--- a/src/pages/new-safe/load.tsx
+++ b/src/pages/new-safe/load.tsx
@@ -11,7 +11,9 @@ const Load: NextPage = () => {
   return (
     <main>
       <Head>
-        <title>Safe{'{Wallet}'} – Add Safe Account</title>
+        <title>
+          <>{'Safe{Wallet}'} – Add Safe Account</>
+        </title>
       </Head>
 
       {safeAddress ? (

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -6,7 +6,9 @@ const PrivacyPolicy: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Privacy policy</title>
+        <title>
+          <>{'Safe{Wallet}'} – Privacy policy</>
+        </title>
       </Head>
 
       <main>

--- a/src/pages/settings/appearance.tsx
+++ b/src/pages/settings/appearance.tsx
@@ -35,7 +35,9 @@ const Appearance: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Settings – Appearance</title>
+        <title>
+          <>{'Safe{Wallet}'} – Settings – Appearance</>
+        </title>
       </Head>
 
       <SettingsHeader />
@@ -53,7 +55,7 @@ const Appearance: NextPage = () => {
               <Typography mb={2}>
                 Choose whether to prepend{' '}
                 <ExternalLink href="https://eips.ethereum.org/EIPS/eip-3770">EIP-3770</ExternalLink> address prefixes
-                across all Safes.
+                across all Safe Accounts.
               </Typography>
               <FormGroup>
                 <FormControlLabel

--- a/src/pages/settings/data.tsx
+++ b/src/pages/settings/data.tsx
@@ -7,7 +7,9 @@ const Data: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Settings – Data</title>
+        <title>
+          <>{'Safe{Wallet}'} – Settings – Data</>
+        </title>
       </Head>
 
       <SettingsHeader />

--- a/src/pages/settings/environment-variables.tsx
+++ b/src/pages/settings/environment-variables.tsx
@@ -7,7 +7,9 @@ const EnvironmentVariablesPage: NextPage = () => {
   return (
     <>
       <Head>
-        <title>{'{Wallet}'} – Settings – Environment variables</title>
+        <title>
+          <>{'Safe{Wallet}'} – Settings – Environment variables</>
+        </title>
       </Head>
 
       <SettingsHeader />

--- a/src/pages/settings/modules.tsx
+++ b/src/pages/settings/modules.tsx
@@ -10,7 +10,9 @@ const Modules: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Settings – Modules</title>
+        <title>
+          <>{'Safe{Wallet}'} – Settings – Modules</>
+        </title>
       </Head>
 
       <SettingsHeader />

--- a/src/pages/settings/safe-apps/index.tsx
+++ b/src/pages/settings/safe-apps/index.tsx
@@ -9,7 +9,9 @@ const SafeAppsPermissionsPage: NextPage = () => {
     <>
       <Head>
         <title>
-          Safe{'{Wallet}'} – Settings – Safe{'{Apps}'} permissions
+          <>
+            {'Safe{Wallet}'} – Settings – {'Safe{Apps}'} permissions
+          </>
         </title>
       </Head>
 

--- a/src/pages/settings/setup.tsx
+++ b/src/pages/settings/setup.tsx
@@ -17,7 +17,9 @@ const Setup: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Settings – Setup</title>
+        <title>
+          <>{'Safe{Wallet}'} – Settings – Setup</>
+        </title>
       </Head>
 
       <SettingsHeader />

--- a/src/pages/settings/spending-limits.tsx
+++ b/src/pages/settings/spending-limits.tsx
@@ -7,7 +7,9 @@ const SpendingLimitsPage: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Settings – Spending limit</title>
+        <title>
+          <>{'Safe{Wallet}'} – Settings – Spending limit</>
+        </title>
       </Head>
 
       <SettingsHeader />

--- a/src/pages/share/safe-app.tsx
+++ b/src/pages/share/safe-app.tsx
@@ -31,7 +31,9 @@ const ShareSafeApp = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Apps}'} – Share</title>
+        <title>
+          <>{'Safe{Apps}'} – Share</>
+        </title>
       </Head>
 
       <main>

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -6,7 +6,9 @@ const Imprint: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Terms</title>
+        <title>
+          <>{'Safe{Wallet}'} – Terms</>
+        </title>
       </Head>
 
       <main>

--- a/src/pages/transactions/history.tsx
+++ b/src/pages/transactions/history.tsx
@@ -24,7 +24,9 @@ const History: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Transaction history</title>
+        <title>
+          <>{'Safe{Wallet}'} – Transaction history</>
+        </title>
       </Head>
 
       <TxHeader>

--- a/src/pages/transactions/messages.tsx
+++ b/src/pages/transactions/messages.tsx
@@ -9,7 +9,9 @@ const Messages: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Messages</title>
+        <title>
+          <>{'Safe{Wallet}'} – Messages</>
+        </title>
       </Head>
 
       <TxHeader>

--- a/src/pages/transactions/queue.tsx
+++ b/src/pages/transactions/queue.tsx
@@ -14,7 +14,9 @@ const Queue: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Transaction queue</title>
+        <title>
+          <>{'Safe{Wallet}'} – Transaction queue</>
+        </title>
       </Head>
 
       <BatchExecuteHoverProvider>

--- a/src/pages/transactions/tx.tsx
+++ b/src/pages/transactions/tx.tsx
@@ -8,7 +8,9 @@ const SingleTransaction: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Transaction details</title>
+        <title>
+          <>{'Safe{Wallet}'} – Transaction details</>
+        </title>
       </Head>
 
       <main>

--- a/src/pages/welcome.tsx
+++ b/src/pages/welcome.tsx
@@ -6,7 +6,9 @@ const Welcome: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Safe{'{Wallet}'} – Welcome</title>
+        <title>
+          <>{'Safe{Wallet}'} – Welcome</>
+        </title>
       </Head>
 
       <NewSafe />

--- a/src/services/ls-migration/addedSafes.ts
+++ b/src/services/ls-migration/addedSafes.ts
@@ -61,7 +61,7 @@ export const migrateAddedSafes = (lsData: LOCAL_STORAGE_DATA): AddedSafesState |
     const legacyAddedSafes = parseLsValue<OldAddedSafes>(lsData[IMMORTAL_PREFIX + chainPrefix + OLD_LS_KEY])
 
     if (legacyAddedSafes && Object.keys(legacyAddedSafes).length > 0) {
-      console.log('Migrating added safes on chain', chainId)
+      console.log('Migrating added Safe Accounts on chain', chainId)
 
       const safesPerChain = Object.values(legacyAddedSafes).reduce<AddedSafesOnChain>((acc, oldItem) => {
         const migratedOwners = migrateAddedSafesOwners(oldItem.owners)

--- a/src/services/tx/tx-sender/sdk.ts
+++ b/src/services/tx/tx-sender/sdk.ts
@@ -18,7 +18,9 @@ import type { JsonRpcSigner } from '@ethersproject/providers'
 export const getAndValidateSafeSDK = (): Safe => {
   const safeSDK = getSafeSDK()
   if (!safeSDK) {
-    throw new Error('The Safe SDK could not be initialized. Please be aware that we only support v1.0.0 Safes and up.')
+    throw new Error(
+      'The Safe SDK could not be initialized. Please be aware that we only support v1.0.0 Safe Accounts and up.',
+    )
   }
   return safeSDK
 }


### PR DESCRIPTION
## What it solves

Resolves brand alignment inconsistencies and the following console warning:

![image](https://user-images.githubusercontent.com/20442784/234514749-2d0bbd42-f424-4292-a0bf-3e1823b63ca2.png)

## How this PR fixes it

All instances of `Safe{'{xyz}'}` have been converted to `{'Safe{xyz}'}` and all titles containing it wrapped in fragments.

## How to test it

Observe no visual changes regarding "Safe{xyz}" and no console warnings when navigating between pages.

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
