### PR TITLE
Fix: useTxActions should accept origin

### DIFF
--- a/src/components/tx/SignOrExecuteForm/hooks.test.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.test.ts
@@ -370,7 +370,7 @@ describe('SignOrExecute hooks', () => {
         dynamicPart: () => '',
       })
 
-      const id = await executeTx({ gasPrice: 1 }, tx, '123', true)
+      const id = await executeTx({ gasPrice: 1 }, tx, '123', 'origin.com', true)
       expect(proposeSpy).not.toHaveBeenCalled()
       expect(relaySpy).toHaveBeenCalled()
       expect(id).toEqual('123')
@@ -418,7 +418,7 @@ describe('SignOrExecute hooks', () => {
       const { result } = renderHook(() => useTxActions())
       const { executeTx } = result.current
 
-      const id = await executeTx({ gasPrice: 1 }, tx, '123', true)
+      const id = await executeTx({ gasPrice: 1 }, tx, '123', 'origin.com', true)
       expect(proposeSpy).toHaveBeenCalled()
       expect(signSpy).toHaveBeenCalled()
       expect(relaySpy).toHaveBeenCalled()
@@ -467,7 +467,7 @@ describe('SignOrExecute hooks', () => {
       const { result } = renderHook(() => useTxActions())
       const { executeTx } = result.current
 
-      await expect(() => executeTx({ gasPrice: 1 }, tx, '123', true)).rejects.toThrowError(
+      await expect(() => executeTx({ gasPrice: 1 }, tx, '123', 'origin.com', true)).rejects.toThrowError(
         'Cannot relay an unsigned transaction from a smart contract wallet',
       )
       expect(proposeSpy).not.toHaveBeenCalled()

--- a/src/components/tx/SignOrExecuteForm/hooks.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.ts
@@ -18,11 +18,12 @@ import type { OnboardAPI } from '@web3-onboard/core'
 import { hasEnoughSignatures } from '@/utils/transactions'
 
 type TxActions = {
-  signTx: (safeTx?: SafeTransaction, txId?: string) => Promise<string>
+  signTx: (safeTx?: SafeTransaction, txId?: string, origin?: string) => Promise<string>
   executeTx: (
     txOptions: TransactionOptions,
     safeTx?: SafeTransaction,
     txId?: string,
+    origin?: string,
     isRelayed?: boolean,
   ) => Promise<string>
 }
@@ -70,7 +71,7 @@ export const useTxActions = (): TxActions => {
       return await dispatchTxSigning(safeTx, version, onboard, chainId, txId)
     }
 
-    const signTx: TxActions['signTx'] = async (safeTx, txId) => {
+    const signTx: TxActions['signTx'] = async (safeTx, txId, origin) => {
       assertTx(safeTx)
       assertWallet(wallet)
       assertOnboard(onboard)
@@ -90,7 +91,7 @@ export const useTxActions = (): TxActions => {
       return await proposeTx(wallet.address, signedTx, txId, origin)
     }
 
-    const executeTx: TxActions['executeTx'] = async (txOptions, safeTx, txId, isRelayed) => {
+    const executeTx: TxActions['executeTx'] = async (txOptions, safeTx, txId, origin, isRelayed) => {
       assertTx(safeTx)
       assertWallet(wallet)
       assertOnboard(onboard)

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -108,13 +108,13 @@ const SignOrExecuteForm = ({
 
   // Sign transaction
   const onSign = async (): Promise<string | undefined> => {
-    return await signTx(tx, txId)
+    return await signTx(tx, txId, origin)
   }
 
   // Execute transaction
   const onExecute = async (): Promise<string | undefined> => {
     const txOptions = getTxOptions(advancedParams, currentChain)
-    return await executeTx(txOptions, tx, txId, willRelay)
+    return await executeTx(txOptions, tx, txId, origin, willRelay)
   }
 
   // On modal submit


### PR DESCRIPTION
## What it solves

Resolves #1925

## How this PR fixes it
We didn't notice the bug, because there's a global variable `window.origin` which was masking the undefined `origin`.

`executeTx` and `signTx` now take an `origin` parameter.