### PR TITLE
Fix: track QR button in address inputs

### DIFF
--- a/cypress/e2e/smoke/pending_actions.cy.js
+++ b/cypress/e2e/smoke/pending_actions.cy.js
@@ -10,6 +10,7 @@ describe('Pending actions', () => {
     cy.contains('button', 'Accept all').click()
 
     // Ensure wallet is connected to correct chain via header
+    cy.wait(5000)
     cy.contains('E2E Wallet @ Görli')
   })
 

--- a/src/components/common/ScanQRModal/ScanQRButton.tsx
+++ b/src/components/common/ScanQRModal/ScanQRButton.tsx
@@ -1,6 +1,8 @@
 import React, { lazy, useState, Suspense, type ReactElement } from 'react'
 import QrCodeIcon from '@/public/images/common/qr.svg'
 import { IconButton, SvgIcon } from '@mui/material'
+import Track from '../Track'
+import { MODALS_EVENTS } from '@/services/analytics'
 
 const ScanQRModal = lazy(() => import('.'))
 
@@ -26,9 +28,11 @@ const ScanQRButton = ({ onScan }: Props): ReactElement => {
 
   return (
     <>
-      <IconButton onClick={openQrModal}>
-        <SvgIcon component={QrCodeIcon} inheritViewBox color="primary" fontSize="small" />
-      </IconButton>
+      <Track {...MODALS_EVENTS.SCAN_QR}>
+        <IconButton onClick={openQrModal}>
+          <SvgIcon component={QrCodeIcon} inheritViewBox color="primary" fontSize="small" />
+        </IconButton>
+      </Track>
 
       {open && (
         <Suspense>

--- a/src/services/analytics/events/modals.ts
+++ b/src/services/analytics/events/modals.ts
@@ -15,6 +15,10 @@ export const MODALS_EVENTS = {
     action: 'Contract interaction',
     category: MODALS_CATEGORY,
   },
+  SCAN_QR: {
+    action: 'Scan QR',
+    category: MODALS_CATEGORY,
+  },
   TX_DETAILS: {
     action: 'Transaction details',
     category: MODALS_CATEGORY,


### PR DESCRIPTION
## What it solves

I'd like to re-evaluate the usefulness of a QR scanner on desktop. Adding a tracker to see how many users click on it. 
