### PR TITLE
fix: don't scroll wrap in transaction list

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -90,7 +90,7 @@ export const Multisend = ({
       {!noHeader && <MultisendActionsHeader setOpen={setOpenMap} amount={multiSendTransactions.length} />}
 
       <div className={noHeader && multiSendTransactions.length >= MIN_SCROLL_TXS ? css.scrollWrapper : undefined}>
-        <Box display="flex" flexDirection="column">
+        <Box display="flex" flexDirection="column" gap={noHeader ? 1 : undefined}>
           {multiSendTransactions.map(({ dataDecoded, data, value, to, operation }, index) => {
             const onChange: AccordionProps['onChange'] = (_, expanded) => {
               setOpenMap((prev) => ({

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -90,7 +90,7 @@ export const Multisend = ({
       {!noHeader && <MultisendActionsHeader setOpen={setOpenMap} amount={multiSendTransactions.length} />}
 
       <div className={noHeader && multiSendTransactions.length >= MIN_SCROLL_TXS ? css.scrollWrapper : undefined}>
-        <Box display="flex" flexDirection="column" gap={1}>
+        <Box display="flex" flexDirection="column">
           {multiSendTransactions.map(({ dataDecoded, data, value, to, operation }, index) => {
             const onChange: AccordionProps['onChange'] = (_, expanded) => {
               setOpenMap((prev) => ({

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -89,7 +89,7 @@ export const Multisend = ({
     <>
       {!noHeader && <MultisendActionsHeader setOpen={setOpenMap} amount={multiSendTransactions.length} />}
 
-      <div className={multiSendTransactions.length >= MIN_SCROLL_TXS ? css.scrollWrapper : undefined}>
+      <div className={noHeader && multiSendTransactions.length >= MIN_SCROLL_TXS ? css.scrollWrapper : undefined}>
         <Box display="flex" flexDirection="column" gap={1}>
           {multiSendTransactions.map(({ dataDecoded, data, value, to, operation }, index) => {
             const onChange: AccordionProps['onChange'] = (_, expanded) => {


### PR DESCRIPTION
## What it solves

Resolves #1914

## How this PR fixes it

The scroll wrapper is not added in the transaction list.

## How to test it

- Open the transaction mentioned in the issue of the PR and observe no scrollbar next to the decoded transaction.
- Batch an NFT transfer and observe that the scrollbar _is_ present next to the decoded transactions in the modal.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/234604603-92b6d1f2-5556-48b0-b812-73b2f26a9437.png)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
