### PR TITLE
fix: Dashboard layout with relaying widget

### DIFF
--- a/src/components/dashboard/FeaturedApps/FeaturedApps.tsx
+++ b/src/components/dashboard/FeaturedApps/FeaturedApps.tsx
@@ -8,7 +8,7 @@ import { SafeAppsTag } from '@/config/constants'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
 import SafeAppIconCard from '@/components/safe-apps/SafeAppIconCard'
 
-export const FeaturedApps = ({ smallLayout }: { smallLayout: boolean }): ReactElement | null => {
+export const FeaturedApps = ({ stackedLayout }: { stackedLayout: boolean }): ReactElement | null => {
   const router = useRouter()
   const [featuredApps, _, remoteSafeAppsLoading] = useRemoteSafeApps(SafeAppsTag.DASHBOARD_FEATURED)
 
@@ -23,7 +23,7 @@ export const FeaturedApps = ({ smallLayout }: { smallLayout: boolean }): ReactEl
         <WidgetBody>
           <Grid
             container
-            flexDirection={{ xs: 'column', sm: 'row', lg: smallLayout ? 'column' : undefined }}
+            flexDirection={{ xs: 'column', sm: 'row', lg: stackedLayout ? 'column' : undefined }}
             gap={3}
             height={1}
           >

--- a/src/components/dashboard/FeaturedApps/FeaturedApps.tsx
+++ b/src/components/dashboard/FeaturedApps/FeaturedApps.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from 'react'
-import styled from '@emotion/styled'
 import { Box, Grid, Typography, Link } from '@mui/material'
 import { Card, WidgetBody, WidgetContainer } from '../styled'
 import { useRouter } from 'next/router'
@@ -9,16 +8,7 @@ import { SafeAppsTag } from '@/config/constants'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
 import SafeAppIconCard from '@/components/safe-apps/SafeAppIconCard'
 
-const StyledGrid = styled(Grid)`
-  gap: 24px;
-  height: 100%;
-`
-
-const StyledGridItem = styled(Grid)`
-  min-width: 300px;
-`
-
-export const FeaturedApps = (): ReactElement | null => {
+export const FeaturedApps = ({ smallLayout }: { smallLayout: boolean }): ReactElement | null => {
   const router = useRouter()
   const [featuredApps, _, remoteSafeAppsLoading] = useRemoteSafeApps(SafeAppsTag.DASHBOARD_FEATURED)
 
@@ -31,9 +21,14 @@ export const FeaturedApps = (): ReactElement | null => {
           Connect &amp; transact
         </Typography>
         <WidgetBody>
-          <StyledGrid container flexDirection={{ xs: 'column', sm: 'row', lg: 'column' }}>
+          <Grid
+            container
+            flexDirection={{ xs: 'column', sm: 'row', lg: smallLayout ? 'column' : undefined }}
+            gap={3}
+            height={1}
+          >
             {featuredApps?.map((app) => (
-              <StyledGridItem item xs md key={app.id}>
+              <Grid item xs md key={app.id}>
                 <NextLink
                   passHref
                   href={{ pathname: AppRoutes.apps.open, query: { ...router.query, appUrl: app.url } }}
@@ -58,9 +53,9 @@ export const FeaturedApps = (): ReactElement | null => {
                     </Card>
                   </a>
                 </NextLink>
-              </StyledGridItem>
+              </Grid>
             ))}
-          </StyledGrid>
+          </Grid>
         </WidgetBody>
       </WidgetContainer>
     </Grid>

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -29,7 +29,7 @@ const Dashboard = (): ReactElement => {
         </Grid>
 
         <Grid item xs={12} lg={supportsRelaying ? 6 : undefined}>
-          <FeaturedApps smallLayout={!!supportsRelaying} />
+          <FeaturedApps stackedLayout={!!supportsRelaying} />
         </Grid>
 
         {supportsRelaying ? (

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -29,7 +29,7 @@ const Dashboard = (): ReactElement => {
         </Grid>
 
         <Grid item xs={12} lg={supportsRelaying ? 6 : undefined}>
-          <FeaturedApps />
+          <FeaturedApps smallLayout={!!supportsRelaying} />
         </Grid>
 
         {supportsRelaying ? (


### PR DESCRIPTION
## What it solves

Part of #1867 

The featured apps dashboard widget took up the whole space if relaying was disabled.

<img width="1275" alt="Screenshot 2023-04-26 at 10 39 26" src="https://user-images.githubusercontent.com/5880855/234519637-b2835f4a-e35a-4b10-a807-bbea9b8a36f5.png">

## How this PR fixes it

- Adjusts the layout of `FeaturedApps` depending on whether the relaying widget is visible or not

## How to test it

1. Open the Dashboard on a network without relaying
2. Observe the FeaturedApps taking up half the width
3. Open the Dashboard on a network with relaying
4. Observe the FeaturedApps taking up the whole available space

## Screenshots

With no Relaying widget:

<img width="1271" alt="Screenshot 2023-04-26 at 10 41 45" src="https://user-images.githubusercontent.com/5880855/234520242-4525e416-2e0a-4f18-b4af-e0445c21316d.png">

With Relaying widget:

<img width="1271" alt="Screenshot 2023-04-26 at 10 42 02" src="https://user-images.githubusercontent.com/5880855/234520334-95df89db-02d7-42e8-b39e-36b5bc2f4c78.png">

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
