### PR TITLE
Fix: improve ApprovalEditorForm

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -5,7 +5,7 @@ export default defineConfig({
   trashAssetsBeforeRuns: true,
 
   retries: {
-    runMode: 2,
+    runMode: 3,
     openMode: 0,
   },
 

--- a/src/components/common/TokenIcon/styles.module.css
+++ b/src/components/common/TokenIcon/styles.module.css
@@ -1,12 +1,10 @@
 .image {
   display: block;
   width: auto;
-  mix-blend-mode: multiply;
 }
 
 [data-theme='dark'] .image {
   background: var(--color-secondary-main);
   border-radius: 4px;
   padding: 2px;
-  mix-blend-mode: normal;
 }

--- a/src/components/common/TokenIcon/styles.module.css
+++ b/src/components/common/TokenIcon/styles.module.css
@@ -1,10 +1,12 @@
 .image {
   display: block;
   width: auto;
+  mix-blend-mode: multiply;
 }
 
 [data-theme='dark'] .image {
   background: var(--color-secondary-main);
   border-radius: 4px;
   padding: 2px;
+  mix-blend-mode: normal;
 }

--- a/src/components/tx/ApprovalEditor/ApprovalEditor.test.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalEditor.test.tsx
@@ -7,6 +7,7 @@ import {
   render,
   type RenderResult,
   waitFor,
+  act,
 } from '@/tests/test-utils'
 import ApprovalEditor from '.'
 import { type DecodedDataResponse, type SafeBalanceResponse, TokenType } from '@safe-global/safe-gateway-typescript-sdk'
@@ -160,8 +161,7 @@ describe('ApprovalEditor', () => {
         const buttons = getAllByRole(accordionDetails as HTMLElement, 'button')
         // 2 rows with one button each
         expect(buttons).toHaveLength(2)
-        // edit first transfer
-        buttons[0].click()
+
         await waitFor(() => {
           const amountInput = accordionDetails?.querySelector('input[name="approvals.0"]') as HTMLInputElement
           expect(amountInput).not.toBeNull()
@@ -171,8 +171,13 @@ describe('ApprovalEditor', () => {
 
         const amountInput = accordionDetails?.querySelector('input[name="approvals.0"]') as HTMLInputElement
 
-        fireEvent.change(amountInput!, { target: { value: '123' } })
-        getAllByRole(accordionDetails as HTMLElement, 'button')[0].click()
+        await act(() => {
+          fireEvent.change(amountInput!, { target: { value: '123' } })
+        })
+
+        await act(() => {
+          buttons[0].click()
+        })
 
         await waitFor(() => {
           expect(updateCallback).toHaveBeenCalledWith([
@@ -206,8 +211,6 @@ describe('ApprovalEditor', () => {
         const buttons = getAllByRole(accordionDetails as HTMLElement, 'button')
         // 2 rows with one button each
         expect(buttons).toHaveLength(2)
-        // edit first transfer
-        buttons[1].click()
         await waitFor(() => {
           const amountInput = accordionDetails?.querySelector('input[name="approvals.1"]') as HTMLInputElement
           expect(amountInput).not.toBeNull()
@@ -217,8 +220,13 @@ describe('ApprovalEditor', () => {
 
         const amountInput = accordionDetails?.querySelector('input[name="approvals.1"]') as HTMLInputElement
 
-        fireEvent.change(amountInput!, { target: { value: '456' } })
-        getAllByRole(accordionDetails as HTMLElement, 'button')[1].click()
+        await act(() => {
+          fireEvent.change(amountInput!, { target: { value: '456' } })
+        })
+
+        await act(() => {
+          buttons[1].click()
+        })
 
         await waitFor(() => {
           expect(updateCallback).toHaveBeenCalledWith([
@@ -288,7 +296,6 @@ describe('ApprovalEditor', () => {
       expect(accordionDetails).not.toBeNull()
 
       // toggle edit row
-      getByRole(accordionDetails as HTMLElement, 'button').click()
       await waitFor(() => {
         const amountInput = accordionDetails?.querySelector('input[name="approvals.0"]') as HTMLInputElement
         expect(amountInput).not.toBeNull()
@@ -298,8 +305,13 @@ describe('ApprovalEditor', () => {
 
       const amountInput = accordionDetails?.querySelector('input[name="approvals.0"]') as HTMLInputElement
 
-      fireEvent.change(amountInput!, { target: { value: '100' } })
-      getByRole(accordionDetails as HTMLElement, 'button').click()
+      await act(() => {
+        fireEvent.change(amountInput!, { target: { value: '100' } })
+      })
+
+      await act(() => {
+        getByRole(accordionDetails as HTMLElement, 'button').click()
+      })
 
       await waitFor(() => {
         expect(updateCallback).toHaveBeenCalledWith([

--- a/src/components/tx/ApprovalEditor/ApprovalEditorForm.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalEditorForm.tsx
@@ -31,7 +31,7 @@ export const ApprovalEditorForm = ({
   })
 
   const {
-    formState: { errors, isDirty },
+    formState: { errors, dirtyFields },
     getValues,
   } = formMethods
 
@@ -58,7 +58,7 @@ export const ApprovalEditorForm = ({
                     <IconButton
                       className={css.iconButton}
                       onClick={onSave}
-                      disabled={isReadonly || !!errors.approvals || !isDirty}
+                      disabled={isReadonly || !!errors.approvals || !dirtyFields.approvals?.[idx]}
                       title="Save"
                     >
                       <SvgIcon component={CheckIcon} />

--- a/src/components/tx/ApprovalEditor/ApprovalEditorForm.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalEditorForm.tsx
@@ -33,12 +33,14 @@ export const ApprovalEditorForm = ({
   const {
     formState: { errors, dirtyFields },
     getValues,
+    reset,
   } = formMethods
 
   const onSave = () => {
     if (isReadonly) return
     const formData = getValues('approvals')
     updateApprovals(formData)
+    reset({ approvals: formData })
   }
 
   return (

--- a/src/components/tx/ApprovalEditor/index.tsx
+++ b/src/components/tx/ApprovalEditor/index.tsx
@@ -9,13 +9,7 @@ import css from './styles.module.css'
 import { UNLIMITED_APPROVAL_AMOUNT } from '@/utils/tokens'
 import { ApprovalEditorForm } from './ApprovalEditorForm'
 import { useMemo } from 'react'
-import {
-  type ApprovalInfo,
-  APPROVAL_SIGNATURE_HASH,
-  extractTxs,
-  updateApprovalTxs,
-  PSEUDO_APPROVAL_VALUES,
-} from './utils/approvals'
+import { type ApprovalInfo, APPROVAL_SIGNATURE_HASH, extractTxs, updateApprovalTxs } from './utils/approvals'
 import { useApprovalInfos } from './hooks/useApprovalInfos'
 
 const Summary = ({ approvalInfos, approvalTxs }: { approvalInfos: ApprovalInfo[]; approvalTxs: BaseTransaction[] }) => {
@@ -24,9 +18,7 @@ const Summary = ({ approvalInfos, approvalTxs }: { approvalInfos: ApprovalInfo[]
 
   if (approvalInfos.length === 1) {
     const approval = approvalInfos[0]
-    const amount = UNLIMITED_APPROVAL_AMOUNT.eq(approval.amount)
-      ? PSEUDO_APPROVAL_VALUES.UNLIMITED
-      : approval.amountFormatted
+    const amount = UNLIMITED_APPROVAL_AMOUNT.eq(approval.amount) ? 'unlimited' : approval.amountFormatted
     return (
       <Box display="flex" flexDirection="row" justifyContent="space-between" width="100%">
         <Typography fontWeight={700} display="inline-flex" alignItems="center" gap={1}>
@@ -99,12 +91,14 @@ export const ApprovalEditor = ({
           <Summary approvalInfos={approvalInfos} approvalTxs={approvalTxs} />
         )}
       </AccordionSummary>
-      <AccordionDetails>
+
+      <AccordionDetails sx={{ pb: 0 }}>
         {loading || !approvalInfos ? null : (
           <>
             <Typography fontSize="14px">
               This allows contracts to spend the selected amounts of your asset balance.
             </Typography>
+
             <ApprovalEditorForm approvalInfos={approvalInfos} updateApprovals={updateApprovals} />
           </>
         )}

--- a/src/components/tx/ApprovalEditor/styles.module.css
+++ b/src/components/tx/ApprovalEditor/styles.module.css
@@ -23,19 +23,27 @@
 .iconButton {
   border-radius: 4px;
   padding: 6px;
-  background-color: var(--color-background-main);
   width: 48px;
   height: 48px;
-}
-
-.applyIconButton {
   background-color: var(--color-primary-main);
 }
 
-.applyIconButton:hover {
+.iconButton:hover {
   background-color: var(--color-primary-dark);
 }
 
-.applyIconButton svg {
+.iconButton svg {
   color: var(--color-background-paper);
+}
+
+.iconButton:disabled {
+  background-color: var(--color-text-disabled);
+}
+
+.iconButton:disabled svg {
+  color: var(--color-border-dark);
+}
+
+.approvalsList {
+  padding-bottom: 0;
 }

--- a/src/components/tx/ApprovalEditor/utils/approvals.ts
+++ b/src/components/tx/ApprovalEditor/utils/approvals.ts
@@ -19,7 +19,7 @@ const UINT256_TYPE = 'uint256'
 const ERC20_INTERFACE = ERC20__factory.createInterface()
 
 export enum PSEUDO_APPROVAL_VALUES {
-  UNLIMITED = 'Unlimited',
+  UNLIMITED = 'Unlimited (not recommended)',
 }
 
 export type ApprovalInfo = {


### PR DESCRIPTION
The approved amount input is now editable right away and you just need to press the ✔️ button to save it.

<img width="593" alt="Screenshot 2023-04-26 at 12 50 50" src="https://user-images.githubusercontent.com/381895/234539271-19bf9548-864f-4fc8-b3bc-1771b98cf54d.png">

Plus some minor visual tweaks.
